### PR TITLE
Use on-disk recording ID to create recordings if it is a UUID

### DIFF
--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replayio/replay",
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "description": "CLI tool for uploading and managing recordings",
   "bin": {
     "replay": "bin/replay"

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replayio/replay",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.7",
   "description": "CLI tool for uploading and managing recordings",
   "bin": {
     "replay": "bin/replay"

--- a/packages/replay/src/main.js
+++ b/packages/replay/src/main.js
@@ -304,7 +304,7 @@ async function doUploadRecording(
     maybeLog(verbose, `Upload failed: can't connect to server ${server}`);
     return null;
   }
-  const recordingId = await connectionCreateRecording(recording.buildId);
+  const recordingId = await connectionCreateRecording(recording.id, recording.buildId);
   maybeLog(verbose, `Created remote recording ${recordingId}, uploading...`);
   if (recording.metadata) {
     maybeLog(verbose, `Setting recording metadata for ${recordingId}`);

--- a/packages/replay/src/upload.js
+++ b/packages/replay/src/upload.js
@@ -1,5 +1,5 @@
 const ProtocolClient = require("./client");
-const { defer, maybeLog } = require("./utils");
+const { defer, maybeLog, isValidUUID } = require("./utils");
 
 let gClient;
 let gClientReady = defer();
@@ -36,11 +36,15 @@ async function initConnection(server, accessToken, verbose, agent) {
   return gClientReady.promise;
 }
 
-async function connectionCreateRecording(buildId) {
+async function connectionCreateRecording(id, buildId) {
   const { recordingId } = await gClient.sendCommand(
     "Internal.createRecording",
     {
       buildId,
+      // 3/22/2022: Older builds use integers instead of UUIDs for the recording
+      // IDs written to disk. These are not valid to use as recording IDs when
+      // uploading recordings to the backend.
+      recordingId: isValidUUID(id) ? id : undefined,
       // Ensure that if the upload fails, we will not create
       // partial recordings.
       requireFinish: true,

--- a/packages/replay/src/utils.js
+++ b/packages/replay/src/utils.js
@@ -21,4 +21,16 @@ function getDirectory(opts) {
   return (opts && opts.directory) || process.env.RECORD_REPLAY_DIRECTORY || path.join(home, ".replay");
 }
 
-module.exports = { defer, maybeLog, getDirectory };
+function isValidUUID(str) {
+  if (typeof str != "string" || str.length != 36) {
+    return false;
+  }
+  for (let i = 0; i < str.length; i++) {
+    if ("0123456789abcdef-".indexOf(str[i]) == -1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+module.exports = { defer, maybeLog, getDirectory, isValidUUID };


### PR DESCRIPTION
For https://github.com/RecordReplay/backend/issues/5028, only use a single ID if the one created by the driver is a UUID.