### PR TITLE
Fix installing firefox for playwright

### DIFF
--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Replayio/replay-cli/blob/main/packages/playwright/README.md",
   "dependencies": {
-    "@replayio/replay": "^0.1.0"
+    "@replayio/replay": "^0.1.1"
   },
   "peerDependencies": {
     "@playwright/test": "1.19.x"

--- a/packages/replay/src/install.js
+++ b/packages/replay/src/install.js
@@ -21,12 +21,12 @@ async function ensurePlaywrightBrowsersInstalled(kind = "all", opts = {}) {
 
   switch (process.platform) {
     case "darwin":
-      if (["all", "gecko"].includes(kind)) {
+      if (["all", "firefox"].includes(kind)) {
         await installReplayBrowser("macOS-replay-playwright.tar.xz", "playwright", "firefox", "firefox", opts);
       }
       break;
     case "linux":
-      if (["all", "gecko"].includes(kind)) {
+      if (["all", "firefox"].includes(kind)) {
         await installReplayBrowser("linux-replay-playwright.tar.xz", "playwright", "firefox", "firefox", opts);
       }
       if (["all", "chromium"].includes(kind)) {


### PR DESCRIPTION
* Adds logging to the install process (unlocked by `opts.verbose` as elsewhere)
* Renames the key for installing the replay firefox browser from "gecko" to "firefox"