### PR TITLE
Use unique binary name

### DIFF
--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -9,7 +9,9 @@
     "build": "rm -rf dist/ && tsc && chmod 755 dist/bin/* && cp package.json README.md dist/",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "bin": "./bin/replayio-playwright.js",
+  "bin": {
+    "replayio-playwright": "./bin/replayio-playwright.js"
+  },
   "author": "",
   "publishConfig": {
     "directory": "dist"


### PR DESCRIPTION
## Issue

If `@replayio/playwright` and `playwright` are both available, `npx @replayio/playwright` doesn't (always?) pick the right one to run

## Resolution

Give it a unique binary name to disambiguate