### PR TITLE
Add support for setting metadata via a file per worker

### DIFF
--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -8,6 +8,7 @@ Exports
 
 - `getExecutablePath(browserName: string)` - Returns the path to the replay browser for the given `browserName`: either `"chromium"` or `"firefox"`. If `browserName` isn't supported on the current platform, `undefined` is returned.
 - `devices` - Object of configurations suitable for using with `@playwright/test`. Currently supports `"Replay Firefox"` and `"Replay Chromium"` configurations. If the configuration isn't supported on the current platform, a warning is emitted and the `executablePath` will be undefined.
+- `getMetadataFilePath(workerIndex: number = 0)` - Returns the path of a worker-specific metadata file keyed by the `workerIndex`. The file path will be within the `RECORD_REPLAY_DIRECTORY`.
 
 ## Using standalone
 

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -1,20 +1,33 @@
 import { getPlaywrightBrowserPath, BrowserName } from "@replayio/replay";
+import { getDirectory } from "@replayio/replay/src/utils";
+import path from "path";
 
 function getDeviceConfig(browserName: BrowserName) {
-  const executablePath = getPlaywrightBrowserPath(browserName);
+  const executablePath = getExecutablePath(browserName);
   if (!executablePath) {
     console.warn(`${browserName} is not supported on this platform`);
+  }
+
+  const env: Record<string, any> = {
+    ...process.env,
+    RECORD_ALL_CONTENT: 1,
+  };
+
+  if (process.env.TEST_WORKER_INDEX && !("RECORD_REPLAY_METADATA" in env)) {
+    env.RECORD_REPLAY_METADATA_FILE = getMetadataFilePath(+process.env.TEST_WORKER_INDEX);
   }
 
   return {
     launchOptions: {
       executablePath,
-      env: {
-        RECORD_ALL_CONTENT: 1,
-      },
+      env,
     },
     defaultBrowserType: browserName,
   };
+}
+
+export function getMetadataFilePath(workerIndex = 0) {
+  return path.join(getDirectory(), `PLAYWRIGHT_METADATA_${workerIndex}`);
 }
 
 export function getExecutablePath(browserName: BrowserName) {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -13,8 +13,13 @@ function getDeviceConfig(browserName: BrowserName) {
     RECORD_ALL_CONTENT: 1,
   };
 
-  if (process.env.TEST_WORKER_INDEX && !("RECORD_REPLAY_METADATA" in env)) {
-    env.RECORD_REPLAY_METADATA_FILE = getMetadataFilePath(+process.env.TEST_WORKER_INDEX);
+  if (process.env.TEST_WORKER_INDEX) {
+    if ("RECORD_REPLAY_METADATA" in env && env.RECORD_REPLAY_METADATA) {
+      console.warn(`RECORD_REPLAY_METADATA is set so a per-worker metadata file will not be used`);
+    } else {
+      env.RECORD_REPLAY_METADATA = undefined;
+      env.RECORD_REPLAY_METADATA_FILE = getMetadataFilePath(+process.env.TEST_WORKER_INDEX);
+    }
   }
 
   return {

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -13,6 +13,10 @@ function getDeviceConfig(browserName: BrowserName) {
     RECORD_ALL_CONTENT: 1,
   };
 
+  // When TEST_WORKER_INDEX is set, this is being run in the context of a
+  // @playwright/test worker so we create a per-worker metadata file that can be
+  // used by the reporter to inject test-specific metadata which will be picked
+  // up by the driver when it creates a new recording
   if (process.env.TEST_WORKER_INDEX) {
     if ("RECORD_REPLAY_METADATA" in env && env.RECORD_REPLAY_METADATA) {
       console.warn(`RECORD_REPLAY_METADATA is set so a per-worker metadata file will not be used`);

--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -1,20 +1,44 @@
-import type { Reporter, TestCase, TestResult } from "@playwright/test/reporter";
+import type { FullConfig, Reporter, Suite, TestCase, TestResult } from "@playwright/test/reporter";
 import { getDirectory } from "@replayio/replay/src/utils";
 import { listAllRecordings } from "@replayio/replay";
-import { appendFileSync } from "fs";
+import { writeFileSync, appendFileSync, existsSync } from "fs";
 import path from "path";
 
+import { getMetadataFilePath } from "./index";
+
 class ReplayReporter implements Reporter {
+  baseId = Date.now()
+
+  getTestId(test: TestCase) {
+    return `${this.baseId}-${test.titlePath().join("-")}`;
+  }
+
+  onBegin(config: FullConfig, suite: Suite) {
+    // prime all the metadata files
+    for (let i = 0; i < config.workers; i++) {
+      writeFileSync(getMetadataFilePath(i), "{}");
+    }
+  }
+
+  onTestBegin(test: TestCase, testResult: TestResult) {
+    const metadataFilePath = getMetadataFilePath(testResult.workerIndex);
+    if (existsSync(metadataFilePath)) {
+      writeFileSync(metadataFilePath, JSON.stringify({
+        testId: this.getTestId(test)
+      }, undefined, 2), {});
+    }
+  }
+
   onTestEnd(test: TestCase, result: TestResult) {
     if (!["passed", "failed"].includes(result.status)) return;
 
-    const last = listAllRecordings().pop();
-    if (last) {
+    const rec = listAllRecordings().find(r => r.metadata.testId === this.getTestId(test))
+    if (rec) {
       const metadata = {
-        id: last.id,
+        id: rec.id,
         kind: "addMetadata",
         metadata: {
-          title: `[${result.status.toUpperCase()}] - ${test.title}`,
+          title: test.title,
           testStatus: result.status,
         },
         timestamp: Date.now(),


### PR DESCRIPTION
## Issue

We can't run tests in parallel right now because we don't have a way to tie a recording to a test. Instead, we've serialized the tests so that we can assume the most recent recording was for the most recent test.

## Resolution

* Define a `testId` that should be unique for the run and set that as metadata for the test
* Match against that same id when the test completes to append the test result metadata