### PR TITLE
Fix default title generation to only apply if title is unset

### DIFF
--- a/packages/replay/src/main.js
+++ b/packages/replay/src/main.js
@@ -96,9 +96,12 @@ function readRecordings(dir, includeHidden) {
         if (recording) {
           Object.assign(
             recording.metadata,
-            { title: generateDefaultTitle(metadata) },
             metadata
           );
+
+          if (!recording.metadata.title) {
+            recording.metadata.title = generateDefaultTitle(recording.metadata);
+          }
         }
         break;
       }


### PR DESCRIPTION
## Issue

If a `title` was already set for a recording and another `addMetadata` record comes along, the default title overwrites the previously set title

## Resolution

Only set a default title if no title exists yet