### PR TITLE
Fix updating metadata when multiple recordings have the same testId

### DIFF
--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -1,4 +1,10 @@
-import type { FullConfig, Reporter, Suite, TestCase, TestResult } from "@playwright/test/reporter";
+import type {
+  FullConfig,
+  Reporter,
+  Suite,
+  TestCase,
+  TestResult,
+} from "@playwright/test/reporter";
 import { getDirectory } from "@replayio/replay/src/utils";
 import { listAllRecordings } from "@replayio/replay";
 import { writeFileSync, appendFileSync, existsSync } from "fs";
@@ -7,7 +13,7 @@ import path from "path";
 import { getMetadataFilePath } from "./index";
 
 class ReplayReporter implements Reporter {
-  baseId = Date.now()
+  baseId = Date.now();
 
   getTestId(test: TestCase) {
     return `${this.baseId}-${test.titlePath().join("-")}`;
@@ -23,31 +29,43 @@ class ReplayReporter implements Reporter {
   onTestBegin(test: TestCase, testResult: TestResult) {
     const metadataFilePath = getMetadataFilePath(testResult.workerIndex);
     if (existsSync(metadataFilePath)) {
-      writeFileSync(metadataFilePath, JSON.stringify({
-        testId: this.getTestId(test)
-      }, undefined, 2), {});
+      writeFileSync(
+        metadataFilePath,
+        JSON.stringify(
+          {
+            testId: this.getTestId(test),
+          },
+          undefined,
+          2
+        ),
+        {}
+      );
     }
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
     if (!["passed", "failed"].includes(result.status)) return;
 
-    const rec = listAllRecordings().find(r => r.metadata.testId === this.getTestId(test))
-    if (rec) {
-      const metadata = {
-        id: rec.id,
-        kind: "addMetadata",
-        metadata: {
-          title: test.title,
-          testStatus: result.status,
-        },
-        timestamp: Date.now(),
-      };
+    const recs = listAllRecordings().filter(
+      (r) => r.metadata.testId === this.getTestId(test)
+    );
+    if (recs.length > 0) {
+      recs.forEach((rec) => {
+        const metadata = {
+          id: rec.id,
+          kind: "addMetadata",
+          metadata: {
+            title: test.title,
+            testStatus: result.status,
+          },
+          timestamp: Date.now(),
+        };
 
-      appendFileSync(
-        path.join(getDirectory(), "recordings.log"),
-        `\n${JSON.stringify(metadata)}\n`
-      );
+        appendFileSync(
+          path.join(getDirectory(), "recordings.log"),
+          `\n${JSON.stringify(metadata)}\n`
+        );
+      });
     }
   }
 }


### PR DESCRIPTION
## Issue

We can generate a bunch of recordings when launching the browser for each browsing context. Not all of them are used and are discarded with "no interesting content" but the `find()` logic in the reporter will sometimes find one of these discarded recordings instead of the real one and only set the metadata on it.

## Resolution

Update all the recordings with the same test id. This has the added benefit of setting the test status on multiple recordings if  a test opened multiple tabs.