### PR TITLE
Change default playwright project to chromium

### DIFF
--- a/.github/actions/replay/action.yml
+++ b/.github/actions/replay/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: "npx playwright test"
   project:
     description: "Project for replay browser"
-    default: "replay-firefox"
+    default: "replay-chromium"
   issue-number:
     description: "Pull Request on which to comment results"
   apiKey:

--- a/.github/workflows/create-react-app-typescript-ci.yml
+++ b/.github/workflows/create-react-app-typescript-ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/playwright
         with:
-          project: "replay-firefox"
+          project: "replay-chromium"
           issue-number: ${{ github.event.pull_request.number }}
           apiKey: ${{ secrets.RECORD_REPLAY_API_KEY }}
           working-directory: examples/create-react-app-typescript

--- a/examples/create-react-app-typescript/playwright.config.ts
+++ b/examples/create-react-app-typescript/playwright.config.ts
@@ -4,7 +4,7 @@ const config = {
   forbidOnly: !!process.env.CI,
   use: {
     trace: "on-first-retry",
-    defaultBrowserType: "firefox",
+    defaultBrowserType: "chromium",
   },
   webServer: {
     command: "npm start",
@@ -17,6 +17,12 @@ const config = {
       name: "replay-firefox",
       use: {
         ...(replayDevices["Replay Firefox"] as any),
+      },
+    },
+    {
+      name: "replay-chromium",
+      use: {
+        ...(replayDevices["Replay Chromium"] as any),
       },
     },
   ],


### PR DESCRIPTION
Our chromium fork runs quite a bit faster than gecko so I'm swapping over the default to chromium for the time being.

see https://github.com/RecordReplay/ops/issues/742#issuecomment-1105860965