### PR TITLE
Add metadata api method

### DIFF
--- a/packages/replay/metadata/index.ts
+++ b/packages/replay/metadata/index.ts
@@ -1,5 +1,8 @@
+import { appendFileSync } from "fs";
+import path from "path";
+
 import { Options } from "../src/types";
-import { maybeLog } from "../src/utils";
+import { getDirectory, maybeLog } from "../src/utils";
 
 import * as test from "./test";
 import * as source from "./source";
@@ -52,4 +55,30 @@ function sanitize(metadata: UnstructuredMetadata, opts: Options = {}) {
   return updated;
 }
 
-export { sanitize, test };
+/**
+ * Adds unstructured metadata to the local recordings database.
+ *
+ * New metadata will be merged with existing data. If the same key is used by
+ * multiple entries, the most recent entry's value will be used.
+ *
+ * Metadata is not validated until the recording is uploaded so arbitrary keys
+ * may be used here to manage recordings before upload.
+ *
+ * @param recordingId UUID of the recording
+ * @param metadata Recording metadata
+ */
+function add(recordingId: string, metadata: Record<string, unknown>) {
+  const entry = {
+    id: recordingId,
+    kind: "addMetadata",
+    metadata,
+    timestamp: Date.now(),
+  };
+
+  appendFileSync(
+    path.join(getDirectory(), "recordings.log"),
+    `\n${JSON.stringify(entry)}\n`
+  );
+}
+
+export { add, sanitize, source, test };

--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -581,12 +581,12 @@ function removeAllRecordings(opts = {}) {
   }
 }
 
-function addRecordingMetadata(recordingId: string, metadata: Record<string, unknown>) {
+function addLocalRecordingMetadata(recordingId: string, metadata: Record<string, unknown>) {
   add(recordingId, metadata);
 }
 
 export {
-  addRecordingMetadata,
+  addLocalRecordingMetadata,
   listAllRecordings,
   uploadRecording,
   processRecording,

--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -22,6 +22,7 @@ import {
 import { getDirectory, maybeLog } from "./utils";
 import { spawn } from "child_process";
 import { Options, RecordingEntry } from "./types";
+import { add } from "../metadata";
 export type { BrowserName } from "./types";
 
 function getRecordingsFile(dir: string) {
@@ -580,7 +581,12 @@ function removeAllRecordings(opts = {}) {
   }
 }
 
+function addRecordingMetadata(recordingId: string, metadata: Record<string, unknown>) {
+  add(recordingId, metadata);
+}
+
 export {
+  addRecordingMetadata,
   listAllRecordings,
   uploadRecording,
   processRecording,


### PR DESCRIPTION
Refactor the logic to append recording metadata to a first class API so other systems (e.g. GH actions) can augment our metadata.