### PR TITLE
Add trigger to source metadata

### DIFF
--- a/packages/replay/metadata/source.ts
+++ b/packages/replay/metadata/source.ts
@@ -18,6 +18,11 @@ const versions: Record<number, Struct> = {
       title: optional(string()),
       url: optional(string())
     }),
+    trigger: optional(object({
+      user: optional(string()),
+      name: string(),
+      workflow: optional(string()),
+    })),
     merge: optional(object({
       id: string(),
       title: string(),


### PR DESCRIPTION
Fixes RUN-171

Adds support for optional `trigger` source metadata