### PR TITLE
Fix playwright reporter to set metadata on retry

### DIFF
--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -6,7 +6,7 @@ import type {
 } from "@playwright/test/reporter";
 import { listAllRecordings } from "@replayio/replay";
 import { add, test as testMetadata } from "@replayio/replay/metadata";
-import { writeFileSync, existsSync } from "fs";
+import { writeFileSync } from "fs";
 import path from "path";
 const uuid = require("uuid");
 
@@ -89,32 +89,26 @@ class ReplayReporter implements Reporter {
   }
 
   onBegin(config: FullConfig) {
-    // prime all the metadata files
-    for (let i = 0; i < config.workers; i++) {
-      writeFileSync(getMetadataFilePath(i), "{}");
-    }
-
     this.parseConfig(config);
   }
 
   onTestBegin(test: TestCase, testResult: TestResult) {
     const metadataFilePath = getMetadataFilePath(testResult.workerIndex);
-    if (existsSync(metadataFilePath)) {
-      writeFileSync(
-        metadataFilePath,
-        JSON.stringify(
-          {
-            ...(this.baseMetadata || {}),
-            "x-playwright": {
-              id: this.getTestId(test),
-            },
+
+    writeFileSync(
+      metadataFilePath,
+      JSON.stringify(
+        {
+          ...(this.baseMetadata || {}),
+          "x-playwright": {
+            id: this.getTestId(test),
           },
-          undefined,
-          2
-        ),
-        {}
-      );
-    }
+        },
+        undefined,
+        2
+      ),
+      {}
+    );
   }
 
   onTestEnd(test: TestCase, result: TestResult) {


### PR DESCRIPTION
## Issue

When playwright retries a failed test, it starts a new worker and increments the worker index. As a result, the reporter wasn't writing the metadata so the replay was missing that data

## Resolution

Rather than pre-creating empty metadata files based on the number of workers, just create the metadata files as needed when the test begins. By not checking for an existing file, we always create the correct file regardless of the worker index.