### PR TITLE
Fix install script for cypress

### DIFF
--- a/packages/cypress/bin/replayio-cypress.ts
+++ b/packages/cypress/bin/replayio-cypress.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import install from "../src/install";
+
+let [, , cmd, ...args] = process.argv;
+
+if (cmd === "first-run" && process.env.CYPRESS_INSTALL_BINARY !== "0") {
+  args = [];
+  cmd = "install";
+}
+
+function commandInstall() {
+  console.log("Installing Replay browsers for cypress");
+
+  let browser = args[0] || "all";
+  install(browser).then(() => {
+    console.log("Done");
+  });
+}
+
+function help() {
+  console.log(`
+npx @replayio/cypress
+
+Provides utilities to support using Replay (https://replay.io) with Cypress
+
+Available commands:
+
+  - install [all | firefox | chromium]
+    Installs all or the specified Replay browser
+  `);
+}
+
+switch (cmd) {
+  case "install":
+    commandInstall();
+    break;
+  case "help":
+  default:
+    help();
+    break;
+}

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -7,9 +7,13 @@
     "if:exists": "node -e 'process.exit(require(\"fs\").existsSync(process.argv[1]) ? 0 : 1)'",
     "if:dist": "npm run if:exists -- src/index.js",
     "prepare": "npm run if:dist || npm run build",
+    "install": "npm run if:source || node ./bin/replayio-cypress first-run",
     "build": "rm -rf dist/ && tsc && cp package.json README.md dist/",
     "test": "echo \"Error: no test specified\" && exit 1",
     "typecheck": "tsc --noEmit"
+  },
+  "bin": {
+    "replayio-cypress": "./bin/replayio-cypress.js"
   },
   "author": "",
   "license": "BSD-3-Clause",

--- a/packages/cypress/src/install.ts
+++ b/packages/cypress/src/install.ts
@@ -1,3 +1,20 @@
-import { ensurePuppeteerBrowsersInstalled } from "@replayio/replay";
+import {
+  BrowserName,
+  ensurePlaywrightBrowsersInstalled,
+} from "@replayio/replay";
 
-(async () => await ensurePuppeteerBrowsersInstalled("all"))();
+function isValidBrowser(
+  browserName: string
+): browserName is BrowserName | "all" {
+  return ["chromium", "firefox", "all"].includes(browserName);
+}
+
+async function install(browser: string) {
+  if (isValidBrowser(browser)) {
+    await ensurePlaywrightBrowsersInstalled(browser, {verbose: true});
+  } else {
+    console.error("Browser", browser, "is not supported");
+  }
+}
+
+export default install;


### PR DESCRIPTION
## Issue

`@replayio/cypress` doesn't install the replay browsers

## Analysis

The code for this was copied from a much earlier version of the plugins which included an install script but it wasn't as robust. Also, the `package.json` didn't include the `install` hook so the existing script wasn't called.

## Resolution

* Update the script to match the newer version
* Add support for `CYPRESS_INSTALL_BINARY` to suppress install (like `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`)
* Add `install` script to `package.json`
