### PR TITLE
Limit cypress plugin to ignore pending tests

### DIFF
--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -82,7 +82,7 @@ class ReplayReporter {
       "passed"
     );
 
-    if (!status) return;
+    if (!["passed", "failed"].includes(status)) return;
 
     const recs = listAllRecordings().filter((r) => {
       if (


### PR DESCRIPTION
We're only support passed/failed/timedOut test status and cypress doesn't support timedOut so we'll limit to passed/failed.