### PR TITLE
Throw when trying to run on a unsupported platform

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -4,9 +4,6 @@ import path from "path";
 
 function getDeviceConfig(browserName: BrowserName) {
   const executablePath = getExecutablePath(browserName);
-  if (!executablePath) {
-    console.warn(`${browserName} is not supported on this platform`);
-  }
 
   const env: Record<string, any> = {
     ...process.env,
@@ -33,7 +30,13 @@ function getDeviceConfig(browserName: BrowserName) {
 
   return {
     launchOptions: {
-      executablePath,
+      get executablePath() {
+        if (!executablePath) {
+          throw new Error(`${browserName} is not supported on this platform`);
+        }
+
+        return executablePath;
+      },
       env,
     },
     defaultBrowserType: browserName,


### PR DESCRIPTION
## Issue

`@replayio/playwright` complains about chromium not being supported even if you're not using it if the device config is fetch.

That's annoying.

## Resolution

Cut the warning and instead throw an error if the user actually tries to run tests with an unsupported browser. This means we're not as noisy and tests will actually fail rather than reverting to the default executable path for the browser type.