### PR TITLE
Log the metadata we are setting

### DIFF
--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -348,7 +348,7 @@ async function doUploadRecording(
   );
   maybeLog(verbose, `Created remote recording ${recordingId}, uploading...`);
   if (metadata) {
-    maybeLog(verbose, `Setting recording metadata for ${recordingId}`);
+    maybeLog(verbose, `Setting recording metadata for ${recordingId}: ${metadata}`);
     await setRecordingMetadata(recordingId, metadata);
   }
   addRecordingEvent(dir, "uploadStarted", recording.id, {


### PR DESCRIPTION
These logs can be helpful to when viewing task output directly, and they
would be even *more* helpful if they would tell you which metadata is
associated with what recording upload.