### PR TITLE
adds uuid version to match playwright package

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -22,7 +22,8 @@
     "cypress": "^10.0.3"
   },
   "dependencies": {
-    "@replayio/replay": "^0.4.4"
+    "@replayio/replay": "^0.4.4",
+    "uuid": "^8.3.2"
   },
   "publishConfig": {
     "directory": "dist",


### PR DESCRIPTION
https://linear.app/replay/issue/BAC-1933/replayiocypress-throws-error-in-yarn-plugnplay-mode-for-requiring

Adds uuid as a dependency in cypress package to resolve yarn pnp error.