### PR TITLE
list all recordings from test runner reporters

### DIFF
--- a/.github/actions/replay/upload.js
+++ b/.github/actions/replay/upload.js
@@ -19,7 +19,7 @@ async function uploadFailedRecordings({require}) {
   });
 
   return cli
-    .listAllRecordings()
+    .listAllRecordings({ all: true })
     .filter((r) => r.status === "uploaded")
     .map((r) => ({ id: r.recordingId, title: r.metadata.title }));
 }

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "if:exists": "node -e 'process.exit(require(\"fs\").existsSync(process.argv[1]) ? 0 : 1)'",
     "if:dist": "npm run if:exists -- src/index.js",
+    "if:source": "npm run if:exists -- src/index.ts",
     "prepare": "npm run if:dist || npm run build",
     "install": "npm run if:source || node ./bin/replayio-cypress first-run",
     "build": "rm -rf dist/ && tsc && cp package.json README.md dist/",

--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -84,7 +84,7 @@ class ReplayReporter {
 
     if (!["passed", "failed"].includes(status)) return;
 
-    const recs = listAllRecordings().filter((r) => {
+    const recs = listAllRecordings({all: true}).filter((r) => {
       if (
         r.metadata["x-cypress"] &&
         typeof r.metadata["x-cypress"] === "object"

--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -116,7 +116,7 @@ class ReplayReporter implements Reporter {
     // skipped tests won't have a reply so nothing to do here
     if (status === "skipped") return;
 
-    const recs = listAllRecordings().filter((r) => {
+    const recs = listAllRecordings({ all: true }).filter((r) => {
       if (
         r.metadata["x-playwright"] &&
         typeof r.metadata["x-playwright"] === "object"


### PR DESCRIPTION
Fix a regression from the addition of the `--all` option in which adding metadata was failing because it wasn't finding the pending recordings.