### PR TITLE
Fix replay ls title generation

### DIFF
--- a/packages/replay/src/cli/__snapshots__/formatRecordings.test.ts.snap
+++ b/packages/replay/src/cli/__snapshots__/formatRecordings.test.ts.snap
@@ -11,6 +11,11 @@ exports[`formatAllRecordingsHumanReadable sorts recording by createTime, most re
 1   onDisk  Replay of test  2020-01-01T00:00:00.000Z"
 `;
 
+exports[`formatAllRecordingsHumanReadable uses the metadata title when it exists 1`] = `
+"ID  Status  Title             Created At
+1   onDisk  A Node Recording  2020-01-01T00:00:00.000Z"
+`;
+
 exports[`formatAllReordingsJson matches snapshot 1`] = `
 "[
   {

--- a/packages/replay/src/cli/formatRecordings.test.ts
+++ b/packages/replay/src/cli/formatRecordings.test.ts
@@ -17,6 +17,23 @@ describe("formatAllRecordingsHumanReadable", () => {
     expect(result).toMatchSnapshot();
   });
 
+  it("uses the metadata title when it exists", () => {
+    const recordings: ExternalRecordingEntry[] = [
+      {
+        id: "1",
+        createTime: new Date("2020-01-01"),
+        runtime: "node",
+        metadata: {
+          title: "A Node Recording",
+        },
+        status: "onDisk",
+        sourcemaps: [],
+      },
+    ];
+    const result = formatAllRecordingsHumanReadable(recordings);
+    expect(result).toMatchSnapshot();
+  });
+
   it("sorts recording by createTime, most recent recording first", () => {
     const recordings: ExternalRecordingEntry[] = [
       {

--- a/packages/replay/src/cli/formatRecordings.ts
+++ b/packages/replay/src/cli/formatRecordings.ts
@@ -12,12 +12,11 @@ export function formatAllRecordingsHumanReadable(recordings: ExternalRecordingEn
     return b.createTime.getTime() - a.createTime.getTime();
   });
   const formattedRecordings = recordings.map(recording => {
-    return [
-      recording.id,
-      recording.status,
-      generateDefaultTitle(recording.metadata) || "",
-      recording.createTime.toISOString(),
-    ];
+    const title =
+      typeof recording.metadata?.title === "string"
+        ? recording.metadata.title
+        : generateDefaultTitle(recording.metadata);
+    return [recording.id, recording.status, title || "", recording.createTime.toISOString()];
   });
 
   const tableBody: Array<Array<string>> = [


### PR DESCRIPTION
## Issue

A default title is always generated even if there is one either from gecko or test metadata

## Resolution

Use the title if it's there