### PR TITLE
Add filter option to ls and upload-all

### DIFF
--- a/packages/replay/package-lock.json
+++ b/packages/replay/package-lock.json
@@ -6,12 +6,13 @@
   "packages": {
     "": {
       "name": "@replayio/replay",
-      "version": "0.6.1",
+      "version": "0.8.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@replayio/sourcemap-upload": "^1.0.1",
+        "@replayio/sourcemap-upload": "^1.0.2",
         "commander": "^7.2.0",
         "is-uuid": "^1.0.2",
+        "jsonata": "^1.8.6",
         "superstruct": "^0.15.4",
         "text-table": "^0.2.0",
         "ws": "^7.5.0"
@@ -933,9 +934,9 @@
       }
     },
     "node_modules/@replayio/sourcemap-upload": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@replayio/sourcemap-upload/-/sourcemap-upload-1.0.1.tgz",
-      "integrity": "sha512-GWxXH4pU0QF2/UHSLkWljny/hx7x2VR6QBqYIVBQ++RsVd8B22Up32Q9s6/PpmTO+y01XdWpldupU5LuzvCcnQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@replayio/sourcemap-upload/-/sourcemap-upload-1.0.2.tgz",
+      "integrity": "sha512-gsFKIjHW3IycC7g/uHH3PkECeZ2l+QugJ9lQxAiDlRoMVQg77CrAm6yciBTpdlodRsw97vrJWYJj8c5tNOIUZQ==",
       "dependencies": {
         "commander": "^7.2.0",
         "debug": "^4.3.1",
@@ -2946,6 +2947,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonata": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-1.8.6.tgz",
+      "integrity": "sha512-ZH2TPYdNP2JecOl/HvrH47Xc+9imibEMQ4YqKy/F/FrM+2a6vfbGxeCX23dB9Fr6uvGwv+ghf1KxWB3iZk09wA==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4794,9 +4803,9 @@
       }
     },
     "@replayio/sourcemap-upload": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@replayio/sourcemap-upload/-/sourcemap-upload-1.0.1.tgz",
-      "integrity": "sha512-GWxXH4pU0QF2/UHSLkWljny/hx7x2VR6QBqYIVBQ++RsVd8B22Up32Q9s6/PpmTO+y01XdWpldupU5LuzvCcnQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@replayio/sourcemap-upload/-/sourcemap-upload-1.0.2.tgz",
+      "integrity": "sha512-gsFKIjHW3IycC7g/uHH3PkECeZ2l+QugJ9lQxAiDlRoMVQg77CrAm6yciBTpdlodRsw97vrJWYJj8c5tNOIUZQ==",
       "requires": {
         "commander": "^7.2.0",
         "debug": "^4.3.1",
@@ -6300,6 +6309,11 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
+    },
+    "jsonata": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-1.8.6.tgz",
+      "integrity": "sha512-ZH2TPYdNP2JecOl/HvrH47Xc+9imibEMQ4YqKy/F/FrM+2a6vfbGxeCX23dB9Fr6uvGwv+ghf1KxWB3iZk09wA=="
     },
     "kleur": {
       "version": "3.0.3",

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -29,6 +29,7 @@
     "@replayio/sourcemap-upload": "^1.0.2",
     "commander": "^7.2.0",
     "is-uuid": "^1.0.2",
+    "jsonata": "^1.8.6",
     "superstruct": "^0.15.4",
     "text-table": "^0.2.0",
     "ws": "^7.5.0"

--- a/packages/replay/src/bin.ts
+++ b/packages/replay/src/bin.ts
@@ -12,7 +12,7 @@ import {
   removeAllRecordings,
   updateBrowsers,
 } from "./main";
-import { CommandLineOptions, SourcemapUploadOptions } from "./types";
+import { CommandLineOptions, FilterOptions, SourcemapUploadOptions } from "./types";
 
 // TODO(dmiller): `--json` should probably be a global option that applies to all commands.
 program
@@ -21,6 +21,7 @@ program
   .option("--directory <dir>", "Alternate recording directory.")
   .option("-a, --all", "Include all recordings")
   .option("--json", "Output in JSON format")
+  .option("--filter <filter string>", "String to filter recordings")
   .action(commandListAllRecordings);
 
 program
@@ -45,6 +46,7 @@ program
   .option("--directory <dir>", "Alternate recording directory.")
   .option("--server <address>", "Alternate server to upload recordings to.")
   .option("--api-key <key>", "Authentication API Key")
+  .option("--filter <filter string>", "String to filter recordings")
   .option(
     "--include-in-progress",
     "Upload all recordings, including ones with an in progress status"
@@ -117,7 +119,9 @@ function collectIgnorePatterns(value: string, previous: Array<string> = []) {
   return previous.concat([value]);
 }
 
-function commandListAllRecordings(opts: Pick<CommandLineOptions, "directory" | "json">) {
+function commandListAllRecordings(
+  opts: Pick<CommandLineOptions, "directory" | "json"> & FilterOptions
+) {
   const recordings = listAllRecordings({ ...opts, verbose: true });
   if (opts.json) {
     console.log(formatAllRecordingsJson(recordings));
@@ -137,7 +141,7 @@ async function commandProcessRecording(id: string, opts: CommandLineOptions) {
   process.exit(recordingId ? 0 : 1);
 }
 
-async function commandUploadAllRecordings(opts: CommandLineOptions) {
+async function commandUploadAllRecordings(opts: CommandLineOptions & FilterOptions) {
   const uploadedAll = await uploadAllRecordings({ ...opts, verbose: true });
   process.exit(uploadedAll ? 0 : 1);
 }

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -37,7 +37,11 @@ export interface SourcemapUploadOptions {
   root?: string;
 }
 
-export interface ListOptions {
+export interface FilterOptions {
+  filter?: string;
+}
+
+export interface ListOptions extends FilterOptions {
   all?: boolean;
 }
 


### PR DESCRIPTION
Adds `--filter` option to `ls` and `upload-all` to support a declarative way to filter the recordings