### PR TITLE
Add cli option to generate metadata

### DIFF
--- a/packages/replay/metadata/source.ts
+++ b/packages/replay/metadata/source.ts
@@ -1,4 +1,4 @@
-import type { Struct } from "superstruct";
+import { number, Struct } from "superstruct";
 const { create, object, optional, defaulted } = require("superstruct");
 
 import { envString } from "./env";
@@ -89,6 +89,7 @@ const versions: Record<number, Struct> = {
         "CIRCLE_PROJECT_REPONAME"
       )
     ),
+    version: defaulted(number(), () => 1),
   }),
 };
 

--- a/packages/replay/metadata/test.ts
+++ b/packages/replay/metadata/test.ts
@@ -1,4 +1,5 @@
 import type { Struct } from "superstruct";
+import { envString, firstEnvValueOf } from "./env";
 const {
   array,
   create,
@@ -18,16 +19,25 @@ const VERSION = 1;
 
 const versions: Record<number, Struct> = {
   1: object({
-    file: optional(string()),
+    file: optional(envString("RECORD_REPLAY_METADATA_TEST_FILE")),
     path: optional(array(string())),
-    result: enums(["passed", "failed", "timedOut"]),
-    run: optional(
-      object({
-        id: define("uuid", (v: any) => isUuid.v4(v)),
-        title: optional(string()),
-      })
+    result: defaulted(
+      enums(["passed", "failed", "timedOut"]),
+      firstEnvValueOf("RECORD_REPLAY_METADATA_TEST_RESULT")
     ),
-    title: string(),
+    run: optional(
+      defaulted(
+        object({
+          id: defaulted(
+            define("uuid", (v: any) => isUuid.v4(v)),
+            firstEnvValueOf("RECORD_REPLAY_METADATA_TEST_RUN_ID", "RECORD_REPLAY_TEST_RUN_ID")
+          ),
+          title: optional(envString("RECORD_REPLAY_METADATA_TEST_RUN_TITLE")),
+        }),
+        {}
+      )
+    ),
+    title: envString("RECORD_REPLAY_METADATA_TEST_TITLE"),
     version: defaulted(number(), () => 1),
   }),
 };
@@ -40,7 +50,7 @@ function validate(metadata: { test: UnstructuredMetadata }) {
   return init(metadata.test);
 }
 
-function init(data: UnstructuredMetadata) {
+function init(data: UnstructuredMetadata = {}) {
   const version = typeof data.version === "number" ? data.version : VERSION;
   if (versions[version]) {
     return {

--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -26,10 +26,11 @@ import {
   ExternalRecordingEntry,
   FilterOptions,
   ListOptions,
+  MetadataOptions,
   Options,
   RecordingEntry,
 } from "./types";
-import { add } from "../metadata";
+import { add, sanitize, source as sourceMetadata, test as testMetadata } from "../metadata";
 import { generateDefaultTitle } from "./generateDefaultTitle";
 import jsonata from "jsonata";
 export type { BrowserName } from "./types";
@@ -574,6 +575,71 @@ function addLocalRecordingMetadata(recordingId: string, metadata: Record<string,
   add(recordingId, metadata);
 }
 
+function updateMetadata({
+  init: metadata,
+  keys = [],
+  filter,
+  verbose,
+  warn,
+}: MetadataOptions & FilterOptions) {
+  try {
+    let md: any = {};
+    if (metadata) {
+      md = JSON.parse(metadata);
+    }
+
+    const data = keys.reduce((acc, v) => {
+      try {
+        switch (v) {
+          case "source":
+            return {
+              ...acc,
+              ...sourceMetadata.init(md.source || {}),
+            };
+          case "test": {
+            return {
+              ...acc,
+              ...testMetadata.init(md.test || {}),
+            };
+          }
+        }
+
+        return acc;
+      } catch (e) {
+        if (!warn) {
+          console.error("Unable to initialize metadata field", v);
+          console.error(e);
+
+          process.exit(1);
+        }
+
+        console.warn("Unable to initialize metadata field", v);
+        console.warn(String(e));
+
+        return acc;
+      }
+    }, md);
+
+    const sanitized = sanitize(data);
+
+    console.group("Metadata:");
+    console.log(JSON.stringify(sanitized, undefined, 2));
+    console.groupEnd();
+
+    const recordings = filterRecordings(listAllRecordings(), filter);
+
+    recordings.forEach(r => {
+      if (verbose) console.log("Setting metadata for", r.id);
+      add(r.id, sanitized);
+    });
+  } catch (e) {
+    console.error("Failed to set recording metadata");
+    console.error(e);
+
+    process.exit(1);
+  }
+}
+
 export {
   addLocalRecordingMetadata,
   listAllRecordings,
@@ -585,6 +651,7 @@ export {
   removeRecording,
   removeAllRecordings,
   updateBrowsers,
+  updateMetadata,
   // These methods aren't documented or available via the CLI, and are used by other
   // replay NPM packages.
   ensurePlaywrightBrowsersInstalled,

--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -622,14 +622,13 @@ function updateMetadata({
 
     const sanitized = sanitize(data);
 
-    console.group("Metadata:");
-    console.log(JSON.stringify(sanitized, undefined, 2));
-    console.groupEnd();
+    maybeLog(verbose, "Metadata:");
+    maybeLog(verbose, JSON.stringify(sanitized, undefined, 2));
 
     const recordings = filterRecordings(listAllRecordings(), filter);
 
     recordings.forEach(r => {
-      if (verbose) console.log("Setting metadata for", r.id);
+      maybeLog(verbose, `Setting metadata for ${r.id}`);
       add(r.id, sanitized);
     });
   } catch (e) {

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -37,6 +37,13 @@ export interface SourcemapUploadOptions {
   root?: string;
 }
 
+export interface MetadataOptions {
+  init?: string;
+  keys?: string[];
+  warn?: boolean;
+  verbose?: boolean;
+}
+
 export interface FilterOptions {
   filter?: string;
 }


### PR DESCRIPTION
* Improves initialization for `test` metadata to pull from env variables like `source` does
* Adds `metadata` command to cli to generate and set metadata for recordings. Can be `--filter`-ed to limit which are updated. (so blocked by #71)