### PR TITLE
Treat pending cypress test results as passed when aggregating

### DIFF
--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -74,10 +74,13 @@ class ReplayReporter {
   }
 
   onTestEnd(spec: Cypress.Spec, result: CypressCommandLine.RunResult) {
-    const status = result.tests.reduce<string>(
-      (acc, t) => (acc === "failed" || !t.state ? acc : t.state),
-      "passed"
-    );
+    const status = result.tests.reduce<string>((acc, t) => {
+      if (acc === "failed" || t.state === "failed") {
+        return "failed";
+      }
+
+      return "passed";
+    }, "passed");
 
     if (!["passed", "failed"].includes(status)) return;
 


### PR DESCRIPTION
## Issue

If a cypress spec file finished with a pending test and had not failed on a previous test, the spec file would be discarded because the aggregate test result was "pending" instead of "passed" or "failed".

## Resolution

Treat pending tests as passed so that only true failures set the status as failed