### PR TITLE
Update packages to include git repo references

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -16,8 +16,16 @@
   "bin": {
     "replayio-cypress": "./bin/replayio-cypress.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/replayio/replay-cli.git"
+  },
   "author": "",
   "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/replayio/replay-cli/issues"
+  },
+  "homepage": "https://github.com/replayio/replay-cli/blob/main/packages/cypress/README.md",
   "devDependencies": {
     "@types/node": "^16.11.39",
     "cypress": "^10.0.3"

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -15,16 +15,20 @@
   "bin": {
     "replayio-jest": "./bin/replayio-jest.js"
   },
-  "author": "",
   "publishConfig": {
     "directory": "dist",
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/replayio/replay-cli.git"
+  },
+  "author": "",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/ReplayIO/replay-cli/issues"
+    "url": "https://github.com/replayio/replay-cli/issues"
   },
-  "homepage": "https://github.com/Replayio/replay-cli/blob/main/packages/jest/README.md",
+  "homepage": "https://github.com/replayio/replay-cli/blob/main/packages/jest/README.md",
   "devDependencies": {
     "@jest/reporters": "^27.5.1",
     "@jest/test-result": "^27.5.1",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -21,6 +21,6 @@
   "bugs": {
     "url": "https://github.com/replayio/replay-cli/issues"
   },
-  "homepage": "https://github.com/Replayio/replay-cli/blob/main/packages/node/README.md",
+  "homepage": "https://github.com/replayio/replay-cli/blob/main/packages/node/README.md",
   "gitHead": "1f66765d6ce66d3676c247110e21a78b2594314b"
 }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -16,20 +16,24 @@
   "bin": {
     "replayio-playwright": "./bin/replayio-playwright.js"
   },
-  "author": "",
   "publishConfig": {
     "directory": "dist"
   },
-  "license": "BSD-3-Clause",
   "devDependencies": {
     "@playwright/test": "1.19.x",
     "@types/node": "^17.0.21",
     "@types/uuid": "^8.3.4"
   },
-  "bugs": {
-    "url": "https://github.com/ReplayIO/replay-cli/issues"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/replayio/replay-cli.git"
   },
-  "homepage": "https://github.com/Replayio/replay-cli/blob/main/packages/playwright/README.md",
+  "author": "",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/replayio/replay-cli/issues"
+  },
+  "homepage": "https://github.com/replayio/replay-cli/blob/main/packages/playwright/README.md",
   "dependencies": {
     "@replayio/replay": "^0.9.3",
     "uuid": "^8.3.2"

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -16,18 +16,22 @@
   "bin": {
     "replayio-puppeteer": "./bin/replayio-puppeteer.js"
   },
-  "author": "",
   "publishConfig": {
     "directory": "dist"
   },
-  "license": "BSD-3-Clause",
   "devDependencies": {
     "@types/node": "^17.0.21"
   },
-  "bugs": {
-    "url": "https://github.com/ReplayIO/replay-cli/issues"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/replayio/replay-cli.git"
   },
-  "homepage": "https://github.com/Replayio/replay-cli/blob/main/packages/puppeteer/README.md",
+  "author": "",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/replayio/replay-cli/issues"
+  },
+  "homepage": "https://github.com/replayio/replay-cli/blob/main/packages/puppeteer/README.md",
   "dependencies": {
     "@replayio/replay": "^0.9.3"
   },

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -17,14 +17,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ReplayIO/replay-cli.git"
+    "url": "git+https://github.com/replayio/replay-cli.git"
   },
   "author": "",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/ReplayIO/replay-cli/issues"
+    "url": "https://github.com/replayio/replay-cli/issues"
   },
-  "homepage": "https://github.com/Replayio/replay-cli/blob/main/packages/replay/README.md",
+  "homepage": "https://github.com/replayio/replay-cli/blob/main/packages/replay/README.md",
   "dependencies": {
     "@replayio/sourcemap-upload": "^1.0.2",
     "commander": "^7.2.0",

--- a/packages/sourcemap-upload-webpack-plugin/package.json
+++ b/packages/sourcemap-upload-webpack-plugin/package.json
@@ -32,7 +32,7 @@
   "bugs": {
     "url": "https://github.com/replayio/replay-cli/issues"
   },
-  "homepage": "https://github.com/Replayio/replay-cli/blob/main/packages/sourcemap-upload-webpack-plugin/README.md",
+  "homepage": "https://github.com/replayio/replay-cli/blob/main/packages/sourcemap-upload-webpack-plugin/README.md",
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/glob": "^7.1.3",

--- a/packages/sourcemap-upload/package.json
+++ b/packages/sourcemap-upload/package.json
@@ -31,7 +31,7 @@
   "bugs": {
     "url": "https://github.com/replayio/replay-cli/issues"
   },
-  "homepage": "https://github.com/Replayio/replay-cli/blob/main/packages/sourcemap-upload/README.md",
+  "homepage": "https://github.com/replayio/replay-cli/blob/main/packages/sourcemap-upload/README.md",
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/glob": "^7.1.3",


### PR DESCRIPTION
* Adds `repository` key to `cypress` and `jest` packages
* Standardize the rest to use the same order and casing