### PR TITLE
Add errors to test metadata

### DIFF
--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -19,7 +19,6 @@ function extractErrorMessage(errorStep?: TestStep) {
 
 class ReplayPlaywrightReporter implements Reporter {
   reporter?: ReplayReporter;
-  rootDir?: string;
 
   getTestId(test: TestCase) {
     return test.titlePath().join("-");
@@ -48,7 +47,6 @@ class ReplayPlaywrightReporter implements Reporter {
   }
 
   onBegin(config: FullConfig) {
-    this.rootDir = config.rootDir;
     this.reporter = new ReplayReporter({ name: "playwright", version: config.version });
     this.reporter.onTestSuiteBegin(this.parseConfig(config), "PLAYWRIGHT_REPLAY_METADATA");
   }

--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -4,9 +4,24 @@ import path from "path";
 import { ReplayReporter, ReplayReporterConfig } from "@replayio/test-utils";
 
 import { getMetadataFilePath } from "./index";
+import { readFileSync } from "fs";
+import { Step } from "@replayio/test-utils/src/reporter";
+const removeAnsiCodes =
+  /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+
+const fileCache = new Map<string, string[]>();
+function readLines(fileName: string) {
+  if (!fileCache.has(fileName)) {
+    const lines = readFileSync(fileName).toString().split("\n");
+    fileCache.set(fileName, lines);
+  }
+
+  return fileCache.get(fileName)!;
+}
 
 class ReplayPlaywrightReporter implements Reporter {
   reporter?: ReplayReporter;
+  rootDir?: string;
 
   getTestId(test: TestCase) {
     return test.titlePath().join("-");
@@ -35,6 +50,7 @@ class ReplayPlaywrightReporter implements Reporter {
   }
 
   onBegin(config: FullConfig) {
+    this.rootDir = config.rootDir;
     this.reporter = new ReplayReporter({ name: "playwright", version: config.version });
     this.reporter.onTestSuiteBegin(this.parseConfig(config), "PLAYWRIGHT_REPLAY_METADATA");
   }
@@ -48,12 +64,35 @@ class ReplayPlaywrightReporter implements Reporter {
     // skipped tests won't have a reply so nothing to do here
     if (status === "skipped") return;
 
+    const steps = result.steps.map<Step>(step => {
+      const lines = step.location ? readLines(step.location.file) : undefined;
+      return {
+        title: step.title,
+        location: step.location
+          ? {
+              ...step.location,
+              // we don't need or want the user's full path so shortening to the
+              // path relative to the project root directory
+              file: path.relative(this.rootDir!, step.location.file),
+            }
+          : undefined,
+        error:
+          step.error?.message && lines
+            ? {
+                message: step.error.message.replace(removeAnsiCodes, ""),
+                lines: lines.slice(Math.max(0, step.location!.line - 3), step.location!.line + 3),
+              }
+            : undefined,
+      };
+    });
+
     this.reporter?.onTestEnd({
       id: this.getTestId(test),
       title: test.title,
       path: test.titlePath(),
       result: status,
       relativePath: test.titlePath()[2] || test.location.file,
+      steps,
     });
   }
 }

--- a/packages/replay/metadata/test.ts
+++ b/packages/replay/metadata/test.ts
@@ -32,10 +32,7 @@ const versions: Record<number, Struct<any, any>> = {
           title: string(),
           path: optional(array(string())),
           relativePath: optional(string()),
-          result: defaulted(
-            enums(["passed", "failed", "timedOut"]),
-            firstEnvValueOf("RECORD_REPLAY_METADATA_TEST_RESULT")
-          ),
+          result: enums(["passed", "failed", "timedOut"]),
           error: optional(
             object({
               message: string(),

--- a/packages/replay/metadata/test.ts
+++ b/packages/replay/metadata/test.ts
@@ -1,6 +1,5 @@
-import type { Struct } from "superstruct";
 import { envString, firstEnvValueOf } from "./env";
-const {
+import {
   array,
   create,
   defaulted,
@@ -10,14 +9,15 @@ const {
   optional,
   string,
   define,
-} = require("superstruct");
+  Struct,
+} from "superstruct";
 const isUuid = require("is-uuid");
 
 import { UnstructuredMetadata } from "./types";
 
 const VERSION = 1;
 
-const versions: Record<number, Struct> = {
+const versions: Record<number, Struct<any, any>> = {
   1: object({
     file: optional(envString("RECORD_REPLAY_METADATA_TEST_FILE")),
     path: optional(array(string())),
@@ -25,12 +25,33 @@ const versions: Record<number, Struct> = {
       enums(["passed", "failed", "timedOut"]),
       firstEnvValueOf("RECORD_REPLAY_METADATA_TEST_RESULT")
     ),
+    steps: optional(
+      array(
+        object({
+          title: optional(string()),
+          location: optional(
+            object({
+              file: string(),
+              line: number(),
+              column: number(),
+            })
+          ),
+          error: optional(
+            object({
+              message: optional(string()),
+              lines: optional(array(string())),
+            })
+          ),
+        })
+      )
+    ),
     runner: optional(
       defaulted(
         object({
           name: optional(envString("RECORD_REPLAY_METADATA_TEST_RUNNER_NAME")),
           version: optional(envString("RECORD_REPLAY_METADATA_TEST_RUNNER_VERSION")),
-        })
+        }),
+        {}
       )
     ),
     run: optional(

--- a/packages/replay/metadata/test.ts
+++ b/packages/replay/metadata/test.ts
@@ -25,21 +25,22 @@ const versions: Record<number, Struct<any, any>> = {
       enums(["passed", "failed", "timedOut"]),
       firstEnvValueOf("RECORD_REPLAY_METADATA_TEST_RESULT")
     ),
-    steps: optional(
+    tests: optional(
       array(
         object({
-          title: optional(string()),
-          location: optional(
-            object({
-              file: string(),
-              line: number(),
-              column: number(),
-            })
+          id: optional(string()),
+          title: string(),
+          path: optional(array(string())),
+          relativePath: optional(string()),
+          result: defaulted(
+            enums(["passed", "failed", "timedOut"]),
+            firstEnvValueOf("RECORD_REPLAY_METADATA_TEST_RESULT")
           ),
           error: optional(
             object({
-              message: optional(string()),
-              lines: optional(array(string())),
+              message: string(),
+              line: optional(number()),
+              column: optional(number()),
             })
           ),
         })

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -2,4 +2,5 @@ import ReplayReporter from "./reporter";
 
 export type { Test, ReplayReporterConfig } from "./reporter";
 export { pingTestMetrics } from "./metrics";
+export { removeAnsiCodes } from "./terminal";
 export { ReplayReporter };

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -12,12 +12,26 @@ export interface ReplayReporterConfig {
   metadata?: Record<string, any> | string;
 }
 
+export interface Step {
+  title?: string;
+  location?: {
+    file: string;
+    line: number;
+    column: number;
+  };
+  error?: {
+    message: string;
+    lines: string[];
+  };
+}
+
 export interface Test {
   id?: string;
   title: string;
   path: string[];
   result: "passed" | "failed" | "timedOut";
   relativePath: string;
+  steps?: Step[];
 }
 
 export interface TestRunner {
@@ -143,6 +157,7 @@ class ReplayReporter {
               title: this.runTitle,
             },
             file: test.relativePath,
+            steps: test.steps,
           }),
         })
       );

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -12,19 +12,6 @@ export interface ReplayReporterConfig {
   metadata?: Record<string, any> | string;
 }
 
-export interface Step {
-  title?: string;
-  location?: {
-    file: string;
-    line: number;
-    column: number;
-  };
-  error?: {
-    message: string;
-    lines: string[];
-  };
-}
-
 export interface Test {
   id?: string;
   title: string;

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -31,7 +31,11 @@ export interface Test {
   path: string[];
   result: "passed" | "failed" | "timedOut";
   relativePath: string;
-  steps?: Step[];
+  error?: {
+    message: string;
+    line?: number;
+    column?: number;
+  };
 }
 
 export interface TestRunner {
@@ -132,12 +136,20 @@ class ReplayReporter {
     );
   }
 
-  onTestEnd(test: Test) {
+  onTestEnd(tests: Test[], replayTitle?: string) {
     const recs = listAllRecordings({
-      filter: `function($v) { $v.metadata.\`x-replay-test\`.id = "${this.getTestId(
-        test.id
-      )}" and $not($exists($v.metadata.test)) }`,
+      filter: `function($v) { $v.metadata.\`x-replay-test\`.id in ["${tests
+        .map(test => this.getTestId(test.id))
+        .join('", "')}"] and $not($exists($v.metadata.test)) }`,
     });
+
+    const test = tests[0];
+    const results = tests.map(t => t.result);
+    const result = results.includes("failed")
+      ? "failed"
+      : results.includes("timedOut")
+      ? "timedOut"
+      : "passed";
 
     let recordingId: string | undefined;
     let runtime: string | undefined;
@@ -146,10 +158,10 @@ class ReplayReporter {
       runtime = recs[0].runtime;
       recs.forEach(rec =>
         add(rec.id, {
-          title: test.title,
+          title: replayTitle || test.title,
           ...testMetadata.init({
-            title: test.title,
-            result: test.result,
+            title: replayTitle || test.title,
+            result,
             path: test.path,
             runner: this.runner,
             run: {
@@ -157,7 +169,7 @@ class ReplayReporter {
               title: this.runTitle,
             },
             file: test.relativePath,
-            steps: test.steps,
+            tests: tests,
           }),
         })
       );

--- a/packages/test-utils/src/terminal.ts
+++ b/packages/test-utils/src/terminal.ts
@@ -1,0 +1,5 @@
+export const removeAnsiCodes = (message?: string) =>
+  message?.replace(
+    /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
+    ""
+  );


### PR DESCRIPTION
* Adds `tests` to `test` metadata
* Surfaces errors from jest, playwright, and cypress in `tests`