### PR TITLE
Escape test ids passed to jsonata

### DIFF
--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -125,9 +125,9 @@ class ReplayReporter {
 
   onTestEnd(tests: Test[], replayTitle?: string) {
     const recs = listAllRecordings({
-      filter: `function($v) { $v.metadata.\`x-replay-test\`.id in ["${tests
-        .map(test => this.getTestId(test.id))
-        .join('", "')}"] and $not($exists($v.metadata.test)) }`,
+      filter: `function($v) { $v.metadata.\`x-replay-test\`.id in ${JSON.stringify(
+        tests.map(test => this.getTestId(test.id))
+      )} and $not($exists($v.metadata.test)) }`,
     });
 
     const test = tests[0];


### PR DESCRIPTION
If the test id has a backslash (e.g. it was generated from the relative path of the test file on windows), jsonata will throw an error for an invalid escape sequence.

The format of the string follows JSON rules so stringifying it handles the escaping.