### PR TITLE
Fix build scripts to avoid error-warnings on node 14

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -4,11 +4,11 @@
   "description": "Plugin to record your Cypress tests with Replay",
   "main": "src/index.js",
   "scripts": {
-    "if:exists": "node -e 'process.exit(require(\"fs\").existsSync(process.argv[1]) ? 0 : 1)'",
+    "if:exists": "node -e 'require(\"fs\").existsSync(process.argv[1]) ? require(\"child_process\").spawnSync(process.argv[2], process.argv.slice(3), {stdio: \"inherit\"}) : 0'",
     "if:dist": "npm run if:exists -- src/index.js",
     "if:source": "npm run if:exists -- src/index.ts",
-    "prepare": "npm run if:dist || npm run build",
-    "install": "npm run if:source || node ./bin/replayio-cypress first-run",
+    "prepare": "npm run if:source -- npm run build",
+    "install": "npm run if:dist -- node ./bin/replayio-cypress first-run",
     "build": "rm -rf dist/ && tsc && cp package.json README.md dist/",
     "test": "echo \"Error: no test specified\"",
     "typecheck": "tsc --noEmit"

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -4,10 +4,9 @@
   "description": "Configuration utilities for using capturing metadata from Jest for Replay browsers",
   "main": "src/index.js",
   "scripts": {
-    "if:exists": "node -e 'process.exit(require(\"fs\").existsSync(process.argv[1]) ? 0 : 1)'",
+    "if:exists": "node -e 'require(\"fs\").existsSync(process.argv[1]) ? require(\"child_process\").spawnSync(process.argv[2], process.argv.slice(3), {stdio: \"inherit\"}) : 0'",
     "if:source": "npm run if:exists -- src/index.ts",
-    "if:dist": "npm run if:exists -- src/index.js",
-    "prepare": "npm run if:dist || npm run build",
+    "prepare": "npm run if:source -- npm run build",
     "build": "rm -rf dist/ && tsc && cp package.json README.md dist/",
     "test": "echo \"Error: no test specified\"",
     "typecheck": "tsc --noEmit"

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -4,11 +4,11 @@
   "description": "Configuration utilities for using the Replay browsers with playwright",
   "main": "src/index.js",
   "scripts": {
-    "if:exists": "node -e 'process.exit(require(\"fs\").existsSync(process.argv[1]) ? 0 : 1)'",
+    "if:exists": "node -e 'require(\"fs\").existsSync(process.argv[1]) ? require(\"child_process\").spawnSync(process.argv[2], process.argv.slice(3), {stdio: \"inherit\"}) : 0'",
     "if:source": "npm run if:exists -- src/index.ts",
     "if:dist": "npm run if:exists -- src/index.js",
-    "prepare": "npm run if:dist || npm run build",
-    "install": "npm run if:source || node ./bin/replayio-playwright first-run",
+    "prepare": "npm run if:source -- npm run build",
+    "install": "npm run if:dist -- node ./bin/replayio-playwright first-run",
     "build": "rm -rf dist/ && tsc && chmod 755 dist/bin/* && cp package.json README.md dist/",
     "test": "echo \"Error: no test specified\"",
     "typecheck": "tsc --noEmit"

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -4,11 +4,11 @@
   "description": "Configuration utilities for using the Replay browsers with puppeteer",
   "main": "src/index.js",
   "scripts": {
-    "if:exists": "node -e 'process.exit(require(\"fs\").existsSync(process.argv[1]) ? 0 : 1)'",
+    "if:exists": "node -e 'require(\"fs\").existsSync(process.argv[1]) ? require(\"child_process\").spawnSync(process.argv[2], process.argv.slice(3), {stdio: \"inherit\"}) : 0'",
     "if:source": "npm run if:exists -- src/index.ts",
     "if:dist": "npm run if:exists -- src/index.js",
-    "prepare": "npm run if:dist || npm run build",
-    "install": "npm run if:source || node ./bin/replayio-puppeteer first-run",
+    "prepare": "npm run if:source -- npm run build",
+    "install": "npm run if:dist -- node ./bin/replayio-puppeteer first-run",
     "build": "rm -rf dist/ && tsc && chmod 755 dist/bin/* && cp package.json README.md dist/",
     "test": "echo \"Error: no test specified\"",
     "typecheck": "tsc --noEmit"

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -7,10 +7,9 @@
   },
   "main": "src/main.js",
   "scripts": {
-    "if:exists": "node -e 'process.exit(require(\"fs\").existsSync(process.argv[1]) ? 0 : 1)'",
-    "if:source": "npm run if:exists -- src/main.ts",
+    "if:exists": "node -e 'require(\"fs\").existsSync(process.argv[1]) ? require(\"child_process\").spawnSync(process.argv[2], process.argv.slice(3), {stdio: \"inherit\"}) : 0'",
     "if:dist": "npm run if:exists -- src/main.js",
-    "prepare": "npm run if:dist || npm run build",
+    "prepare": "npm run if:dist -- npm run build",
     "build": "rm -rf dist/ && tsc && chmod 755 dist/bin/* && cp package.json README.md dist/",
     "test": "jest --ci",
     "typecheck": "tsc --noEmit"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -4,10 +4,9 @@
   "description": "Utilities for recording tests with replay.io",
   "main": "src/index.js",
   "scripts": {
-    "if:exists": "node -e 'process.exit(require(\"fs\").existsSync(process.argv[1]) ? 0 : 1)'",
-    "if:source": "npm run if:exists -- src/index.ts",
+    "if:exists": "node -e 'require(\"fs\").existsSync(process.argv[1]) ? require(\"child_process\").spawnSync(process.argv[2], process.argv.slice(3), {stdio: \"inherit\"}) : 0'",
     "if:dist": "npm run if:exists -- src/index.js",
-    "prepare": "npm run if:dist || npm run build",
+    "prepare": "npm run if:dist -- npm run build",
     "build": "rm -rf dist/ && tsc && cp package.json README.md dist/",
     "test": "echo \"Error: no test specified\"",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
Switch the `if:exists` script to spawn a process rather than exit to avoid the case where node 14 logs an error (but then continues) if an intermediate step returns a non-zero exit code.