### PR TITLE
Add parentId to test steps

### DIFF
--- a/packages/replay/metadata/test.ts
+++ b/packages/replay/metadata/test.ts
@@ -30,6 +30,7 @@ const versions: Record<number, Struct<any, any>> = {
       array(
         object({
           id: optional(string()),
+          parentId: optional(string()),
           title: string(),
           path: optional(array(string())),
           relativePath: optional(string()),

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -21,6 +21,7 @@ export interface TestError {
 
 export interface TestStep {
   id: string;
+  parentId?: string;
   name: string;
   args?: any[];
   error?: TestError;


### PR DESCRIPTION
* Remaps cypress ids to independent ids
* Groups related cypress steps by `chainerId` into `parentId` in test step