### PR TITLE
Use relative path from plugin

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -54,13 +54,13 @@ const plugin: Cypress.PluginConfig = (on, config) => {
 
       return {
         title: t.title[t.title.length - 1] || spec.relative,
-        relativePath: spec.relative,
         // If we found the test from the steps array (we should), merge it in
         // and overwrite the default title and relativePath values. It won't
         // have the correct path or result so those are added and we bubble up
         // the first error found in a step falling back to reported test error
         // if it exists.
         ...foundTest,
+        relativePath: spec.relative,
         path: ["", selectedBrowser || "", spec.relative, spec.specType || ""],
         result: t.state == "failed" ? "failed" : "passed",
         error,


### PR DESCRIPTION
We're sometimes getting the wrong file from steps. The plugin seems to have the correct file so we'll use that instead.