### PR TITLE
Fix duration calculations for asserts

### DIFF
--- a/packages/cypress/src/constants.ts
+++ b/packages/cypress/src/constants.ts
@@ -1,1 +1,2 @@
 export const TASK_NAME = "replay-event";
+export const AFTER_EACH_HOOK = `"after each" hook`;


### PR DESCRIPTION
## Issue

We were logging negative durations for some assertion steps causing odd visuals in the devtools reporter

## Resolution

I think this was caused by matching to assertion steps from previous tests since we were only matching on the id which could be duplicated. As part of this, I removed `assertStack` and used the prior `find()` logic for both command and assertions. I also clamped durations to a min of 0 as a fallback.