### PR TITLE
Add test harness for cypress events

### DIFF
--- a/packages/cypress/src/fixture.ts
+++ b/packages/cypress/src/fixture.ts
@@ -1,0 +1,28 @@
+import { writeFileSync, appendFileSync } from "fs";
+import path from "path";
+
+function getFixtureFile() {
+  return path.resolve(__filename, "../../../tests/fixtures/fixture.log");
+}
+
+export function initFixtureFile() {
+  if (process.env.REPLAY_UPDATE_FIXTURE) {
+    try {
+      writeFileSync(getFixtureFile(), "");
+    } catch (e) {
+      console.error(e);
+      process.env.REPLAY_UPDATE_FIXTURE = undefined;
+    }
+  }
+}
+
+export function appendToFixtureFile(type: string, value: any) {
+  if (process.env.REPLAY_UPDATE_FIXTURE) {
+    try {
+      appendFileSync(getFixtureFile(), JSON.stringify({ type, value }) + "\n");
+    } catch (e) {
+      console.error(e);
+      process.env.REPLAY_UPDATE_FIXTURE = undefined;
+    }
+  }
+}

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -3,20 +3,22 @@
 import path from "path";
 import { getPlaywrightBrowserPath } from "@replayio/replay";
 import { getDirectory } from "@replayio/replay/src/utils";
-import { ReplayReporter, Test } from "@replayio/test-utils";
+import { ReplayReporter } from "@replayio/test-utils";
+
 import { TASK_NAME } from "./constants";
-import type { StepEvent } from "./support";
-import { groupStepsByTest } from "./steps";
+import { appendToFixtureFile, initFixtureFile } from "./fixture";
+import CypressReporter from "./reporter";
+
+let cypressReporter: CypressReporter;
 
 const plugin: Cypress.PluginConfig = (on, config) => {
-  let steps: StepEvent[] = [];
+  initFixtureFile();
 
   const reporter = new ReplayReporter({ name: "cypress", version: config.version });
-  let selectedBrowser: "chromium" | "firefox";
-  let startTime: number | undefined;
+  cypressReporter = new CypressReporter();
 
   on("before:browser:launch", (browser, launchOptions) => {
-    selectedBrowser = browser.family;
+    cypressReporter.setSelectedBrowser(browser.family);
     reporter.onTestSuiteBegin(undefined, "CYPRESS_REPLAY_METADATA");
 
     const [major, minor] = config.version?.split(".") || [];
@@ -25,7 +27,7 @@ const plugin: Cypress.PluginConfig = (on, config) => {
         ...launchOptions,
         env: {
           RECORD_REPLAY_DRIVER:
-            process.env.RECORD_REPLAY_NO_RECORD && selectedBrowser === "chromium"
+            process.env.RECORD_REPLAY_NO_RECORD && browser.family === "chromium"
               ? __filename
               : undefined,
           RECORD_ALL_CONTENT: process.env.RECORD_REPLAY_NO_RECORD ? undefined : 1,
@@ -34,45 +36,17 @@ const plugin: Cypress.PluginConfig = (on, config) => {
       };
     }
   });
-  on("before:spec", () => {
-    startTime = Date.now();
+  on("before:spec", spec => {
+    const startTime = Date.now();
+    appendToFixtureFile("spec:start", { spec, startTime });
+
+    cypressReporter.setStartTime(startTime);
     reporter.onTestBegin(undefined, getMetadataFilePath());
   });
   on("after:spec", (spec, result) => {
-    let testsWithSteps: Test[] = [];
-    try {
-      testsWithSteps = groupStepsByTest(steps, startTime!);
-    } catch (e) {
-      console.warn("Failed to build test step metadata for this replay.");
-      console.warn(e);
-    }
+    appendToFixtureFile("spec:end", { spec, result });
 
-    const tests = result.tests.map<Test>(t => {
-      const foundTest = testsWithSteps.find(ts => ts.title === t.title[t.title.length - 1]) || null;
-
-      const error = t.displayError
-        ? {
-            // typically, we won't use this because we'll have a step error that
-            // originated the message but keeping as a fallback
-            message: t.displayError.substring(0, t.displayError.indexOf("\n")),
-          }
-        : undefined;
-
-      return {
-        title: t.title[t.title.length - 1] || spec.relative,
-        // If we found the test from the steps array (we should), merge it in
-        // and overwrite the default title and relativePath values. It won't
-        // have the correct path or result so those are added and we bubble up
-        // the first error found in a step falling back to reported test error
-        // if it exists.
-        ...foundTest,
-        relativePath: spec.relative,
-        path: ["", selectedBrowser || "", spec.relative, spec.specType || ""],
-        result: t.state == "failed" ? "failed" : "passed",
-        error,
-      };
-    });
-
+    const tests = cypressReporter.getTestResults(spec, result);
     reporter.onTestEnd(tests, spec.relative);
   });
 
@@ -82,7 +56,8 @@ const plugin: Cypress.PluginConfig = (on, config) => {
     [TASK_NAME]: value => {
       if (!value || typeof value !== "object") return;
 
-      steps.push(value);
+      appendToFixtureFile("task", value);
+      cypressReporter.addStep(value);
 
       return true;
     },
@@ -130,6 +105,10 @@ export function getMetadataFilePath(workerIndex = 0) {
     process.env.RECORD_REPLAY_METADATA_FILE ||
     path.join(getDirectory(), `CYPRESS_METADATA_${workerIndex}`)
   );
+}
+
+export function getCypressReporter() {
+  return cypressReporter;
 }
 
 export default plugin;

--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -1,0 +1,63 @@
+/// <reference types="cypress" />
+
+import type { Test } from "@replayio/test-utils";
+import type { StepEvent } from "./support";
+import { groupStepsByTest } from "./steps";
+
+class CypressReporter {
+  startTime: number | undefined;
+  steps: StepEvent[] = [];
+  selectedBrowser: "chromium" | "firefox" | undefined;
+
+  setStartTime(startTime: number) {
+    this.startTime = startTime;
+  }
+
+  setSelectedBrowser(browser: "chromium" | "firefox") {
+    this.selectedBrowser = browser;
+  }
+
+  addStep(step: StepEvent) {
+    this.steps.push(step);
+  }
+
+  getTestResults(spec: Cypress.Spec, result: CypressCommandLine.RunResult) {
+    let testsWithSteps: Test[] = [];
+    try {
+      testsWithSteps = groupStepsByTest(this.steps, this.startTime!);
+    } catch (e) {
+      console.warn("Failed to build test step metadata for this replay.");
+      console.warn(e);
+    }
+
+    const tests = result.tests.map<Test>(t => {
+      const foundTest = testsWithSteps.find(ts => ts.title === t.title[t.title.length - 1]) || null;
+
+      const error = t.displayError
+        ? {
+            // typically, we won't use this because we'll have a step error that
+            // originated the message but keeping as a fallback
+            message: t.displayError.substring(0, t.displayError.indexOf("\n")),
+          }
+        : undefined;
+
+      return {
+        title: t.title[t.title.length - 1] || spec.relative,
+        // If we found the test from the steps array (we should), merge it in
+        // and overwrite the default title and relativePath values. It won't
+        // have the correct path or result so those are added and we bubble up
+        // the first error found in a step falling back to reported test error
+        // if it exists.
+        ...foundTest,
+        relativePath: spec.relative,
+        path: ["", this.selectedBrowser || "", spec.relative, spec.specType || ""],
+        result: t.state == "failed" ? "failed" : "passed",
+        error,
+      };
+    });
+
+    return tests;
+  }
+}
+
+export default CypressReporter;

--- a/packages/cypress/tests/driver.ts
+++ b/packages/cypress/tests/driver.ts
@@ -53,6 +53,8 @@ driver(
       case "spec:start":
         events["before:spec"]?.forEach(f => {
           if (typeof f === "function") {
+            // monkey-patch the "current time" from the spec:start msg into
+            // Date.now() and restore it after the fact
             DateNow = Date.now;
             Date.now = () => value.startTime;
             f(value.spec);

--- a/packages/cypress/tests/driver.ts
+++ b/packages/cypress/tests/driver.ts
@@ -1,0 +1,84 @@
+import * as readline from "node:readline";
+import { existsSync, createReadStream } from "fs";
+import path from "node:path";
+
+import plugin, { getCypressReporter } from "../src/index";
+import { TASK_NAME } from "../src/constants";
+
+async function driver(
+  callback: (type: string, value: any) => void,
+  {
+    file = path.resolve(__dirname, "./fixtures/fixture.log"),
+    delay = 100,
+  }: { file?: string; delay?: number } = {}
+) {
+  if (existsSync(file)) {
+    const f = createReadStream(file);
+    const rl = readline.createInterface({
+      input: f,
+      crlfDelay: Infinity,
+    });
+
+    for await (const line of rl) {
+      try {
+        const json = JSON.parse(line);
+        callback(json.type, json.value);
+      } catch (e) {
+        console.error("Error parsing JSON");
+        console.error(e);
+      }
+
+      if (delay) {
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
+  } else {
+    console.error(`${file} does not exist`);
+    process.exit(1);
+  }
+}
+
+type EmitterCallback = ((...args: any[]) => void) | Record<string, (value: any) => any>;
+const events: Record<string, EmitterCallback[]> = {};
+const emitter = (name: string, cb: EmitterCallback) => {
+  events[name] = events[name] || [];
+  events[name].push(cb);
+};
+
+plugin(emitter as any, { version: "0.0.0", browsers: [] } as any);
+driver(
+  (type, value) => {
+    let DateNow: any = undefined;
+    switch (type) {
+      case "spec:start":
+        events["before:spec"]?.forEach(f => {
+          if (typeof f === "function") {
+            DateNow = Date.now;
+            Date.now = () => value.startTime;
+            f(value.spec);
+            Date.now = DateNow;
+          }
+        });
+        break;
+      case "spec:end":
+        events["after:spec"]?.forEach(f => {
+          if (typeof f === "function") {
+            f(value.spec, value.result);
+          }
+        });
+        break;
+      case "task":
+        events[type]?.forEach(f => {
+          if (typeof f === "function") {
+            f("task", value);
+          } else {
+            f[TASK_NAME]?.(value);
+          }
+        });
+        break;
+    }
+  },
+  { delay: 0 }
+).then(() => {
+  console.log("done");
+});

--- a/packages/cypress/tests/driver.ts
+++ b/packages/cypress/tests/driver.ts
@@ -52,21 +52,20 @@ driver(
     switch (type) {
       case "spec:start":
         events["before:spec"]?.forEach(f => {
-          if (typeof f === "function") {
-            // monkey-patch the "current time" from the spec:start msg into
-            // Date.now() and restore it after the fact
-            DateNow = Date.now;
-            Date.now = () => value.startTime;
-            f(value.spec);
-            Date.now = DateNow;
-          }
+          if (typeof f !== "function") return;
+
+          // monkey-patch the "current time" from the spec:start msg into
+          // Date.now() and restore it after the fact
+          DateNow = Date.now;
+          Date.now = () => value.startTime;
+          f(value.spec);
+          Date.now = DateNow;
         });
         break;
       case "spec:end":
         events["after:spec"]?.forEach(f => {
-          if (typeof f === "function") {
-            f(value.spec, value.result);
-          }
+          if (typeof f !== "function") return;
+          f(value.spec, value.result);
         });
         break;
       case "task":


### PR DESCRIPTION
Start at a test harness that can capture the events sent from the cypress runner to the plugin and then re-run those events through the plugin to test it.