### PR TITLE
Fix if:exists script for windows

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -4,7 +4,7 @@
   "description": "Plugin to record your Cypress tests with Replay",
   "main": "src/index.js",
   "scripts": {
-    "if:exists": "node -e 'require(\"fs\").existsSync(process.argv[1]) ? require(\"child_process\").spawnSync(process.argv[2], process.argv.slice(3), {stdio: \"inherit\"}) : 0'",
+    "if:exists": "node -e \"require('fs').existsSync(process.argv[1]) ? require('child_process').spawnSync(process.argv[2], process.argv.slice(3), {shell: true, stdio: 'inherit'}) : 0\"",
     "if:dist": "npm run if:exists -- src/index.js",
     "if:source": "npm run if:exists -- src/index.ts",
     "prepare": "npm run if:source -- npm run build",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -4,7 +4,7 @@
   "description": "Configuration utilities for using capturing metadata from Jest for Replay browsers",
   "main": "src/index.js",
   "scripts": {
-    "if:exists": "node -e 'require(\"fs\").existsSync(process.argv[1]) ? require(\"child_process\").spawnSync(process.argv[2], process.argv.slice(3), {stdio: \"inherit\"}) : 0'",
+    "if:exists": "node -e \"require('fs').existsSync(process.argv[1]) ? require('child_process').spawnSync(process.argv[2], process.argv.slice(3), {shell: true, stdio: 'inherit'}) : 0\"",
     "if:source": "npm run if:exists -- src/index.ts",
     "prepare": "npm run if:source -- npm run build",
     "build": "rm -rf dist/ && tsc && cp package.json README.md dist/",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -4,7 +4,7 @@
   "description": "Configuration utilities for using the Replay browsers with playwright",
   "main": "src/index.js",
   "scripts": {
-    "if:exists": "node -e 'require(\"fs\").existsSync(process.argv[1]) ? require(\"child_process\").spawnSync(process.argv[2], process.argv.slice(3), {stdio: \"inherit\"}) : 0'",
+    "if:exists": "node -e \"require('fs').existsSync(process.argv[1]) ? require('child_process').spawnSync(process.argv[2], process.argv.slice(3), {shell: true, stdio: 'inherit'}) : 0\"",
     "if:source": "npm run if:exists -- src/index.ts",
     "if:dist": "npm run if:exists -- src/index.js",
     "prepare": "npm run if:source -- npm run build",

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -4,7 +4,7 @@
   "description": "Configuration utilities for using the Replay browsers with puppeteer",
   "main": "src/index.js",
   "scripts": {
-    "if:exists": "node -e 'require(\"fs\").existsSync(process.argv[1]) ? require(\"child_process\").spawnSync(process.argv[2], process.argv.slice(3), {stdio: \"inherit\"}) : 0'",
+    "if:exists": "node -e \"require('fs').existsSync(process.argv[1]) ? require('child_process').spawnSync(process.argv[2], process.argv.slice(3), {shell: true, stdio: 'inherit'}) : 0\"",
     "if:source": "npm run if:exists -- src/index.ts",
     "if:dist": "npm run if:exists -- src/index.js",
     "prepare": "npm run if:source -- npm run build",

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -7,7 +7,7 @@
   },
   "main": "src/main.js",
   "scripts": {
-    "if:exists": "node -e 'require(\"fs\").existsSync(process.argv[1]) ? require(\"child_process\").spawnSync(process.argv[2], process.argv.slice(3), {stdio: \"inherit\"}) : 0'",
+    "if:exists": "node -e \"require('fs').existsSync(process.argv[1]) ? require('child_process').spawnSync(process.argv[2], process.argv.slice(3), {shell: true, stdio: 'inherit'}) : 0\"",
     "if:dist": "npm run if:exists -- src/main.js",
     "prepare": "npm run if:dist -- npm run build",
     "build": "rm -rf dist/ && tsc && chmod 755 dist/bin/* && cp package.json README.md dist/",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -4,7 +4,7 @@
   "description": "Utilities for recording tests with replay.io",
   "main": "src/index.js",
   "scripts": {
-    "if:exists": "node -e 'require(\"fs\").existsSync(process.argv[1]) ? require(\"child_process\").spawnSync(process.argv[2], process.argv.slice(3), {stdio: \"inherit\"}) : 0'",
+    "if:exists": "node -e \"require('fs').existsSync(process.argv[1]) ? require('child_process').spawnSync(process.argv[2], process.argv.slice(3), {shell: true, stdio: 'inherit'}) : 0\"",
     "if:source": "npm run if:exists -- src/index.ts",
     "prepare": "npm run if:source -- npm run build",
     "build": "rm -rf dist/ && tsc && cp package.json README.md dist/",


### PR DESCRIPTION
* Fixes quoting for windows
* Adds `shell: true` parameter to spawn so windows can find `npm` (instead of using `npm.cmd` for windows)