### PR TITLE
Add plugin version to test runner metadata

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -9,10 +9,16 @@ import { TASK_NAME } from "./constants";
 import type { StepEvent } from "./support";
 import { groupStepsByTest } from "./steps";
 
+const pluginVersion = require("../package.json").version;
+
 const plugin: Cypress.PluginConfig = (on, config) => {
   let steps: StepEvent[] = [];
 
-  const reporter = new ReplayReporter({ name: "cypress", version: config.version });
+  const reporter = new ReplayReporter({
+    name: "cypress",
+    version: config.version,
+    plugin: pluginVersion,
+  });
   let selectedBrowser: "chromium" | "firefox";
   let startTime: number | undefined;
 

--- a/packages/jest/src/runner.ts
+++ b/packages/jest/src/runner.ts
@@ -8,6 +8,7 @@ import path from "path";
 import { getMetadataFilePath } from ".";
 
 const runner = require("jest-circus/runner");
+const pluginVersion = require("../package.json").version;
 
 let version: string | undefined;
 
@@ -36,7 +37,7 @@ const ReplayRunner = async (
   }
 
   const relativePath = path.relative(config.cwd, testPath);
-  const reporter = new ReplayReporter({ name: "jest", version });
+  const reporter = new ReplayReporter({ name: "jest", version, plugin: pluginVersion });
   reporter.onTestSuiteBegin(undefined, "JEST_REPLAY_METADATA");
 
   function getTestId(test: Circus.TestEntry) {

--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -17,6 +17,8 @@ import {
 import { getMetadataFilePath } from "./index";
 import { readFileSync } from "fs";
 
+const pluginVersion = require("../package.json").version;
+
 function extractErrorMessage(errorStep?: TestStep) {
   const errorMessageLines = removeAnsiCodes(errorStep?.error?.message)?.split("\n");
   let stackStart = errorMessageLines?.findIndex(l => l.startsWith("Call log:"));
@@ -84,7 +86,11 @@ class ReplayPlaywrightReporter implements Reporter {
 
   onBegin(config: FullConfig) {
     const cfg = this.parseConfig(config);
-    this.reporter = new ReplayReporter({ name: "playwright", version: config.version });
+    this.reporter = new ReplayReporter({
+      name: "playwright",
+      version: config.version,
+      plugin: pluginVersion,
+    });
     this.reporter.onTestSuiteBegin(cfg, "PLAYWRIGHT_REPLAY_METADATA");
 
     if (cfg.captureTestFile === false) {

--- a/packages/replay/metadata/test.ts
+++ b/packages/replay/metadata/test.ts
@@ -53,6 +53,7 @@ const versions: Record<number, Struct<any, any>> = {
         object({
           name: optional(envString("RECORD_REPLAY_METADATA_TEST_RUNNER_NAME")),
           version: optional(envString("RECORD_REPLAY_METADATA_TEST_RUNNER_VERSION")),
+          plugin: optional(envString("RECORD_REPLAY_METADATA_TEST_RUNNER_PLUGIN")),
         }),
         {}
       )

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -46,6 +46,7 @@ export interface Test {
 export interface TestRunner {
   name?: string;
   version?: string;
+  plugin?: string;
 }
 
 export function getMetadataFilePath(workerIndex = 0) {


### PR DESCRIPTION
Adds `plugin` key to `test.runner` metadata to help troubleshooting plugin issues with replays.