### PR TITLE
Use invocation stack as a fallback to id a cypress step

### DIFF
--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -99,6 +99,8 @@ const getCurrentTestHook = (): TestStep["hook"] => {
 };
 
 function getCypressId(cmd: Cypress.CommandQueue): string {
+  // Cypress 8 doesn't include an `id` on the command so we fall back to
+  // userInvocationStack as a means to uniquely identify a command
   return cmd.get("id") || cmd.get("userInvocationStack");
 }
 


### PR DESCRIPTION
Cypress 8 doesn't include an `id` on commands we were inadvertently associating the all annotations to `id: 1` causing some weird behaviors.

The `userInvocationStack` seems to give us a reasonable fallback for v8.