### PR TITLE
Do not fail upload when metadata upload fails

### DIFF
--- a/packages/replay/src/client.ts
+++ b/packages/replay/src/client.ts
@@ -72,6 +72,9 @@ class ProtocolClient {
         if (!err && data) {
           this.socket.send(data, callback);
         } else {
+          if (err) {
+            debug("Received socket error: %s", err);
+          }
           callback?.(err);
         }
       }

--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -375,7 +375,12 @@ async function doUploadRecording(
   const recordingId = await client.connectionCreateRecording(recording.id, recording.buildId!);
   debug(`Created remote recording ${recordingId}`);
   if (metadata) {
-    await client.setRecordingMetadata(recordingId, metadata);
+    try {
+      await client.setRecordingMetadata(recordingId, metadata);
+    } catch (e) {
+      console.warn("Failed to set recording metadata");
+      console.warn(e);
+    }
   }
 
   addRecordingEvent(dir, "uploadStarted", recording.id, {


### PR DESCRIPTION
Sometimes setting metadata fails (usually because of size limits) but this shouldn't fail the upload.