### PR TITLE
Handle failures to extract browser archive on install

### DIFF
--- a/packages/cypress/bin/replayio-cypress.ts
+++ b/packages/cypress/bin/replayio-cypress.ts
@@ -4,9 +4,11 @@ import install from "../src/install";
 
 let [, , cmd, ...args] = process.argv;
 
+let firstRun = false;
 if (cmd === "first-run" && process.env.CYPRESS_INSTALL_BINARY !== "0") {
   args = [];
   cmd = "install";
+  firstRun = true;
 }
 
 function commandInstall() {
@@ -31,12 +33,21 @@ Available commands:
   `);
 }
 
-switch (cmd) {
-  case "install":
-    commandInstall();
-    break;
-  case "help":
-  default:
-    help();
-    break;
+try {
+  switch (cmd) {
+    case "install":
+      commandInstall();
+      break;
+    case "help":
+    default:
+      help();
+      break;
+  }
+} catch (e) {
+  if (firstRun) {
+    // Log install errors during first-run but don't fail package install
+    console.error(e);
+  } else {
+    throw e;
+  }
 }

--- a/packages/playwright/bin/replayio-playwright.ts
+++ b/packages/playwright/bin/replayio-playwright.ts
@@ -4,9 +4,11 @@ import install from "../src/install";
 
 let [, , cmd, ...args] = process.argv;
 
+let firstRun = false;
 if (cmd === "first-run" && !process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD) {
   args = [];
   cmd = "install";
+  firstRun = true;
 }
 
 function commandInstall() {
@@ -31,12 +33,21 @@ Available commands:
   `);
 }
 
-switch (cmd) {
-  case "install":
-    commandInstall();
-    break;
-  case "help":
-  default:
-    help();
-    break;
+try {
+  switch (cmd) {
+    case "install":
+      commandInstall();
+      break;
+    case "help":
+    default:
+      help();
+      break;
+  }
+} catch (e) {
+  if (firstRun) {
+    // Log install errors during first-run but don't fail package install
+    console.error(e);
+  } else {
+    throw e;
+  }
 }

--- a/packages/replay/src/install.ts
+++ b/packages/replay/src/install.ts
@@ -188,6 +188,19 @@ function getPuppeteerBrowserPath(kind: BrowserName) {
   return getExecutablePath("puppeteer", kind);
 }
 
+function extractBrowserArchive(browserDir: string, name: string) {
+  const fullName = path.join(browserDir, name);
+  const tarResult = spawnSync("tar", ["xf", name], { cwd: browserDir });
+  if (tarResult.status !== 0) {
+    console.error("Failed to extract", fullName);
+    console.error(String(tarResult.stderr));
+
+    throw new Error("Unable to extract browser archive");
+  }
+
+  fs.unlinkSync(fullName);
+}
+
 // Installs a browser if it isn't already installed.
 async function installReplayBrowser(
   name: string,
@@ -216,8 +229,7 @@ async function installReplayBrowser(
 
   maybeLog(opts.verbose, `Saving ${dstName} to ${browserDir}`);
   fs.writeFileSync(path.join(browserDir, name), contents);
-  spawnSync("tar", ["xf", name], { cwd: browserDir });
-  fs.unlinkSync(path.join(browserDir, name));
+  extractBrowserArchive(browserDir, name);
 
   if (srcName != dstName) {
     fs.renameSync(path.join(browserDir, srcName), path.join(browserDir, dstName));


### PR DESCRIPTION
If `tar` fails (e.g. if xz-utils is missing on the platform), we don't report that error and instead fail on the next step (for chromium installs) on rename because the source file doesn't exist.

Instead, let's catch that non-zero return from `spawnSync`, report the error, and throw. Cypress and Playwright packages should catch this error so npm installs don't fail due to browser installs.