### PR TITLE
Remove cypress no browser flag

### DIFF
--- a/packages/cypress/bin/replayio-cypress.ts
+++ b/packages/cypress/bin/replayio-cypress.ts
@@ -4,7 +4,7 @@ import install from "../src/install";
 
 let [, , cmd, ...args] = process.argv;
 
-if (cmd === "first-run" && process.env.CYPRESS_INSTALL_BINARY !== "0") {
+if (cmd === "first-run" && !process.env.REPLAY_SKIP_BROWSER_DOWNLOAD) {
   args = [];
   cmd = "install";
 }

--- a/packages/playwright/bin/replayio-playwright.ts
+++ b/packages/playwright/bin/replayio-playwright.ts
@@ -4,7 +4,11 @@ import install from "../src/install";
 
 let [, , cmd, ...args] = process.argv;
 
-if (cmd === "first-run" && !process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD) {
+if (
+  cmd === "first-run" &&
+  !process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD &&
+  !process.env.REPLAY_SKIP_BROWSER_DOWNLOAD
+) {
   args = [];
   cmd = "install";
 }


### PR DESCRIPTION
I added support for `CYPRESS_INSTALL_BINARY` as a proxy for a way to suppress browser downloading for Cypress but it's unexpected for users.

Instead, I've removed that and added `REPLAY_SKIP_BROWSER_DOWNLOAD` (which mirrors `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`) for both cypress and playwright.