### PR TITLE
Fix handling multiple end events for cypress asserts

### DIFF
--- a/packages/cypress/src/steps.ts
+++ b/packages/cypress/src/steps.ts
@@ -158,9 +158,8 @@ function groupStepsByTest(steps: StepEvent[], firstTimestamp: number): Test[] {
           relativeEndTime - currentTestStep.relativeStartTime!
         );
 
-        if (step.error) {
-          currentTestStep.error = step.error;
-        }
+        // Always set the error so that a successful retry will clear a previous error
+        currentTestStep.error = step.error;
         break;
       case "test:end":
         currentTest.duration =


### PR DESCRIPTION
* Get the correct ref to `failedCommandLog` since it may not be the first log
* Always set the error on the step so if a retry succeeds, the `error` member on the step will be cleared