### PR TITLE
Add describe/context path to cypress metadata

### DIFF
--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -64,7 +64,7 @@ class CypressReporter {
         // if it exists.
         ...foundTest,
         relativePath: spec.relative,
-        path: ["", this.selectedBrowser || "", spec.relative, spec.specType || ""],
+        path: ["", this.selectedBrowser || "", spec.relative, ...(foundTest?.path || [])],
         result: t.state == "failed" ? "failed" : "passed",
         error,
       };

--- a/packages/cypress/src/steps.ts
+++ b/packages/cypress/src/steps.ts
@@ -62,7 +62,7 @@ function groupStepsByTest(steps: StepEvent[], firstTimestamp: number): Test[] {
     .filter(a => a.event === "test:start")
     .map(step => ({
       title: step.test[step.test.length - 1] || step.file,
-      path: [],
+      path: step.test,
       result: "passed",
       relativePath: step.file,
       relativeStartTime: toRelativeTime(step.timestamp, firstTimestamp),


### PR DESCRIPTION
Adds cypress describe and context values to test path metadata so we can show it in the UI