### PR TITLE
Remove objects from cypress args

### DIFF
--- a/packages/cypress/src/steps.ts
+++ b/packages/cypress/src/steps.ts
@@ -113,11 +113,15 @@ function groupStepsByTest(steps: StepEvent[], firstTimestamp: number): Test[] {
           activeGroup = { groupId: step.command.groupId, parentId: step.command.id };
         }
 
+        // Simplify args to avoid sending large objects in metadata that we
+        // won't render in the UI anyway
+        const args = step.command!.args.map(a => (a && typeof a === "object" ? {} : a));
+
         const testStep = {
           id: step.command!.id,
           parentId,
           name: step.command!.name,
-          args: step.command!.args,
+          args: args,
           relativeStartTime:
             toRelativeTime(step.timestamp, firstTimestamp) - currentTest.relativeStartTime!,
           category: step.category || "other",


### PR DESCRIPTION
Some cypress commands can include large objects as args which we won't display in the UI and will exceed the metadata size limits so we'll suppress them for now.