### PR TITLE
Fix metadata cli command to continue when --warn is set

### DIFF
--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -643,13 +643,13 @@ async function updateMetadata({
       md = JSON.parse(metadata);
     }
 
-    const keyedObjects = await pMap<string, Record<string, any> | null>(keys, v => {
+    const keyedObjects = await pMap<string, Record<string, any> | null>(keys, async v => {
       try {
         switch (v) {
           case "source":
-            return sourceMetadata.init(md.source || {});
+            return await sourceMetadata.init(md.source || {});
           case "test":
-            return testMetadata.init(md.test || {});
+            return await testMetadata.init(md.test || {});
         }
       } catch (e) {
         if (!warn) {


### PR DESCRIPTION
We changed the souce metadata initializer to return a promise so it could inflate metadata from GH but did not await that promise in the CLI command. So when the init() threw, it skipped over the try/catch in the mapper and was caught in the outer try/catch which aborted the command altogether