### PR TITLE
Fix log reference for failed commands

### DIFF
--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -257,14 +257,10 @@ export default function register() {
 
       const failedCommand: Cypress.CommandQueue = nextAssertion?.get("prev");
       if (error && failedCommand) {
-        const failedCommandLog = failedCommand
-          .get("logs")
-          ?.find((l: any) => l.get("id") === changedLog.id);
-
         // if an assertion fails, emit step:end for the failed command
         addAnnotation(currentTest!, "step:end", {
           commandVariable: "failedCommand",
-          logVariable: failedCommandLog ? "failedCommandLog" : undefined,
+          logVariable: "changedLog",
           id: getReplayId(getCypressId(failedCommand)),
         });
         handleCypressEvent(currentTest!, "step:end", "command", toCommandJSON(failedCommand));


### PR DESCRIPTION
The type of object for the `failedCommandLog` was different than expected. Specifically, `consoleProps` existed via a getter which returned a function that returned the console props. We expect `consoleProps` to be an member on the log object and return the console props object itself which is what `changedLog` gives us so we can simplify this.