### PR TITLE
Associate cypress assertions with triggering command

### DIFF
--- a/packages/cypress/src/steps.ts
+++ b/packages/cypress/src/steps.ts
@@ -122,12 +122,15 @@ function groupStepsByTest(steps: StepEvent[], firstTimestamp: number): Test[] {
           parentId,
           name: step.command!.name,
           args: args,
+          commandId: step.command!.commandId,
           relativeStartTime:
             toRelativeTime(step.timestamp, firstTimestamp) - currentTest.relativeStartTime!,
           category: step.category || "other",
           hook: step.hook,
         };
 
+        // If this assertion has an associated commandId, find that step by
+        // command and add this command to its assertIds array
         if (step.command!.commandId) {
           const commandStep = currentTest.steps!.find(s => s.id === step.command!.commandId);
           if (commandStep) {

--- a/packages/cypress/src/steps.ts
+++ b/packages/cypress/src/steps.ts
@@ -117,7 +117,7 @@ function groupStepsByTest(steps: StepEvent[], firstTimestamp: number): Test[] {
         // won't render in the UI anyway
         const args = step.command!.args.map(a => (a && typeof a === "object" ? {} : a));
 
-        const testStep = {
+        const testStep: TestStep = {
           id: step.command!.id,
           parentId,
           name: step.command!.name,
@@ -127,6 +127,15 @@ function groupStepsByTest(steps: StepEvent[], firstTimestamp: number): Test[] {
           category: step.category || "other",
           hook: step.hook,
         };
+
+        if (step.command!.commandId) {
+          const commandStep = currentTest.steps!.find(s => s.id === step.command!.commandId);
+          if (commandStep) {
+            commandStep.assertIds = commandStep?.assertIds || [];
+            commandStep.assertIds.push(testStep.id);
+          }
+        }
+
         currentTest.steps!.push(testStep);
         stepStack.push({ event: step, step: testStep });
         break;

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -106,7 +106,6 @@ function getCypressId(cmd: Cypress.CommandQueue): string {
 }
 
 function toCommandJSON(cmd: Cypress.CommandQueue): CommandLike {
-  const next = cmd.get("next");
   return {
     name: cmd.get("name"),
     id: getReplayId(getCypressId(cmd)),
@@ -220,11 +219,15 @@ export default function register() {
       : lastCommand?.get("next");
 
     if (maybeCurrentAssertion?.get("type") !== "assertion") {
-      console.error("?????", maybeCurrentAssertion);
+      // debug("Received an assertion log without a prior assertion or command: %o", {
+      //   lastAssertionCommandId: lastAssertionCommand && getCypressId(lastAssertionCommand),
+      //   lastCommandId: lastCommand && getCypressId(lastCommand),
+      //   currentAssertion: maybeCurrentAssertion && maybeCurrentAssertion.toJSON(),
+      // });
       return;
     }
 
-    const assertionId = getReplayId(maybeCurrentAssertion.get("id"));
+    const assertionId = getReplayId(getCypressId(maybeCurrentAssertion));
 
     // store the current assertion as the last assertion so we can identify the
     // enqueued command for chained assertions
@@ -236,7 +239,7 @@ export default function register() {
       groupId: log.chainerId && getReplayId(log.chainerId),
       args: [log.consoleProps.Message],
       category: "assertion",
-      commandId: lastCommand ? getReplayId(lastCommand.get("id")) : undefined,
+      commandId: lastCommand ? getReplayId(getCypressId(lastCommand)) : undefined,
     };
     addAnnotation(currentTest!, "step:start", {
       commandVariable: "lastCommand",

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -29,6 +29,9 @@ export interface TestStep {
   duration?: number;
   hook?: "beforeEach" | "afterEach";
   category: "command" | "assertion" | "other";
+  // Links an assert to the triggering command
+  commandId?: string;
+  assertIds?: string[];
 }
 
 export interface Test {


### PR DESCRIPTION
* Adds `assertIds` and `commandId` to test step metadata to link assertions with their triggering command
* Rewires the logic to connect an assertion to a command to accommodate chained assertions (`cy.get().should(cond1).should(cond2)`)