### PR TITLE
Suppress cypress env variables for electron

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -44,7 +44,7 @@ const plugin: Cypress.PluginConfig = (on, config) => {
 
     debugEvents("Browser launching: %o", { family: browser.family, metadataPath });
 
-    if (config.version && semver.gte(config.version, "10.9.0")) {
+    if (browser.name !== "electron" && config.version && semver.gte(config.version, "10.9.0")) {
       const env = {
         RECORD_REPLAY_DRIVER:
           process.env.RECORD_REPLAY_NO_RECORD && browser.family === "chromium"


### PR DESCRIPTION
Cypress logs the warning when running with our plugin in electron so we should suppress setting the env variables when running in electron.

```
Warning: The following browser launch options were provided but are not supported by electron

 - env
 ```