### PR TITLE
Fix cypress runner retry logic

### DIFF
--- a/packages/cypress/bin/replayio-cypress.ts
+++ b/packages/cypress/bin/replayio-cypress.ts
@@ -55,12 +55,14 @@ async function commandRun() {
     process.exit(1);
   }
 
-  await cypressRepeat({
+  const failed = await cypressRepeat({
     repeat,
     mode: mode === ReplayMode.RecordOnRetry ? SpecRepeatMode.Failed : SpecRepeatMode.All,
     untilPasses: mode === ReplayMode.RecordOnRetry,
     args,
   });
+
+  process.exit(failed ? 1 : 0);
 }
 
 function help() {

--- a/packages/cypress/src/cypress-repeat.ts
+++ b/packages/cypress/src/cypress-repeat.ts
@@ -143,10 +143,14 @@ export default async function CypressRepeat({
           }
         }
       }
+
+      return 0;
     };
 
-    await cypress.run(runOptions).then(onTestResults);
+    const failed = await cypress.run(runOptions).then(onTestResults);
 
     console.log("***** finished %d run(s) successfully *****", repeat);
+
+    return failed;
   }
 }

--- a/packages/cypress/src/cypress-repeat.ts
+++ b/packages/cypress/src/cypress-repeat.ts
@@ -91,66 +91,67 @@ export default async function CypressRepeat({
     const isLastRun = k === n - 1;
     console.log("***** %s %d of %d *****", name, k + 1, n);
 
-    const onTestResults = (
-      testResults: CypressCommandLine.CypressRunResult | CypressCommandLine.CypressFailedRunResult
-    ) => {
-      debug("is %d the last run? %o", k, isLastRun);
-      if (rerunFailedOnly && !isLastRun && "runs" in testResults) {
-        const failedSpecs = testResults.runs
-          .filter(run => run.stats.failures != 0)
-          .map(run => run.spec.relative)
-          .join(",");
+    const testResults:
+      | CypressCommandLine.CypressRunResult
+      | CypressCommandLine.CypressFailedRunResult = await cypress.run(runOptions);
 
-        if (failedSpecs.length) {
-          console.log("%s failed specs", name);
-          console.log(failedSpecs);
-          allRunOptions[k + 1].spec = failedSpecs;
-        } else if (untilPasses) {
-          console.log("%s there were no failed specs", name);
-          console.log("%s exiting", name);
+    debug(
+      "is %d the last run? %o",
+      k,
+      { isLastRun, rerunFailedOnly, runs: (testResults as any).runs }
+      // JSON.stringify(testResults)
+    );
+    if (rerunFailedOnly && !isLastRun && "runs" in testResults) {
+      const failedSpecs = testResults.runs
+        .filter(run => run.stats.failures != 0)
+        .map(run => run.spec.relative)
+        .join(",");
+
+      if (failedSpecs.length) {
+        console.log("%s failed specs", name);
+        console.log(failedSpecs);
+        allRunOptions[k + 1].spec = failedSpecs;
+      } else if (untilPasses) {
+        console.log("%s there were no failed specs", name);
+        console.log("%s exiting", name);
+
+        return 0;
+      }
+    }
+
+    if (testResults.status === "failed") {
+      // failed to even run Cypress tests
+      if (testResults.failures) {
+        console.error(testResults.message);
+
+        return testResults.failures;
+      }
+    }
+
+    if (testResults.status === "finished") {
+      if (untilPasses) {
+        if (!testResults.totalFailed) {
+          console.log("%s successfully passed on run %d of %d", name, k + 1, n);
 
           return 0;
         }
-      }
-
-      if (testResults.status === "failed") {
-        // failed to even run Cypress tests
-        if (testResults.failures) {
-          console.error(testResults.message);
-
-          return testResults.failures;
+        console.error("%s run %d of %d failed", name, k + 1, n);
+        if (k === n - 1) {
+          console.error("%s no more attempts left", name);
+          return testResults.totalFailed;
         }
-      }
-
-      if (testResults.status === "finished") {
-        if (untilPasses) {
-          if (!testResults.totalFailed) {
-            console.log("%s successfully passed on run %d of %d", name, k + 1, n);
-
-            return 0;
-          }
-          console.error("%s run %d of %d failed", name, k + 1, n);
-          if (k === n - 1) {
-            console.error("%s no more attempts left", name);
+      } else {
+        if (testResults.totalFailed) {
+          console.error("%s run %d of %d failed", name, k + 1, n, isLastRun);
+          if (isLastRun) {
             return testResults.totalFailed;
           }
-        } else {
-          if (testResults.totalFailed) {
-            console.error("%s run %d of %d failed", name, k + 1, n);
-            if (isLastRun) {
-              return testResults.totalFailed;
-            }
-          }
         }
       }
+    }
 
-      return 0;
-    };
-
-    const failed = await cypress.run(runOptions).then(onTestResults);
-
-    console.log("***** finished %d run(s) successfully *****", repeat);
-
-    return failed;
+    console.log("***** finished %d run(s) *****", k + 1);
   }
+
+  return 0;
 }

--- a/packages/cypress/src/mode.ts
+++ b/packages/cypress/src/mode.ts
@@ -72,6 +72,7 @@ function getReplayMode(): ReplayMode {
   switch (mode) {
     case "record-on-retry":
       return ReplayMode.RecordOnRetry;
+    case "diagnostic":
     case "diagnostics":
       return ReplayMode.Diagnostics;
     case "stress":


### PR DESCRIPTION
* Exit with a non-zero code when tests fail
* Fix retry logic which was bailing incorrectly in record-on-retry mode
* Support either `diagnostic` or `diagnostics` for mode because plurals are hard