### PR TITLE
Handle pending tests in cypress

### DIFF
--- a/packages/cypress/tests/driver.ts
+++ b/packages/cypress/tests/driver.ts
@@ -45,7 +45,7 @@ const emitter = (name: string, cb: EmitterCallback) => {
   events[name].push(cb);
 };
 
-plugin(emitter as any, { version: "0.0.0", browsers: [] } as any);
+plugin(emitter as any, { version: "0.0.0", browsers: [], env: {} } as any);
 driver(
   (type, value) => {
     let DateNow: any = undefined;


### PR DESCRIPTION
## Issue

If an entire cypress spec file was skipped (e.g. via `@cypress/skip-test`), we still made a replay (because the spec file was still loaded into the cypress runner in the browser) but we were not linking its metadata correctly.

## Resolution

* Add a new `skipped` result value for replays in which all the tests were skipped
* Generate the list of tests for step grouping from the results rather than the events because we do not receive `test:start` events when the test was skipped