### PR TITLE
Add error reporting support to test runner plugins

### DIFF
--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,6 +1,7 @@
 import ReplayReporter from "./reporter";
 
 export type { Test, TestError, TestStep, ReplayReporterConfig } from "./reporter";
+export { ReporterError } from "./reporter";
 export { pingTestMetrics } from "./metrics";
 export { removeAnsiCodes } from "./terminal";
 export { ReplayReporter };


### PR DESCRIPTION
* Refactors the test-utils reporter logic into the cypress reporter
* Adds `x-replay-errors` metadata key to capture reporter-generated errors