### PR TITLE
Sort steps with the same timestamp by event order

### DIFF
--- a/packages/cypress/src/steps.ts
+++ b/packages/cypress/src/steps.ts
@@ -30,6 +30,10 @@ function toRelativeTime(timestamp: string, startTime: number) {
   return toTime(timestamp) - startTime;
 }
 
+function toEventOrder(event: StepEvent) {
+  return ["test:start", "step:enqueue", "step:start", "step:end", "test:end"].indexOf(event.event);
+}
+
 function assertCurrentTest(
   currentTest: Test | undefined,
   step: StepEvent
@@ -92,7 +96,14 @@ function groupStepsByTest(
   }
 
   // The steps can come in out of order but are sortable by timestamp
-  const sortedSteps = [...steps].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  const sortedSteps = [...steps].sort((a, b) => {
+    const tsCompare = a.timestamp.localeCompare(b.timestamp);
+    if (tsCompare === 0) {
+      return toEventOrder(a) - toEventOrder(b);
+    }
+
+    return tsCompare;
+  });
 
   const testStartEvents = sortedSteps.filter(a => a.event === "test:start");
   const tests = resultTests.map<Test>(result => {


### PR DESCRIPTION
## Issue

We were failing to build step metadata for replays in which step events occurred at the same timestamp which caused our sorting logic to order them incorrectly (or at least inconsistently).

## Resolution

Sort by the event type (to ensure starts are sorted before ends) if the timestamp is the same

## Additional Considerations

I think this occurs for commands or assertions that run synchronously like wrapping a jquery result and then `expect`-ing on it or some custom commands that for some reason aren't wrapped in a promise.