### PR TITLE
Fix metadata for cypress replays without any tests

### DIFF
--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -92,7 +92,7 @@ class CypressReporter {
     this.steps.push(step);
   }
 
-  private getTestResults(spec: Cypress.Spec, result: CypressCommandLine.RunResult) {
+  private getTestResults(spec: Cypress.Spec, result: CypressCommandLine.RunResult): Test[] {
     if (
       // If the browser crashes, no tests are run and tests will be null
       !result.tests ||
@@ -103,7 +103,17 @@ class CypressReporter {
       this.debug(msg);
       this.reporter.addError(new ReporterError(spec.relative, msg));
 
-      return [];
+      return [
+        // return an placeholder test because cypress will still launch a
+        // browser for a file that matches the spec format but doesn't contain
+        // any tests.
+        {
+          title: spec.relative,
+          path: [spec.relative],
+          result: "unknown",
+          relativePath: spec.relative,
+        },
+      ];
     }
 
     let testsWithSteps: Test[] = [];

--- a/packages/replay/metadata/test.ts
+++ b/packages/replay/metadata/test.ts
@@ -25,7 +25,7 @@ const versions: Record<number, Struct<any, any>> = {
     title: envString("RECORD_REPLAY_METADATA_TEST_TITLE"),
     path: optional(array(string())),
     result: defaulted(
-      enums(["passed", "failed", "timedOut"]),
+      enums(["passed", "failed", "timedOut", "skipped", "unknown"]),
       firstEnvValueOf("RECORD_REPLAY_METADATA_TEST_RESULT")
     ),
     tests: optional(

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -199,12 +199,18 @@ class ReplayReporter {
     debug("onTestEnd: Found %d recs with filter %s", recs.length, filter);
 
     const test = tests[0];
-    const results = tests.map(t => t.result);
-    const result = results.includes("failed")
-      ? "failed"
-      : results.includes("timedOut")
-      ? "timedOut"
-      : "passed";
+    const results = tests.reduce<Test["result"][]>(
+      (acc, t) => (acc.includes(t.result) ? acc : [...acc, t.result]),
+      []
+    );
+    const result =
+      results.length === 1
+        ? results[0]
+        : results.includes("failed")
+        ? "failed"
+        : results.includes("timedOut")
+        ? "timedOut"
+        : "passed";
 
     let recordingId: string | undefined;
     let runtime: string | undefined;


### PR DESCRIPTION
* Returns a "placeholder" test for cypress spec files that do not include any tests (e.g. when accidentally including a utils file) so test-utils can link up the empty replay with the empty test and 
* Adds `skipped` and `unknown` to the supported metadata values for test result
* Reworks the logic to determine the test result to choose `skipped` or `unknown` if all the tests have that value