### PR TITLE
Add count option to cypress runner for stress mode

### DIFF
--- a/packages/cypress/bin/replayio-cypress.ts
+++ b/packages/cypress/bin/replayio-cypress.ts
@@ -23,21 +23,40 @@ function commandInstall() {
   });
 }
 
+function parseRetryCount(arg: string | undefined) {
+  const num = arg ? Number.parseInt(arg) : NaN;
+  if (isNaN(num)) {
+    throw new Error("Error: --count must be a number");
+  }
+
+  return num;
+}
+
 async function commandRun() {
   let modeOpt: string | undefined;
   let levelOpt: string | undefined;
+  let retryCount: number | undefined;
 
   // TODO [ryanjduffy]: Migrate to commander
   while (args.length) {
     switch (args[0]) {
+      case "-m":
       case "--mode":
         args.shift();
         modeOpt = args.shift();
 
         continue;
+      case "-l":
       case "--level":
         args.shift();
         levelOpt = args.shift();
+
+        continue;
+
+      case "-c":
+      case "--count":
+        args.shift();
+        retryCount = parseRetryCount(args.shift());
 
         continue;
     }
@@ -45,7 +64,7 @@ async function commandRun() {
     break;
   }
 
-  const { repeat, mode } = configure({ mode: modeOpt, level: levelOpt });
+  const { repeat, mode } = configure({ mode: modeOpt, level: levelOpt, stressCount: retryCount });
 
   if (
     (mode === ReplayMode.Diagnostics || mode === ReplayMode.RecordOnRetry) &&

--- a/packages/cypress/src/mode.ts
+++ b/packages/cypress/src/mode.ts
@@ -54,7 +54,7 @@ export enum DiagnosticLevel {
   Full,
 }
 
-export function configure(options: { mode?: string; level?: string }) {
+export function configure(options: { mode?: string; level?: string; stressCount?: number }) {
   // Set this modes into the environment so they can be picked up by the plugin
   process.env.REPLAY_CYPRESS_MODE = options.mode;
   process.env.REPLAY_CYPRESS_DIAGNOSTIC_LEVEL = options.level;
@@ -62,7 +62,7 @@ export function configure(options: { mode?: string; level?: string }) {
   return {
     mode: getReplayMode(),
     level: getDiagnosticLevel(),
-    repeat: getRepeatCount(),
+    repeat: getRepeatCount(options.stressCount),
   };
 }
 
@@ -96,7 +96,7 @@ function getDiagnosticLevel(): DiagnosticLevel {
   return mode === ReplayMode.Diagnostics ? DiagnosticLevel.Basic : DiagnosticLevel.None;
 }
 
-function getRepeatCount() {
+function getRepeatCount(stressCount = 10) {
   const level = getDiagnosticLevel();
 
   switch (getReplayMode()) {
@@ -105,7 +105,7 @@ function getRepeatCount() {
     case ReplayMode.Diagnostics:
       return level === DiagnosticLevel.Basic ? 3 : diagnosticFlags.length + 3;
     case ReplayMode.Stress:
-      return 10;
+      return stressCount;
     case ReplayMode.Record:
       return 1;
   }


### PR DESCRIPTION
Enables configuring how many times to run for `npx @replayio/cypress run --mode stress`