### PR TITLE
Add test run mode to metadata

### DIFF
--- a/packages/cypress/src/mode.ts
+++ b/packages/cypress/src/mode.ts
@@ -1,4 +1,5 @@
 import dbg from "debug";
+import { v4 } from "uuid";
 
 const debug = dbg("replay:cypress:mode");
 
@@ -58,6 +59,12 @@ export function configure(options: { mode?: string; level?: string; stressCount?
   // Set this modes into the environment so they can be picked up by the plugin
   process.env.REPLAY_CYPRESS_MODE = options.mode;
   process.env.REPLAY_CYPRESS_DIAGNOSTIC_LEVEL = options.level;
+
+  // configure shared metadata values
+  process.env.RECORD_REPLAY_METADATA_TEST_RUN_MODE = options.mode;
+  // set a test run id so all the replays share a run when running in retry modes
+  process.env.RECORD_REPLAY_METADATA_TEST_RUN_ID =
+    process.env.RECORD_REPLAY_METADATA_TEST_RUN_ID || v4();
 
   return {
     mode: getReplayMode(),

--- a/packages/cypress/src/mode.ts
+++ b/packages/cypress/src/mode.ts
@@ -60,17 +60,32 @@ export function configure(options: { mode?: string; level?: string; stressCount?
   process.env.REPLAY_CYPRESS_MODE = options.mode;
   process.env.REPLAY_CYPRESS_DIAGNOSTIC_LEVEL = options.level;
 
-  // configure shared metadata values
-  process.env.RECORD_REPLAY_METADATA_TEST_RUN_MODE = options.mode;
-  // set a test run id so all the replays share a run when running in retry modes
-  process.env.RECORD_REPLAY_METADATA_TEST_RUN_ID =
-    process.env.RECORD_REPLAY_METADATA_TEST_RUN_ID || v4();
-
-  return {
+  const config = {
     mode: getReplayMode(),
     level: getDiagnosticLevel(),
     repeat: getRepeatCount(options.stressCount),
   };
+
+  // configure shared metadata values
+  process.env.RECORD_REPLAY_METADATA_TEST_RUN_MODE = toModeString(config.mode);
+  // set a test run id so all the replays share a run when running in retry modes
+  process.env.RECORD_REPLAY_METADATA_TEST_RUN_ID =
+    process.env.RECORD_REPLAY_METADATA_TEST_RUN_ID || v4();
+
+  return config;
+}
+
+function toModeString(mode: ReplayMode) {
+  switch (mode) {
+    case ReplayMode.Record:
+      return "record";
+    case ReplayMode.RecordOnRetry:
+      return "record-on-retry";
+    case ReplayMode.Diagnostics:
+      return "diagnostics";
+    case ReplayMode.Stress:
+      return "stress";
+  }
 }
 
 function getReplayMode(): ReplayMode {
@@ -81,11 +96,13 @@ function getReplayMode(): ReplayMode {
       return ReplayMode.RecordOnRetry;
     case "diagnostic":
     case "diagnostics":
+      process.env.REPLAY_CYPRESS_MODE = "diagnostics";
       return ReplayMode.Diagnostics;
     case "stress":
       return ReplayMode.Stress;
   }
 
+  process.env.REPLAY_CYPRESS_MODE = "record";
   return ReplayMode.Record;
 }
 

--- a/packages/replay/metadata/test.ts
+++ b/packages/replay/metadata/test.ts
@@ -68,6 +68,7 @@ const versions: Record<number, Struct<any, any>> = {
             firstEnvValueOf("RECORD_REPLAY_METADATA_TEST_RUN_ID", "RECORD_REPLAY_TEST_RUN_ID")
           ),
           title: optional(envString("RECORD_REPLAY_METADATA_TEST_RUN_TITLE")),
+          mode: optional(envString("RECORD_REPLAY_METADATA_TEST_RUN_MODE")),
         }),
         {}
       )


### PR DESCRIPTION
* Adds `mode` to test run metadata
* Sets the test run id (when unset) when running `npx @replayio/cypress run` so all replays across cypress invocations share a test run
* Sets the mode used by `@replayio/cypress run` in the test run metadata