### PR TITLE
Exit with zero when successfully not uploading anything

### DIFF
--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -479,7 +479,7 @@ async function uploadAllRecordings(opts: Options & UploadOptions = {}) {
       maybeLog(opts.verbose, `No replays were found to upload`);
     }
 
-    return;
+    return true;
   }
 
   maybeLog(opts.verbose, `Starting upload of ${recordings.length} replays`);


### PR DESCRIPTION
We were returning `undefined` when there were no recordings to upload (either because none existed or none matched the filter). This isn't an error case since no uploads failed so we should exit with a zero exit code.