### PR TITLE
Pass through extra options to node wrapper to node process

### DIFF
--- a/packages/node/src/bin.js
+++ b/packages/node/src/bin.js
@@ -34,10 +34,6 @@ if (argv[0] == "--update") {
     console.log(Usage);
     process.exit(1);
   }
-} else if (argv[0].startsWith("--")) {
-  console.log(`Unrecognized option: ${argv[0]}`);
-  console.log(Usage);
-  process.exit(1);
 }
 
 main();


### PR DESCRIPTION
Passes through any other `--` options on to the wrapped node process rather than warning and exiting.