### PR TITLE
Cache current path for asserts instead of current test

### DIFF
--- a/packages/cypress/tests/driver.ts
+++ b/packages/cypress/tests/driver.ts
@@ -79,7 +79,7 @@ driver(
         break;
     }
   },
-  { delay: 0 }
+  { delay: 0, file: process.argv[2] }
 ).then(() => {
   console.log("done");
 });


### PR DESCRIPTION
makeEvent previously required currentTest and used that to build the current path to account for either the test path or hook path. This resulted in assertions that came in after the hook had changed to be connected to the wrong test because the path was generated for the new test rather than the one to which the assertion belonged.

Standardizing on using the path instead of the test for both the events to the plugin and the annotations means we can cache that path value when the assertion starts and avoid accidentally using a different value when the assertion ends even if the test/hook has changed.