### PR TITLE
Change protocol methods used to upload CLI recording

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "replay-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "replay-cli",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "node-fetch": "^3.3.1"

--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -374,7 +374,7 @@ async function doUploadRecording(
   const metadata = recording.metadata
     ? await client.buildRecordingMetadata(recording.metadata, { verbose })
     : null;
-  const { recordingId, uploadLink } = await client.connectionCreateRecording(
+  const { recordingId, uploadLink } = await client.connectionBeginRecordingUpload(
     recording.id,
     recording.buildId!,
     size
@@ -398,10 +398,7 @@ async function doUploadRecording(
 
   debug("%s: Uploaded %d bytes", recordingId, size);
 
-  // Explicitly mark the recording complete so the server knows that all
-  // recording data has been uploaded. This means if someone presses Ctrl+C,
-  // the server doesn't save a partial recording.
-  await client.finishRecording(recordingId);
+  await client.connectionEndRecordingUpload(recording.id);
 
   for (const sourcemap of recording.sourcemaps) {
     try {


### PR DESCRIPTION
We will now use `Internal.beginRecordingUpload` and `Internal.endRecordingUpload` to mark these events. We won't actually be doing integrity checking to see if the whole recording got properly uploaded right now, but we could add in that (or any other integrity checks) later if we wanted to.

Pairs with https://github.com/replayio/backend/pull/7623