### PR TITLE
Fetch settings and write to disk

### DIFF
--- a/packages/replay/src/bin.ts
+++ b/packages/replay/src/bin.ts
@@ -12,6 +12,7 @@ import {
   removeAllRecordings,
   updateBrowsers,
   updateMetadata,
+  updateSettings,
 } from "./main";
 import {
   CommandLineOptions,
@@ -124,6 +125,14 @@ program
   .option("--filter <filter string>", "String to filter recordings")
   .action(commandMetadata);
 
+program
+  .command("update-settings")
+  .description("Sync recording settings")
+  .option("--directory <dir>", "Alternate recording directory.")
+  .option("--server <address>", "Alternate server to upload recordings to.")
+  .option("--api-key <key>", "Authentication API Key")
+  .action(commandUpdateSettings);
+
 program.parseAsync().catch(err => {
   console.log(err);
   process.exit(1);
@@ -146,6 +155,11 @@ function commandListAllRecordings(
     console.log(formatAllRecordingsHumanReadable(recordings));
   }
   process.exit(0);
+}
+
+async function commandUpdateSettings(opts: Pick<CommandLineOptions, "directory">) {
+  const updated = await updateSettings(opts);
+  process.exit(updated ? 0 : 1);
 }
 
 async function commandUploadRecording(id: string, opts: CommandLineOptions) {

--- a/packages/replay/src/utils.ts
+++ b/packages/replay/src/utils.ts
@@ -2,6 +2,7 @@ import dbg from "debug";
 import path from "path";
 
 import { CommandLineOptions } from "./types";
+import fetch from "node-fetch";
 
 const debug = dbg("replay:cli");
 
@@ -77,6 +78,42 @@ export async function exponentialBackoffRetry<T>(
     }
   }
   throw Error("ShouldBeUnreachable");
+}
+
+export async function queryGraphQL(
+  accessToken: string | null,
+  query: string,
+  variables: Object = {}
+): Promise<any | null> {
+  const response = await fetch("https://api.replay.io/v1/graphql", {
+    method: "POST",
+    headers: {
+      ...(accessToken && {
+        Authorization: `Bearer ${accessToken}`,
+      }),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query,
+      variables,
+    }),
+  });
+  const json = await response.json();
+  return json;
+}
+
+export async function fetchGraphql(query: string, variables: Object, apiKey: string) {
+  const queryRes = await fetch("https://graphql.replay.io/v1/graphql", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-hasura-admin-secret": process.env.HASURA_ADMIN_SECRET,
+    },
+    body: JSON.stringify({
+      query,
+      variables,
+    }),
+  });
 }
 
 export { defer, maybeLog, getDirectory, isValidUUID };


### PR DESCRIPTION
This shows how the CLI could be used to fetch `recording_settings` from the workspace table. 

For this to work, we'll need to
1. add the column to the db and graphql model
2. teach chromium to read the settings file at startup

NOTE: it's possible the apiKey is for a user not a workspace so we probably need to support both use cases