### PR TITLE
Fix linking playwright metadata to replay

### DIFF
--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -91,6 +91,13 @@ class ReplayPlaywrightReporter implements Reporter {
     return cfg;
   }
 
+  getSource(test: TestCase) {
+    return {
+      title: test.title,
+      scope: test.titlePath().slice(3, -1),
+    };
+  }
+
   onBegin(config: FullConfig) {
     const cfg = this.parseConfig(config);
     this.reporter = new ReplayReporter(
@@ -109,10 +116,7 @@ class ReplayPlaywrightReporter implements Reporter {
   }
 
   onTestBegin(test: TestCase, testResult: TestResult) {
-    this.reporter?.onTestBegin(
-      { title: test.title, scope: test.titlePath() },
-      getMetadataFilePath(testResult.workerIndex)
-    );
+    this.reporter?.onTestBegin(this.getSource(test), getMetadataFilePath(testResult.workerIndex));
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
@@ -180,10 +184,7 @@ class ReplayPlaywrightReporter implements Reporter {
       tests: [
         {
           approximateDuration: test.results.reduce((acc, r) => acc + r.duration, 0),
-          source: {
-            title: test.title,
-            scope: test.titlePath().slice(3, -1),
-          },
+          source: this.getSource(test),
           result: status,
           error: errorMessage
             ? {


### PR DESCRIPTION
The test id logic was different between the start and end events after the v2 migration. This refactors the source generation into a common method used by both call sites so we ensure a consistent path