### PR TITLE
Fix counting failed retries multiple times in resultCounts

### DIFF
--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -108,7 +108,14 @@ class ReplayReporter {
       unknown: 0,
     };
 
-    tests.forEach(t => {
+    const testsById: Record<number, Test> = {};
+    tests.forEach(test => {
+      if (!testsById[test.id] || test.attempt > testsById[test.id].attempt) {
+        testsById[test.id] = test;
+      }
+    });
+
+    Object.values(testsById).forEach(t => {
       approximateDuration += t.approximateDuration || 0;
       switch (t.result) {
         case "failed":


### PR DESCRIPTION
## Issue

The `resultCounts` metadata was counting failed retries as multiple failed tests.

## Resolution

Dedupe the results by test id keeping only the last attempt before counting results.