### PR TITLE
Change the add step cy.task to pass the whole eventBuffer array

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -58,11 +58,31 @@ const plugin: Cypress.PluginConfig = (on, config) => {
       debugTask("Handling %s task: %o", TASK_NAME, value);
       if (!value || typeof value !== "object") return;
 
-      cypressReporter.addStep(value);
+      const valueAsArray = Array.isArray(value) ? value : [value];
+      valueAsArray.forEach(v => {
+        if (!value || typeof value !== "object") return;
+        cypressReporter.addStep(v);
+      })
 
       return true;
     },
   });
+  on("task", {
+    // Events are sent to the plugin by the support adapter which runs in the
+    // browser context and has access to `Cypress` and `cy` methods.
+    [constants_1.TASK_NAME]: value => {
+        debugTask("Handling %s task: %o", constants_1.TASK_NAME, value);
+        if (!value || typeof value !== "object")
+            return;
+        const valueArray = Array.isArray(value) ? value : [value];
+        valueArray.forEach(v => {
+            if (v && typeof v === 'object') {
+                cypressReporter.addStep(v);
+            }
+        })
+        return true;
+    },
+});
 
   // make sure we have a config object with the keys we need to mutate
   config = config || {};

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -6,7 +6,7 @@ import { initMetadataFile } from "@replayio/test-utils";
 import dbg from "debug";
 
 import { TASK_NAME } from "./constants";
-import CypressReporter, { getMetadataFilePath } from "./reporter";
+import CypressReporter, { getMetadataFilePath, isStepEvent } from "./reporter";
 
 const debug = dbg("replay:cypress:plugin");
 
@@ -55,17 +55,21 @@ const plugin: Cypress.PluginConfig = (on, config) => {
     // Events are sent to the plugin by the support adapter which runs in the
     // browser context and has access to `Cypress` and `cy` methods.
     [TASK_NAME]: value => {
-      debugTask("Handling %s task: %o", TASK_NAME, value);
+      debugTask("Handling %s task", TASK_NAME);
       if (!Array.isArray(value)) return;
 
       value.forEach(v => {
-        cypressReporter.addStep(v);
+        if (isStepEvent(v)) {
+          debugTask("Forwarding event to reporter: %o", v);
+          cypressReporter.addStep(v);
+        } else {
+          debugTask("Unexpected %s payload: %o", TASK_NAME, v);
+        }
       });
 
       return true;
     },
   });
-});
 
   // make sure we have a config object with the keys we need to mutate
   config = config || {};

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -56,32 +56,15 @@ const plugin: Cypress.PluginConfig = (on, config) => {
     // browser context and has access to `Cypress` and `cy` methods.
     [TASK_NAME]: value => {
       debugTask("Handling %s task: %o", TASK_NAME, value);
-      if (!value || typeof value !== "object") return;
+      if (!Array.isArray(value)) return;
 
-      const valueAsArray = Array.isArray(value) ? value : [value];
-      valueAsArray.forEach(v => {
-        if (!value || typeof value !== "object") return;
+      value.forEach(v => {
         cypressReporter.addStep(v);
-      })
+      });
 
       return true;
     },
   });
-  on("task", {
-    // Events are sent to the plugin by the support adapter which runs in the
-    // browser context and has access to `Cypress` and `cy` methods.
-    [constants_1.TASK_NAME]: value => {
-        debugTask("Handling %s task: %o", constants_1.TASK_NAME, value);
-        if (!value || typeof value !== "object")
-            return;
-        const valueArray = Array.isArray(value) ? value : [value];
-        valueArray.forEach(v => {
-            if (v && typeof v === 'object') {
-                cypressReporter.addStep(v);
-            }
-        })
-        return true;
-    },
 });
 
   // make sure we have a config object with the keys we need to mutate

--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -20,6 +20,7 @@ function isStepEvent(value: unknown): value is StepEvent {
     value &&
     typeof value === "object" &&
     "event" in value &&
+    typeof value.event === "string" &&
     ["step:enqueue", "step:start", "step:end", "test:start", "test:end"].includes(value.event)
   ) {
     return true;

--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -15,6 +15,19 @@ import type { StepEvent } from "./support";
 
 type Test = TestMetadataV2.Test;
 
+function isStepEvent(value: unknown): value is StepEvent {
+  if (
+    value &&
+    typeof value === "object" &&
+    "event" in value &&
+    ["step:enqueue", "step:start", "step:end", "test:start", "test:end"].includes(value.event)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
 class CypressReporter {
   reporter: ReplayReporter;
   config: Cypress.PluginConfigOptions;
@@ -153,3 +166,4 @@ export function getMetadataFilePath(workerIndex = 0) {
 }
 
 export default CypressReporter;
+export { isStepEvent };

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -499,9 +499,7 @@ export default function register() {
         addAnnotation(currentTestScope, "test:end");
         handleCypressEvent(currentTestScope, "test:end");
 
-        eventBuffer.forEach(arg => {
-          cy.task(TASK_NAME, arg, { log: false });
-        });
+        cy.task(TASK_NAME, eventBuffer, { log: false });
 
         eventBuffer = [];
       }


### PR DESCRIPTION
When `cy.task` is invoked for every element of `eventBuffer` we get extra overhead that causes an unresponsiveness as each event is sent.

By passing the `eventBuffer` as an array the overhead is only incurred once and performance doesn't degrade.