### PR TITLE
Fix sending test metrics after v2 metadata change

### DIFF
--- a/packages/test-utils/src/metrics.ts
+++ b/packages/test-utils/src/metrics.ts
@@ -1,5 +1,10 @@
+import dbg from "debug";
 import os from "os";
 import fetch from "node-fetch";
+import { Test } from "./reporter";
+import { TestMetadataV2 } from "@replayio/replay/metadata/test/v2";
+
+const debug = dbg("replay:test-utils:metrics");
 
 function shouldReportTestMetrics() {
   const optOut = process.env.RECORD_REPLAY_TEST_METRICS?.toLowerCase();
@@ -12,12 +17,9 @@ async function pingTestMetrics(
   runId: string,
   test: {
     id: string;
-    duration: number;
+    approximateDuration: number;
     recorded: boolean;
-    source: {
-      title: string;
-      scope: string[];
-    };
+    source: TestMetadataV2.TestRun["source"];
     runtime?: string;
     runner?: string;
     result?: string;
@@ -27,24 +29,28 @@ async function pingTestMetrics(
 
   const webhookUrl = process.env.RECORD_REPLAY_WEBHOOK_URL || "https://webhooks.replay.io";
 
+  const body = JSON.stringify({
+    type: "test.finished",
+    recordingId,
+    test: {
+      ...test,
+      platform: os.platform,
+      runId,
+      env: {
+        disableAsserts: !!process.env.RECORD_REPLAY_DISABLE_ASSERTS,
+        disableSourcemapCollection: !!process.env.RECORD_REPLAY_DISABLE_SOURCEMAP_COLLECTION,
+        disableFeatures: process.env.RECORD_REPLAY_DISABLE_FEATURES || "none",
+      },
+    },
+  });
+
+  debug(body);
+
   try {
     return await fetch(`${webhookUrl}/api/metrics`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        type: "test.finished",
-        recordingId,
-        test: {
-          ...test,
-          platform: os.platform,
-          runId,
-          env: {
-            disableAsserts: !!process.env.RECORD_REPLAY_DISABLE_ASSERTS,
-            disableSourcemapCollection: !!process.env.RECORD_REPLAY_DISABLE_SOURCEMAP_COLLECTION,
-            disableFeatures: process.env.RECORD_REPLAY_DISABLE_FEATURES || "none",
-          },
-        },
-      }),
+      body,
     });
   } catch (e) {
     console.log("Failed to send test metrics", e);

--- a/packages/test-utils/src/metrics.ts
+++ b/packages/test-utils/src/metrics.ts
@@ -14,6 +14,10 @@ async function pingTestMetrics(
     id: string;
     duration: number;
     recorded: boolean;
+    source: {
+      title: string;
+      scope: string[];
+    };
     runtime?: string;
     runner?: string;
     result?: string;

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -309,6 +309,7 @@ class ReplayReporter {
     if (startTime) {
       pingTestMetrics(recordingId, this.baseId, {
         id: testId,
+        source: test.source,
         duration: Date.now() - startTime,
         recorded: !!recordingId,
         runtime: parseRuntime(runtime),

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -73,7 +73,6 @@ class ReplayReporter {
   baseMetadata: Record<string, any> | null = null;
   schemaVersion: string;
   runTitle?: string;
-  startTimes: Record<string, number> = {};
   runner: TestRunner;
   errors: ReporterError[] = [];
 
@@ -215,7 +214,6 @@ class ReplayReporter {
   onTestBegin(source?: Test["source"], metadataFilePath = getMetadataFilePath("REPLAY_TEST", 0)) {
     const id = this.getTestId(source);
     this.errors = [];
-    this.startTimes[id] = Date.now();
     const metadata = {
       ...(this.baseMetadata || {}),
       "x-replay-test": {
@@ -260,13 +258,14 @@ class ReplayReporter {
     const test = tests[0];
     const { approximateDuration, resultCounts } = this.summarizeResults(tests);
     const result = this.getResultFromResultCounts(resultCounts);
+    const source = {
+      path: specFile,
+      title: replayTitle || test.source.title,
+    };
 
     const metadata: TestRun = {
       approximateDuration,
-      source: {
-        path: specFile,
-        title: replayTitle || test.source.title,
-      },
+      source,
       result,
       resultCounts,
       run: {
@@ -303,20 +302,15 @@ class ReplayReporter {
       );
     }
 
-    const testId = this.getTestId(test.source);
-
-    const startTime = this.startTimes[testId];
-    if (startTime) {
-      pingTestMetrics(recordingId, this.baseId, {
-        id: testId,
-        source: test.source,
-        duration: Date.now() - startTime,
-        recorded: !!recordingId,
-        runtime: parseRuntime(runtime),
-        runner: this.runner.name,
-        result: result,
-      });
-    }
+    pingTestMetrics(recordingId, this.baseId, {
+      id: source.path + "#" + source.title,
+      source,
+      approximateDuration,
+      recorded: !!recordingId,
+      runtime: parseRuntime(runtime),
+      runner: this.runner.name,
+      result: result,
+    });
   }
 }
 


### PR DESCRIPTION
## Issue

For cypress at least, we weren't sending test metrics any longer because the call was gated on finding a start time but the test id calculation wasn't valid so metrics weren't sent.

## Resolution

* Use `approximateDuration` included on the test instead of calculating it in `test-utils`
* Add `source` to the payload to aid in test identification