### PR TITLE
Add warning when support file may not have been used

### DIFF
--- a/packages/cypress/package-lock.json
+++ b/packages/cypress/package-lock.json
@@ -6,12 +6,13 @@
   "packages": {
     "": {
       "name": "@replayio/cypress",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@replayio/replay": "^0.12.12",
-        "@replayio/test-utils": "^1.0.0",
+        "@replayio/replay": "^0.12.13",
+        "@replayio/test-utils": "^1.0.2",
+        "chalk": "^4.1.2",
         "debug": "^4.3.4",
         "semver": "^7.5.2",
         "uuid": "^8.3.2"
@@ -79,9 +80,9 @@
       }
     },
     "node_modules/@replayio/replay": {
-      "version": "0.12.12",
-      "resolved": "https://registry.npmjs.org/@replayio/replay/-/replay-0.12.12.tgz",
-      "integrity": "sha512-myuviCc3l8K1P9jM5AIcZYaP+PeiAaJoYXvMQsG+T4f76j282hUPcpwg3M1y3Qrvd29ZrOG34SSw2hTb01yFbQ==",
+      "version": "0.12.13",
+      "resolved": "https://registry.npmjs.org/@replayio/replay/-/replay-0.12.13.tgz",
+      "integrity": "sha512-2Y9HwZgqEmb7i1yLyy7hzs3pRJ+jxCV68+IbrGBksxflLu+MtRG4IdsGPX1NpjwbB+cpDDFuIUiUak6U4R6qhg==",
       "dependencies": {
         "@replayio/sourcemap-upload": "^1.0.7",
         "commander": "^7.2.0",
@@ -114,11 +115,11 @@
       }
     },
     "node_modules/@replayio/test-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@replayio/test-utils/-/test-utils-1.0.0.tgz",
-      "integrity": "sha512-f+SluJJRX7dmHWyXFAXov17iC9bxEFA33XU4QFiq18S3Pd/m2zbr84ETN4g2LZJPQ8AfA68gMBjcXN9Ft5DBtA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@replayio/test-utils/-/test-utils-1.0.2.tgz",
+      "integrity": "sha512-dloSr5Ao1BFnoCUEm3UOpMofXE7qJjQhO3A5cOBkhJe8T67u5lvXkfSkFS6U+Qh7W6II5c7JjZ+UpH5JqaCDUw==",
       "dependencies": {
-        "@replayio/replay": "^0.12.12",
+        "@replayio/replay": "^0.12.13",
         "@types/node-fetch": "^2.6.2",
         "debug": "^4.3.4",
         "node-fetch": "^2.6.7",
@@ -250,7 +251,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -485,7 +485,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -501,7 +500,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -579,7 +577,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -590,8 +587,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/colorette": {
       "version": "2.0.16",
@@ -1243,7 +1239,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2712,9 +2707,9 @@
       }
     },
     "@replayio/replay": {
-      "version": "0.12.12",
-      "resolved": "https://registry.npmjs.org/@replayio/replay/-/replay-0.12.12.tgz",
-      "integrity": "sha512-myuviCc3l8K1P9jM5AIcZYaP+PeiAaJoYXvMQsG+T4f76j282hUPcpwg3M1y3Qrvd29ZrOG34SSw2hTb01yFbQ==",
+      "version": "0.12.13",
+      "resolved": "https://registry.npmjs.org/@replayio/replay/-/replay-0.12.13.tgz",
+      "integrity": "sha512-2Y9HwZgqEmb7i1yLyy7hzs3pRJ+jxCV68+IbrGBksxflLu+MtRG4IdsGPX1NpjwbB+cpDDFuIUiUak6U4R6qhg==",
       "requires": {
         "@replayio/sourcemap-upload": "^1.0.7",
         "commander": "^7.2.0",
@@ -2741,11 +2736,11 @@
       }
     },
     "@replayio/test-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@replayio/test-utils/-/test-utils-1.0.0.tgz",
-      "integrity": "sha512-f+SluJJRX7dmHWyXFAXov17iC9bxEFA33XU4QFiq18S3Pd/m2zbr84ETN4g2LZJPQ8AfA68gMBjcXN9Ft5DBtA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@replayio/test-utils/-/test-utils-1.0.2.tgz",
+      "integrity": "sha512-dloSr5Ao1BFnoCUEm3UOpMofXE7qJjQhO3A5cOBkhJe8T67u5lvXkfSkFS6U+Qh7W6II5c7JjZ+UpH5JqaCDUw==",
       "requires": {
-        "@replayio/replay": "^0.12.12",
+        "@replayio/replay": "^0.12.13",
         "@types/node-fetch": "^2.6.2",
         "debug": "^4.3.4",
         "node-fetch": "^2.6.7",
@@ -2861,7 +2856,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -3018,7 +3012,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3028,7 +3021,6 @@
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -3085,7 +3077,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -3093,8 +3084,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "colorette": {
       "version": "2.0.16",
@@ -3595,8 +3585,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-property-descriptors": {
       "version": "1.0.0",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@replayio/replay": "^0.12.13",
     "@replayio/test-utils": "^1.0.2",
+    "chalk": "^4.1.2",
     "debug": "^4.3.4",
     "semver": "^7.5.2",
     "uuid": "^8.3.2"

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -4,71 +4,128 @@ import semver from "semver";
 import { getPlaywrightBrowserPath } from "@replayio/replay";
 import { initMetadataFile } from "@replayio/test-utils";
 import dbg from "debug";
+import chalk from "chalk";
 
 import { TASK_NAME } from "./constants";
 import CypressReporter, { getMetadataFilePath, isStepEvent } from "./reporter";
 
 const debug = dbg("replay:cypress:plugin");
+const debugTask = debug.extend("task");
+const debugEvents = debug.extend("events");
 
 let cypressReporter: CypressReporter;
+let missingSteps = false;
 
-const plugin: Cypress.PluginConfig = (on, config) => {
-  cypressReporter = new CypressReporter(config, debug);
-  const debugEvents = debug.extend("events");
+function warn(...lines: string[]) {
+  const terminalWidth = process.stdout.columns || 80;
+  const packageName = "@replayio/cypress";
 
-  on("before:browser:launch", (browser, launchOptions) => {
-    debugEvents("Handling before:browser:launch");
-    cypressReporter.onLaunchBrowser(browser.family);
+  const startHeaderWidth = Math.floor((terminalWidth - packageName.length) / 2 - 1);
+  const endHeaderWidth = terminalWidth - startHeaderWidth - packageName.length - 2;
 
-    debugEvents("Browser launching: %o", { family: browser.family });
+  console.warn(
+    "\n%s %s %s\n",
+    "".padEnd(startHeaderWidth, "="),
+    chalk.magentaBright(packageName),
+    "".padEnd(endHeaderWidth, "=")
+  );
+  lines.forEach(l => console.warn(l));
+  console.warn("\n%s\n", "".padEnd(terminalWidth, "="));
+}
 
-    if (browser.name !== "electron" && config.version && semver.gte(config.version, "10.9.0")) {
-      const diagnosticConfig = cypressReporter.getDiagnosticConfig();
-      const noRecord = !!process.env.RECORD_REPLAY_NO_RECORD || diagnosticConfig.noRecord;
+function onBeforeBrowserLaunch(
+  config: Cypress.PluginConfigOptions,
+  browser: Cypress.Browser,
+  launchOptions: Cypress.BrowserLaunchOptions
+) {
+  debugEvents("Handling before:browser:launch");
+  cypressReporter.onLaunchBrowser(browser.family);
 
-      const env: NodeJS.ProcessEnv = {
-        RECORD_REPLAY_DRIVER: noRecord && browser.family === "chromium" ? __filename : undefined,
-        RECORD_ALL_CONTENT: noRecord ? undefined : "1",
-        RECORD_REPLAY_METADATA_FILE: initMetadataFile(getMetadataFilePath()),
-        ...diagnosticConfig.env,
-      };
+  debugEvents("Browser launching: %o", { family: browser.family });
 
-      debugEvents("Adding environment variables to browser: %o", env);
+  if (browser.name !== "electron" && config.version && semver.gte(config.version, "10.9.0")) {
+    const diagnosticConfig = cypressReporter.getDiagnosticConfig();
+    const noRecord = !!process.env.RECORD_REPLAY_NO_RECORD || diagnosticConfig.noRecord;
 
-      return {
-        ...launchOptions,
-        env,
-      };
+    const env: NodeJS.ProcessEnv = {
+      RECORD_REPLAY_DRIVER: noRecord && browser.family === "chromium" ? __filename : undefined,
+      RECORD_ALL_CONTENT: noRecord ? undefined : "1",
+      RECORD_REPLAY_METADATA_FILE: initMetadataFile(getMetadataFilePath()),
+      ...diagnosticConfig.env,
+    };
+
+    debugEvents("Adding environment variables to browser: %o", env);
+
+    return {
+      ...launchOptions,
+      env,
+    };
+  }
+}
+
+function onAfterRun() {
+  if (missingSteps) {
+    warn(
+      "Your tests completed but our plugin did not receive any command events.",
+      "",
+      `Did you remember to include ${chalk.magentaBright(
+        "@replayio/cypress/support"
+      )} in your support file?`
+    );
+  }
+}
+
+function onBeforeSpec(spec: Cypress.Spec) {
+  debugEvents("Handling before:spec %s", spec.relative);
+  cypressReporter.onBeforeSpec(spec);
+}
+
+function onAfterSpec(spec: Cypress.Spec, result: CypressCommandLine.RunResult) {
+  debugEvents("Handling after:spec %s", spec.relative);
+  const metadata = cypressReporter.onAfterSpec(spec, result);
+
+  if (metadata) {
+    const tests = metadata.test.tests;
+    const completedTests = tests.filter(t => ["passed", "failed", "timedOut"].includes(t.result));
+
+    if (
+      completedTests.length > 0 &&
+      tests.flatMap(t => Object.values(t.events).flat()).length === 0
+    ) {
+      missingSteps = true;
+    }
+  }
+}
+
+function onReplayTask(value: any) {
+  debugTask("Handling %s task", TASK_NAME);
+  if (!Array.isArray(value)) return;
+
+  value.forEach(v => {
+    if (isStepEvent(v)) {
+      debugTask("Forwarding event to reporter: %o", v);
+      cypressReporter.addStep(v);
+    } else {
+      debugTask("Unexpected %s payload: %o", TASK_NAME, v);
     }
   });
-  on("before:spec", spec => {
-    debugEvents("Handling before:spec %s", spec.relative);
-    cypressReporter.onBeforeSpec(spec);
-  });
-  on("after:spec", (spec, result) => {
-    debugEvents("Handling after:spec %s", spec.relative);
-    cypressReporter.onAfterSpec(spec, result);
-  });
 
-  const debugTask = debug.extend("task");
+  return true;
+}
+const plugin: Cypress.PluginConfig = (on, config) => {
+  cypressReporter = new CypressReporter(config, debug);
+
+  on("before:browser:launch", (browser, launchOptions) =>
+    onBeforeBrowserLaunch(config, browser, launchOptions)
+  );
+  on("before:spec", onBeforeSpec);
+  on("after:spec", onAfterSpec);
+  on("after:run", onAfterRun);
+
   on("task", {
     // Events are sent to the plugin by the support adapter which runs in the
     // browser context and has access to `Cypress` and `cy` methods.
-    [TASK_NAME]: value => {
-      debugTask("Handling %s task", TASK_NAME);
-      if (!Array.isArray(value)) return;
-
-      value.forEach(v => {
-        if (isStepEvent(v)) {
-          debugTask("Forwarding event to reporter: %o", v);
-          cypressReporter.addStep(v);
-        } else {
-          debugTask("Unexpected %s payload: %o", TASK_NAME, v);
-        }
-      });
-
-      return true;
-    },
+    [TASK_NAME]: onReplayTask,
   });
 
   // make sure we have a config object with the keys we need to mutate
@@ -126,4 +183,12 @@ export function getCypressReporter() {
 }
 
 export default plugin;
-export { getMetadataFilePath };
+export {
+  plugin,
+  onBeforeBrowserLaunch,
+  onBeforeSpec,
+  onAfterSpec,
+  onAfterRun,
+  getMetadataFilePath,
+  TASK_NAME as REPLAY_TASK_NAME,
+};

--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -14,6 +14,7 @@ import { getTestsFromResults, groupStepsByTest, mapStateToResult, sortSteps } fr
 import type { StepEvent } from "./support";
 
 type Test = TestMetadataV2.Test;
+type TestRun = TestMetadataV2.TestRun;
 
 function isStepEvent(value: unknown): value is StepEvent {
   if (
@@ -83,11 +84,15 @@ class CypressReporter {
     this.reporter.onTestBegin(undefined, getMetadataFilePath());
   }
 
-  onAfterSpec(spec: Cypress.Spec, result: CypressCommandLine.RunResult) {
+  onAfterSpec(
+    spec: Cypress.Spec,
+    result: CypressCommandLine.RunResult
+  ): { test: TestRun } | undefined {
     appendToFixtureFile("spec:end", { spec, result });
 
     const tests = this.getTestResults(spec, result);
-    this.reporter.onTestEnd({ tests, replayTitle: spec.relative, specFile: spec.relative });
+
+    return this.reporter.onTestEnd({ tests, replayTitle: spec.relative, specFile: spec.relative });
   }
 
   getDiagnosticConfig() {

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -287,6 +287,7 @@ class ReplayReporter {
 
     let recordingId: string | undefined;
     let runtime: string | undefined;
+    let validatedTestMetadata: { test: TestRun } | undefined;
     if (recs.length > 0) {
       recordingId = recs[0].id;
       runtime = recs[0].runtime;
@@ -294,11 +295,13 @@ class ReplayReporter {
       debug("onTestEnd: Adding test metadata to %s", recordingId);
       debug("onTestEnd: Includes %s errors", this.errors.length);
 
+      validatedTestMetadata = testMetadata.init(metadata) as { test: TestMetadataV2.TestRun };
+
       recs.forEach(rec =>
         add(rec.id, {
           title: replayTitle || test.source.title,
           ...extraMetadata,
-          ...testMetadata.init(metadata),
+          ...validatedTestMetadata,
         })
       );
     }
@@ -316,6 +319,8 @@ class ReplayReporter {
         result: result,
       });
     }
+
+    return validatedTestMetadata;
   }
 }
 


### PR DESCRIPTION
* Adds warning in `after:run` event when the support file may have been omitted by checking if tests passed/failed/timedOut for a spec but we didn't receive any steps. This can occur if you're running a spec file with an empty test but since that's rare, we're not explicitly messaging that.
* Adds exports for the cypress plugin event callbacks so they can be manually applied since Cypress doesn't support multiple listeners for every event. This was required to test with a benchmark repo which already had an `after:run` listener. This also fixes SCS-979 which requires this sort of adapter.