### PR TITLE
Fix aligning beforeEach and afterEach steps to correct events array

### DIFF
--- a/packages/cypress/src/steps.ts
+++ b/packages/cypress/src/steps.ts
@@ -193,7 +193,7 @@ function groupStepsByTest(tests: Test[], steps: StepEvent[]): Test[] {
           }
 
           assertCurrentTest(currentTest, step);
-          currentTest.events.main.push(testStep);
+          currentTest.events[step.hook || "main"].push(testStep);
           break;
         case "step:end":
           const isAssert = step.command!.name === "assert";

--- a/packages/cypress/tests/driver.ts
+++ b/packages/cypress/tests/driver.ts
@@ -73,7 +73,7 @@ driver(
           if (typeof f === "function") {
             f("task", value);
           } else {
-            f[TASK_NAME]?.(value);
+            f[TASK_NAME]?.([value]);
           }
         });
         break;


### PR DESCRIPTION
* `beforeEach` and `afterEach` events were passing straight through to `main` instead of being sorted into their array.
* Also fixes the test driver to wrap task values in an array which I discovered didn't work when trying to identify this issue

Replay with `beforeEach` and `afterEach` again
https://app.replay.io/recording/cypresse2ehooks-spects--efa9df68-52f2-4c4f-acd7-6ceeda37c5cb
<img width="422" alt="image" src="https://github.com/replayio/replay-cli/assets/788456/14edfbd5-fee5-499c-b053-2a308e825adf">
