### PR TITLE
Use null for testId of beforeAll/afterAll hook events

### DIFF
--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -16,7 +16,7 @@ export interface StepEvent {
   test: string[];
   file: string;
   timestamp: string;
-  testId: number;
+  testId: number | null;
   attempt: number;
   category?: UserActionEvent["data"]["category"];
   hook?: HookKind;
@@ -34,7 +34,7 @@ interface CommandLike {
 
 interface CypressTestScope {
   test: string[];
-  testId: number;
+  testId: number | null;
   attempt: number;
 }
 
@@ -122,7 +122,7 @@ function getCurrentTestScope(): CypressTestScope {
     return {
       test,
       attempt: 1,
-      testId: -1,
+      testId: null,
     };
   }
 


### PR DESCRIPTION
Change `testId` to be `null` for `beforeAll` and `afterAll`

See comments in https://app.replay.io/recording/cypresse2ehooks-spects--ca18bc31-5f56-4c0d-aefc-9be8b9aaf680