### PR TITLE
Upload sourcemaps in parallel

### DIFF
--- a/packages/replay/src/bin.ts
+++ b/packages/replay/src/bin.ts
@@ -120,6 +120,7 @@ program
   .option("-i, --ignore <pattern>", "Ignore files that match this pattern", collectIgnorePatterns)
   .option("-q, --quiet", "Silence all stdout logging.")
   .option("-v, --verbose", "Output extra data to stdout when processing files.")
+  .option("--batch-size <batchSize number>", "Number of sourcemaps to upload in parallel (max 25)")
   .option("--root <dirname>", "The base directory to use when computing relative paths")
   .option("--server <address>", "Alternate server to upload sourcemaps to.")
   .arguments("<paths...>")
@@ -224,7 +225,7 @@ async function commandUploadSourcemaps(
   filepaths: Array<string>,
   cliOpts: SourcemapUploadOptions & Pick<CommandLineOptions, "apiKey">
 ): Promise<void> {
-  const { quiet, verbose, apiKey, ...uploadOpts } = cliOpts;
+  const { quiet, verbose, apiKey, batchSize, ...uploadOpts } = cliOpts;
 
   let log: LogCallback | undefined;
   if (!quiet) {
@@ -245,6 +246,7 @@ async function commandUploadSourcemaps(
     filepaths,
     key: apiKey,
     ...uploadOpts,
+    concurrency: batchSize,
     log,
   });
 }

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -37,6 +37,7 @@ export interface SourcemapUploadOptions {
   quiet?: boolean;
   verbose?: boolean;
   root?: string;
+  batchSize?: number;
 }
 
 export interface MetadataOptions {

--- a/packages/sourcemap-upload/README.md
+++ b/packages/sourcemap-upload/README.md
@@ -12,7 +12,7 @@ comments in the JS to find pairs of sourcemap and JS file.
 ## Debugging
 
 If no sourcemaps are being found, consider running the function with verbose
-mode enabled, or with `DEBUG=recordreplay:sourcemap-upload` set in the environment.
+mode enabled, or with `DEBUG=replay:sourcemap-upload` set in the environment.
 
 Most likely, if sourcemaps are not being found, they either:
 

--- a/packages/sourcemap-upload/src/index.ts
+++ b/packages/sourcemap-upload/src/index.ts
@@ -31,6 +31,7 @@ export interface UploadOptions {
   root?: string;
   log?: LogCallback;
   server?: string;
+  concurrency?: number;
 }
 
 export async function uploadSourceMaps(opts: UploadOptions): Promise<void> {
@@ -109,6 +110,7 @@ export async function uploadSourceMaps(opts: UploadOptions): Promise<void> {
     rootPath: path.resolve(cwd, opts.root || ""),
     log: opts.log || (() => undefined),
     apiServer,
+    concurrency: opts.concurrency || 10,
   });
 }
 
@@ -123,6 +125,7 @@ interface NormalizedOptions {
   rootPath: string;
   log: LogCallback;
   apiServer: string;
+  concurrency: number;
 }
 
 interface GeneratedFileEntry {
@@ -210,7 +213,7 @@ async function processSourceMaps(opts: NormalizedOptions) {
         );
       }
     },
-    { concurrency: 10 }
+    { concurrency: Math.min(opts.concurrency, 25) }
   );
 
   debug("Done");


### PR DESCRIPTION
* Updates `sourcemap-upload` to upload in parallel. Defaults to 10 concurrency but overridable via a new option
* Adds `--batch-size` to `replay sourcemap-upload` cli command to control concurrency