### PR TITLE
Fix cypress wrapper to track state of previous runs

### DIFF
--- a/packages/cypress/src/cypress-repeat.ts
+++ b/packages/cypress/src/cypress-repeat.ts
@@ -106,10 +106,14 @@ export default async function CypressRepeat({
         child.send(runOptions);
         child.on("message", msg => {
           const resp: any = msg.valueOf();
-          if (resp.success) {
-            resolve(resp.data);
+          const { success, data, error } =
+            resp && typeof resp === "string"
+              ? JSON.parse(resp)
+              : { success: false, data: null, error: "No response" };
+          if (success) {
+            resolve(data);
           } else {
-            reject(resp.error);
+            reject(error);
           }
         });
 


### PR DESCRIPTION
## Issue

`npx @replayio/cypress` was always exiting with a zero exit code regardless of test steps and `record-on-retry` would always rerun all spec files.

This was caused by treating the response from the child process as an object when it was actually a string.

## Resolution

Parse the response string from the child process