### PR TITLE
Fix dropping args from cy.intercept()

### DIFF
--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -79,6 +79,7 @@ function simplifyCommand(cmd?: CommandLike) {
   // Remove `options` from args so we don't capture them as command args in
   // metadata
   switch (cmd.name) {
+    case "intercept":
     case "request":
     case "route":
     case "stub":


### PR DESCRIPTION
`cy.intercept()` does not accept cypress options as a trailing arg so we shouldn't drop the last object arg which could be a valid arg in this case.