### PR TITLE
Add auth support to cypress plugin

### DIFF
--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -10,7 +10,7 @@ import debug from "debug";
 import { Errors } from "./error";
 import { appendToFixtureFile, initFixtureFile } from "./fixture";
 import { getDiagnosticConfig } from "./mode";
-import { getTestsFromResults, groupStepsByTest, mapStateToResult, sortSteps } from "./steps";
+import { getTestsFromResults, groupStepsByTest, sortSteps } from "./steps";
 import type { StepEvent } from "./support";
 
 type Test = TestMetadataV2.Test;
@@ -38,7 +38,7 @@ class CypressReporter {
   steps: StepEvent[] = [];
   selectedBrowser: string | undefined;
   errors: string[] = [];
-  diagnosticConfig: ReturnType<typeof getDiagnosticConfig>;
+  diagnosticConfig: ReturnType<typeof getDiagnosticConfig> = { noRecord: false, env: {} };
 
   constructor(config: Cypress.PluginConfigOptions, debug: debug.Debugger) {
     initFixtureFile();
@@ -54,7 +54,17 @@ class CypressReporter {
     );
     this.debug = debug.extend("reporter");
 
-    this.diagnosticConfig = getDiagnosticConfig(config);
+    this.configureDiagnostics();
+  }
+
+  async authenticate(apiKey: string) {
+    this.reporter.setApiKey(apiKey);
+    // TODO: we can fetch diagnostics from the cloud later here
+    this.configureDiagnostics();
+  }
+
+  configureDiagnostics() {
+    this.diagnosticConfig = getDiagnosticConfig(this.config);
 
     // Mix diagnostic env into process env so it can be picked up by test
     // metrics and reported to telemetry

--- a/packages/test-utils/src/metrics.ts
+++ b/packages/test-utils/src/metrics.ts
@@ -23,7 +23,8 @@ async function pingTestMetrics(
     runtime?: string;
     runner?: string;
     result?: string;
-  }
+  },
+  apiKey?: string
 ) {
   if (!shouldReportTestMetrics()) return;
 
@@ -46,10 +47,16 @@ async function pingTestMetrics(
 
   debug(body);
 
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
   try {
     return await fetch(`${webhookUrl}/api/metrics`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body,
     });
   } catch (e) {

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -76,10 +76,15 @@ class ReplayReporter {
   runTitle?: string;
   runner: TestRunner;
   errors: ReporterError[] = [];
+  apiKey?: string;
 
   constructor(runner: TestRunner, schemaVersion: string) {
     this.runner = runner;
     this.schemaVersion = schemaVersion;
+  }
+
+  setApiKey(apiKey: string) {
+    this.apiKey = apiKey;
   }
 
   getResultFromResultCounts(resultCounts: TestRun["resultCounts"]): TestResult {
@@ -311,15 +316,20 @@ class ReplayReporter {
       );
     }
 
-    pingTestMetrics(recordingId, this.baseId, {
-      id: source.path + "#" + source.title,
-      source,
-      approximateDuration,
-      recorded: !!recordingId,
-      runtime: parseRuntime(runtime),
-      runner: this.runner.name,
-      result: result,
-    });
+    pingTestMetrics(
+      recordingId,
+      this.baseId,
+      {
+        id: source.path + "#" + source.title,
+        source,
+        approximateDuration,
+        recorded: !!recordingId,
+        runtime: parseRuntime(runtime),
+        runner: this.runner.name,
+        result: result,
+      },
+      this.apiKey
+    );
 
     return validatedTestMetadata;
   }


### PR DESCRIPTION
Adds support for capturing an API key set via environment variable and including it in the test metrics callback to link up test results for tests that were not recorded. This also paves the way for configuring test runs via cloud settings.