### PR TITLE
Adds support for fetching test suite settings from graphql

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -34,6 +34,7 @@ flake:
   ARG --required REPLAY_API_KEY
   WORKDIR /usr/build/e2e-repos/flake
   ENV REPLAY_METADATA_TEST_RUN_TITLE="flake"
+  ENV REPLAY_API_KEY=$REPLAY_API_KEY
   RUN npm i && npm link @replayio/cypress
   RUN npm run start-and-test || exit 0
   DO +UPLOAD --REPLAY_API_KEY=$REPLAY_API_KEY

--- a/Earthfile
+++ b/Earthfile
@@ -36,7 +36,7 @@ flake:
   ENV REPLAY_METADATA_TEST_RUN_TITLE="flake"
   ENV REPLAY_API_KEY=${REPLAY_API_KEY}
   RUN npm i && npm link @replayio/cypress
-  RUN DEBUG=replay:*,-replay:cypress:plugin:task npm run start-and-test || exit 0
+  RUN DEBUG=replay:*,-replay:cypress:plugin:task,-replay:cypress:plugin:reporter:steps npm run start-and-test || exit 0
   DO +UPLOAD --REPLAY_API_KEY=$REPLAY_API_KEY
 
 e2e:

--- a/Earthfile
+++ b/Earthfile
@@ -34,9 +34,9 @@ flake:
   ARG --required REPLAY_API_KEY
   WORKDIR /usr/build/e2e-repos/flake
   ENV REPLAY_METADATA_TEST_RUN_TITLE="flake"
-  ENV REPLAY_API_KEY=$REPLAY_API_KEY
+  ENV REPLAY_API_KEY=${REPLAY_API_KEY}
   RUN npm i && npm link @replayio/cypress
-  RUN npm run start-and-test || exit 0
+  RUN DEBUG=replay:*,-replay:cypress:plugin:task npm run start-and-test || exit 0
   DO +UPLOAD --REPLAY_API_KEY=$REPLAY_API_KEY
 
 e2e:

--- a/packages/cypress/src/mode.ts
+++ b/packages/cypress/src/mode.ts
@@ -135,12 +135,17 @@ function getRepeatCount(stressCount = 10) {
   }
 }
 
-export function getDiagnosticConfig(config: Cypress.PluginConfigOptions): {
+export function getDiagnosticConfig(
+  config: Cypress.PluginConfigOptions,
+  extraEnv: NodeJS.ProcessEnv = {}
+): {
   noRecord: boolean;
   env: NodeJS.ProcessEnv;
 } {
   let noRecord = false;
-  let env: NodeJS.ProcessEnv = {};
+  let env: NodeJS.ProcessEnv = {
+    ...extraEnv,
+  };
 
   const { cypress_repeat_k } = config.env;
   const repeatIndex = cypress_repeat_k ? Number.parseInt(cypress_repeat_k) : undefined;

--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -4,6 +4,7 @@ import {
   ReplayReporter,
   TestMetadataV2,
   ReporterError,
+  fetchWorkspaceConfig,
 } from "@replayio/test-utils";
 import debug from "debug";
 
@@ -59,12 +60,12 @@ class CypressReporter {
 
   async authenticate(apiKey: string) {
     this.reporter.setApiKey(apiKey);
-    // TODO: we can fetch diagnostics from the cloud later here
-    this.configureDiagnostics();
+    const { env } = await fetchWorkspaceConfig(apiKey);
+    this.configureDiagnostics(env);
   }
 
-  configureDiagnostics() {
-    this.diagnosticConfig = getDiagnosticConfig(this.config);
+  configureDiagnostics(extraEnv?: NodeJS.ProcessEnv) {
+    this.diagnosticConfig = getDiagnosticConfig(this.config, extraEnv);
 
     // Mix diagnostic env into process env so it can be picked up by test
     // metrics and reported to telemetry

--- a/packages/test-utils/src/config.ts
+++ b/packages/test-utils/src/config.ts
@@ -29,21 +29,20 @@ async function fetchWorkspaceConfig(apiKey: string) {
     apiKey,
     "GetWorkspaceConfig",
     `
-        query GetWorkspaceConfig {
+      query GetWorkspaceConfig {
         auth {
-            workspaces {
+          workspaces {
             edges {
-                node {
+              node {
                 id
                 settings {
-                    features
+                  features
                 }
-                }
+              }
             }
-            }
+          }
         }
-        }
-  `
+      }`
   );
 
   if (json.errors) {

--- a/packages/test-utils/src/config.ts
+++ b/packages/test-utils/src/config.ts
@@ -1,0 +1,68 @@
+import fetch from "node-fetch";
+import dbg from "debug";
+
+const debug = dbg("replay:test-utils:config");
+
+async function query(apiKey: string, name: string, query: string, variables = {}) {
+  const options = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      query,
+      name,
+      variables,
+    }),
+  };
+
+  const server = process.env.REPLAY_API_SERVER || "https://api.replay.io";
+  debug("Querying %s graphql endpoint", server);
+  const result = await fetch(`${server}/v1/graphql`, options);
+
+  return await result.json();
+}
+
+async function fetchWorkspaceConfig(apiKey: string) {
+  const json = await query(
+    apiKey,
+    "GetWorkspaceConfig",
+    `
+        query GetWorkspaceConfig {
+        auth {
+            workspaces {
+            edges {
+                node {
+                id
+                settings {
+                    features
+                }
+                }
+            }
+            }
+        }
+        }
+  `
+  );
+
+  if (json.errors) {
+    debug("GraphQL failed: %s", json.errors);
+    throw new Error(json.errors[0].message || "Unexpected error");
+  }
+
+  const edges = json.data?.auth.workspaces.edges;
+  if (!edges || edges.length !== 1) {
+    debug("Failed to find workspace: %o", json.data);
+    throw new Error("Failed to find a workspace for the given apiKey");
+  }
+
+  debug("Workspace settings: %o", edges[0].node.settings);
+  const features = edges[0].node.settings.features;
+
+  return {
+    env: features?.testSuites?.env || {},
+  };
+}
+
+export { fetchWorkspaceConfig };

--- a/packages/test-utils/src/config.ts
+++ b/packages/test-utils/src/config.ts
@@ -1,5 +1,6 @@
 import fetch from "node-fetch";
 import dbg from "debug";
+import { warn } from "./logging";
 
 const debug = dbg("replay:test-utils:config");
 
@@ -64,12 +65,7 @@ async function fetchWorkspaceConfig(apiKey: string) {
       env: features?.testSuites?.env || {},
     };
   } catch (e) {
-    console.warn(
-      "Failed to fetch test suite configuration from replay.io. Continuing with defaults."
-    );
-    if (e instanceof Error) {
-      console.warn(e.message);
-    }
+    warn("Failed to fetch test suite configuration; continuing with defaults", e);
 
     return {
       env: {},

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -4,5 +4,6 @@ export type { TestMetadataV1, TestMetadataV2, ReplayReporterConfig } from "./rep
 export { ReporterError } from "./reporter";
 export { pingTestMetrics } from "./metrics";
 export { removeAnsiCodes } from "./terminal";
+export { fetchWorkspaceConfig } from "./config";
 export { ReplayReporter };
 export { getMetadataFilePath, initMetadataFile } from "./metadata";

--- a/packages/test-utils/src/logging.ts
+++ b/packages/test-utils/src/logging.ts
@@ -1,0 +1,6 @@
+export function warn(message: string, e: unknown) {
+  console.warn("[replay.io]:", message);
+  if (e instanceof Error) {
+    console.warn("[replay.io]: Error:", e.message);
+  }
+}

--- a/packages/test-utils/src/metadata.ts
+++ b/packages/test-utils/src/metadata.ts
@@ -1,6 +1,7 @@
 import { writeFileSync, existsSync } from "fs";
 import path from "path";
 import { getDirectory } from "@replayio/replay/src/utils";
+import { warn } from "./logging";
 
 export function getMetadataFilePath(base: string, workerIndex = 0) {
   return (
@@ -17,8 +18,7 @@ export function initMetadataFile(path: string) {
 
     return path;
   } catch (e) {
-    console.error(`Failed to initialize metadata file${path ? ` at ${path}` : ""}`);
-    console.error(e);
+    warn(`Failed to initialize metadata file${path ? ` at ${path}` : ""}`, e);
   }
 
   return undefined;

--- a/packages/test-utils/src/metrics.ts
+++ b/packages/test-utils/src/metrics.ts
@@ -3,6 +3,7 @@ import os from "os";
 import fetch from "node-fetch";
 import { Test } from "./reporter";
 import { TestMetadataV2 } from "@replayio/replay/metadata/test/v2";
+import { warn } from "./logging";
 
 const debug = dbg("replay:test-utils:metrics");
 
@@ -60,7 +61,7 @@ async function pingTestMetrics(
       body,
     });
   } catch (e) {
-    console.log("Failed to send test metrics", e);
+    warn("Failed to send test metrics", e);
   }
 }
 

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -8,6 +8,7 @@ const uuid = require("uuid");
 
 import { getMetadataFilePath } from "./metadata";
 import { pingTestMetrics } from "./metrics";
+import { warn } from "./logging";
 
 const debug = dbg("replay:test-utils:reporter");
 
@@ -233,7 +234,7 @@ class ReplayReporter {
       mkdirSync(dirname(metadataFilePath), { recursive: true });
       writeFileSync(metadataFilePath, JSON.stringify(metadata, undefined, 2), {});
     } catch (e) {
-      console.error("Failed to initialize Replay metadata", e);
+      warn("Failed to initialize Replay metadata", e);
     }
   }
 


### PR DESCRIPTION
Blocked by https://github.com/replayio/replay-cli/pull/222

Fetches environment variables to configure the replay browser when an API key is set for the cypress test runner