### PR TITLE
Fix matching cypress tests when using .only

### DIFF
--- a/packages/cypress/src/fixture.ts
+++ b/packages/cypress/src/fixture.ts
@@ -1,5 +1,8 @@
 import { writeFileSync, appendFileSync, mkdirSync } from "fs";
 import path from "path";
+import dbg from "debug";
+
+const debug = dbg("replay:cypress:fixture");
 
 function getFixtureFile() {
   return (
@@ -13,7 +16,9 @@ function getFixtureFile() {
 }
 
 export function initFixtureFile() {
+  debug("REPLAY_CYPRESS_UPDATE_FIXTURE: %s", process.env.REPLAY_CYPRESS_UPDATE_FIXTURE);
   if (process.env.REPLAY_CYPRESS_UPDATE_FIXTURE) {
+    debug("Initializing fixture file %s", getFixtureFile());
     try {
       mkdirSync(path.dirname(getFixtureFile()), { recursive: true });
       writeFileSync(getFixtureFile(), "");

--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -161,7 +161,10 @@ class CypressReporter {
       ];
     }
 
-    let testsWithoutSteps: Test[] = getTestsFromResults(result.tests);
+    let testsWithoutSteps = getTestsFromResults(
+      result.tests,
+      this.steps.filter(s => s.event === "test:start")
+    );
     let testsWithSteps: Test[] = [];
 
     try {
@@ -172,6 +175,10 @@ class CypressReporter {
       console.warn(e);
 
       this.reporter.addError(e);
+
+      // return tests without steps otherwise the test-utils reporter will bail
+      // and we'll lose the error altogether.
+      return testsWithoutSteps;
     }
 
     return testsWithSteps;


### PR DESCRIPTION
## Issue

* When a reporter error occurs, we're dropping it from metadata because we pass an empty test array to the `test-utils` reporter which bails in that case.
* When using `context.only()`, we hit a metadata error because the omitted tests are excluded from cypress results so the index-based `testId` for the test doesn't match the `testId` included in steps which comes from mocha's view and includes the omitted tests.

## Resolution

* Return the tests without steps when an error occurs so we have tests to which the reporter error can be attached
* Look up the `testId` for the test by its full path from `test:start` events which include the mocha-generated `testId`