### PR TITLE
Allow unknown options to replay launch to pass through to the browser

### DIFF
--- a/packages/replay/src/bin.ts
+++ b/packages/replay/src/bin.ts
@@ -46,6 +46,7 @@ program
   .command("launch [url]")
   .description("Launch the replay browser")
   .option("-b, --browser <browser>", "Browser to launch", "chromium")
+  .allowUnknownOption()
   .action(commandLaunchBrowser);
 
 program


### PR DESCRIPTION
We should pass through extra options (e.g. `--load-extension`) through to the browser from `replay launch`