### PR TITLE
Expose cypress runner in node API

### DIFF
--- a/packages/cypress/src/cypress-repeat.ts
+++ b/packages/cypress/src/cypress-repeat.ts
@@ -1,7 +1,6 @@
 // Adapted from https://github.com/bahmutov/cypress-repeat
 
 import path from "path";
-import cypress from "cypress";
 import dbg from "debug";
 import { fork } from "child_process";
 import terminate from "terminate";
@@ -57,13 +56,13 @@ export default async function CypressRepeat({
   repeat = 1,
   mode = SpecRepeatMode.All,
   untilPasses = false,
-  args = [],
+  options = {},
   timeout,
 }: {
   repeat?: number;
   mode?: SpecRepeatMode;
   untilPasses?: boolean;
-  args?: string[];
+  options?: Partial<CypressCommandLine.CypressRunOptions>;
   timeout?: number;
 }) {
   const name = "cypress-repeat:";
@@ -78,14 +77,6 @@ export default async function CypressRepeat({
   if (rerunFailedOnly) {
     console.log("%s it only reruns specs which have failed", name);
   }
-
-  const parseArguments = async () => {
-    return await cypress.cli.parseRunArguments(["cypress", "run", ...args]);
-  };
-
-  const options = await parseArguments();
-
-  debug("parsed CLI options %o", options);
 
   const allRunOptions = buildAllRunOptions(repeat, options);
 

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -8,6 +8,7 @@ import chalk from "chalk";
 
 import { TASK_NAME } from "./constants";
 import CypressReporter, { getMetadataFilePath, isStepEvent } from "./reporter";
+import run from "./run";
 
 const debug = dbg("replay:cypress:plugin");
 const debugTask = debug.extend("task");
@@ -204,6 +205,7 @@ export function getCypressReporter() {
 export default plugin;
 export {
   plugin,
+  run,
   onBeforeRun,
   onBeforeBrowserLaunch,
   onBeforeSpec,

--- a/packages/cypress/src/mode.ts
+++ b/packages/cypress/src/mode.ts
@@ -43,31 +43,37 @@ const diagnosticFlags = [
 ];
 
 export enum ReplayMode {
-  Record,
-  RecordOnRetry,
-  Diagnostics,
-  Stress,
+  Record = "record",
+  RecordOnRetry = "record-on-retry",
+  Diagnostics = "diagnostics",
+  Stress = "stress",
 }
 
 export enum DiagnosticLevel {
-  None,
-  Basic,
-  Full,
+  None = "none",
+  Basic = "basic",
+  Full = "full",
 }
 
-export function configure(options: { mode?: string; level?: string; stressCount?: number }) {
+export function configure(options: {
+  mode: ReplayMode;
+  level?: DiagnosticLevel;
+  stressCount?: number;
+}) {
   // Set this modes into the environment so they can be picked up by the plugin
   process.env.REPLAY_CYPRESS_MODE = options.mode;
-  process.env.REPLAY_CYPRESS_DIAGNOSTIC_LEVEL = options.level;
+  if (options.mode === ReplayMode.Diagnostics && options.level) {
+    process.env.REPLAY_CYPRESS_DIAGNOSTIC_LEVEL = options.level;
+  }
 
   const config = {
-    mode: getReplayMode(),
-    level: getDiagnosticLevel(),
-    repeat: getRepeatCount(options.stressCount),
+    mode: options.mode,
+    level: options.level,
+    repeat: getRepeatCount(options.mode, options.level, options.stressCount),
   };
 
   // configure shared metadata values
-  process.env.RECORD_REPLAY_METADATA_TEST_RUN_MODE = toModeString(config.mode);
+  process.env.RECORD_REPLAY_METADATA_TEST_RUN_MODE = config.mode;
   // set a test run id so all the replays share a run when running in retry modes
   process.env.RECORD_REPLAY_METADATA_TEST_RUN_ID =
     process.env.RECORD_REPLAY_METADATA_TEST_RUN_ID || v4();
@@ -75,59 +81,50 @@ export function configure(options: { mode?: string; level?: string; stressCount?
   return config;
 }
 
-function toModeString(mode: ReplayMode) {
-  switch (mode) {
-    case ReplayMode.Record:
-      return "record";
-    case ReplayMode.RecordOnRetry:
-      return "record-on-retry";
-    case ReplayMode.Diagnostics:
-      return "diagnostics";
-    case ReplayMode.Stress:
-      return "stress";
+export function toReplayMode(mode?: string) {
+  if (!mode) {
+    mode = "record";
   }
-}
-
-function getReplayMode(): ReplayMode {
-  const { REPLAY_CYPRESS_MODE: mode } = process.env;
 
   switch (mode) {
-    case "record-on-retry":
-      return ReplayMode.RecordOnRetry;
-    case "diagnostic":
     case "diagnostics":
-      process.env.REPLAY_CYPRESS_MODE = "diagnostics";
-      return ReplayMode.Diagnostics;
+      mode = "diagnostics";
+      break;
+    case "record-on-retry":
+    case "diagnostic":
     case "stress":
-      return ReplayMode.Stress;
+    case "record":
+      break;
+    default:
+      throw new Error("Unexpected mode value: " + mode);
   }
 
-  process.env.REPLAY_CYPRESS_MODE = "record";
-  return ReplayMode.Record;
+  return mode as ReplayMode;
 }
 
-function getDiagnosticLevel(): DiagnosticLevel {
-  const mode = getReplayMode();
-  const { REPLAY_CYPRESS_DIAGNOSTIC_LEVEL: level } = process.env;
+export function toDiagnosticLevel(level?: string) {
+  if (!level) {
+    level = "none";
+  }
 
   switch (level) {
     case "basic":
-      return DiagnosticLevel.Basic;
     case "full":
-      return DiagnosticLevel.Full;
+    case "none":
+      break;
+    default:
+      throw new Error("Unexpected level value: " + level);
   }
 
-  return mode === ReplayMode.Diagnostics ? DiagnosticLevel.Basic : DiagnosticLevel.None;
+  return level as DiagnosticLevel;
 }
 
-function getRepeatCount(stressCount = 10) {
-  const level = getDiagnosticLevel();
-
-  switch (getReplayMode()) {
+function getRepeatCount(mode: ReplayMode, diagnosticLevel?: DiagnosticLevel, stressCount = 10) {
+  switch (mode) {
     case ReplayMode.RecordOnRetry:
       return 2;
     case ReplayMode.Diagnostics:
-      return level === DiagnosticLevel.Basic ? 3 : diagnosticFlags.length + 3;
+      return diagnosticLevel === DiagnosticLevel.Basic ? 3 : diagnosticFlags.length + 3;
     case ReplayMode.Stress:
       return stressCount;
     case ReplayMode.Record:
@@ -149,7 +146,8 @@ export function getDiagnosticConfig(
 
   const { cypress_repeat_k } = config.env;
   const repeatIndex = cypress_repeat_k ? Number.parseInt(cypress_repeat_k) : undefined;
-  const mode = getReplayMode();
+
+  const mode = toReplayMode(process.env.REPLAY_CYPRESS_MODE);
 
   if (mode === ReplayMode.RecordOnRetry) {
     noRecord = repeatIndex === 1;

--- a/packages/cypress/src/run.ts
+++ b/packages/cypress/src/run.ts
@@ -1,0 +1,35 @@
+import { gte } from "semver";
+
+import cypressRepeat, { SpecRepeatMode } from "./cypress-repeat";
+import { DiagnosticLevel, ReplayMode, configure } from "./mode";
+
+export default function run({
+  mode,
+  level,
+  count,
+  timeout,
+  ...options
+}: {
+  mode: ReplayMode;
+  level: DiagnosticLevel;
+  count?: number;
+  timeout?: number;
+} & Partial<CypressCommandLine.CypressRunOptions>) {
+  const config = configure({ mode, level, stressCount: count });
+
+  if (
+    (mode === ReplayMode.Diagnostics || mode === ReplayMode.RecordOnRetry) &&
+    !gte(require("cypress/package.json").version, "10.9.0")
+  ) {
+    console.error("Cypress 10.9 or greater is required for diagnostic or record-on-retry modes");
+    process.exit(1);
+  }
+
+  return cypressRepeat({
+    repeat: config.repeat,
+    mode: config.mode === ReplayMode.RecordOnRetry ? SpecRepeatMode.Failed : SpecRepeatMode.All,
+    untilPasses: config.mode === ReplayMode.RecordOnRetry,
+    options,
+    timeout,
+  });
+}


### PR DESCRIPTION
Refactor the code for our cypress runner to be usable via the node API.

```
const {run} = require("@replayio/cypress");
run({
  // replay options
  mode: "stress",
  level: "basic",
  count: 2,
  timeout: 30000,
  // cypress options
  spec: "cypress/e2e/adding-spec.ts",
  browser: "replay-chromium"
}).then((failed) => {
  console.log("done");
  process.exit(failed ? 1 : 0);
}).catch(e => {
  console.error(e);
  process.exit(1);
});
```