### PR TITLE
Fix platform in test metrics

### DIFF
--- a/packages/test-utils/src/metrics.ts
+++ b/packages/test-utils/src/metrics.ts
@@ -36,7 +36,7 @@ async function pingTestMetrics(
     recordingId,
     test: {
       ...test,
-      platform: os.platform,
+      platform: os.platform(),
       runId,
       env: {
         disableAsserts: !!process.env.RECORD_REPLAY_DISABLE_ASSERTS,


### PR DESCRIPTION
`os.platform` => `os.platform()` :(