### PR TITLE
Add env varible to disable cypress integration

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -131,6 +131,12 @@ function onReplayTask(value: any) {
 }
 
 const plugin: Cypress.PluginConfig = (on, config) => {
+  debug("Disabled? %s", process.env.CYPRESS_REPLAY_DISABLED);
+
+  if (process.env.CYPRESS_REPLAY_DISABLED) {
+    return config;
+  }
+
   cypressReporter = new CypressReporter(config, debug);
 
   on("before:run", onBeforeRun);

--- a/packages/cypress/support.ts
+++ b/packages/cypress/support.ts
@@ -1,3 +1,5 @@
 import register from "./src/support";
 
-register();
+if (!Cypress.env("REPLAY_DISABLED")) {
+  register();
+}


### PR DESCRIPTION
Adds support for `CYPRESS_REPLAY_DISABLED` to disable the cypress plugin and support file