### PR TITLE
Replace CYPRESS_REPLAY_DISABLED with CYPRESS_REPLAY_PLUGIN_FEATURES

### DIFF
--- a/packages/cypress/src/features.ts
+++ b/packages/cypress/src/features.ts
@@ -1,0 +1,59 @@
+export enum PluginFeature {
+  Plugin = "plugin",
+  Support = "support",
+  Metrics = "metrics",
+}
+
+type PluginFeatureOption = PluginFeature | `no-${PluginFeature}` | "none" | "all";
+
+function isValidFeatureOption(feature: string): feature is PluginFeatureOption {
+  if (["all", "none"].includes(feature)) {
+    return true;
+  }
+
+  if (feature.startsWith("no-")) {
+    feature = feature.substring(3);
+  }
+
+  return Object.values(PluginFeature).includes(feature as PluginFeature);
+}
+
+function parsePluginFeatureOptions(options: string) {
+  return options
+    .toLowerCase()
+    .split(",")
+    .map(s => s.trim())
+    .filter(s => isValidFeatureOption(s)) as PluginFeatureOption[];
+}
+
+export function getFeatures(options: string | undefined) {
+  const allFeatures = Object.values(PluginFeature);
+
+  if (options) {
+    return parsePluginFeatureOptions(options).reduce<PluginFeature[]>((acc, feature) => {
+      if (feature === "all") {
+        return allFeatures;
+      } else if (feature === "none") {
+        return [];
+      } else if (feature.startsWith("no-")) {
+        feature = feature.substring(3) as PluginFeatureOption;
+
+        if (acc.includes(feature as PluginFeature)) {
+          return acc.filter(f => f !== feature);
+        }
+      } else if (!acc.includes(feature as any)) {
+        acc.push(feature as PluginFeature);
+      }
+
+      return acc;
+    }, []);
+  }
+
+  return allFeatures;
+}
+
+export function isFeatureEnabled(options: string | undefined, feature: PluginFeature) {
+  const features = getFeatures(options);
+
+  return features.includes(feature);
+}

--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -13,6 +13,7 @@ import { appendToFixtureFile, initFixtureFile } from "./fixture";
 import { getDiagnosticConfig } from "./mode";
 import { getTestsFromResults, groupStepsByTest, sortSteps } from "./steps";
 import type { StepEvent } from "./support";
+import { PluginFeature, getFeatures, isFeatureEnabled } from "./features";
 
 type Test = TestMetadataV2.Test;
 type TestRun = TestMetadataV2.TestRun;
@@ -39,6 +40,7 @@ class CypressReporter {
   steps: StepEvent[] = [];
   selectedBrowser: string | undefined;
   errors: string[] = [];
+  featureOptions: string | undefined;
   diagnosticConfig: ReturnType<typeof getDiagnosticConfig> = { noRecord: false, env: {} };
 
   constructor(config: Cypress.PluginConfigOptions, debug: debug.Debugger) {
@@ -56,6 +58,13 @@ class CypressReporter {
     this.debug = debug.extend("reporter");
 
     this.configureDiagnostics();
+
+    this.featureOptions = process.env.CYPRESS_REPLAY_PLUGIN_FEATURES;
+    debug("Features: %o", getFeatures(this.featureOptions));
+  }
+
+  isFeatureEnabled(feature: PluginFeature) {
+    return isFeatureEnabled(this.featureOptions, feature);
   }
 
   async authenticate(apiKey: string) {

--- a/packages/cypress/support.ts
+++ b/packages/cypress/support.ts
@@ -1,5 +1,6 @@
 import register from "./src/support";
+import { PluginFeature, isFeatureEnabled } from "./src/features";
 
-if (!Cypress.env("REPLAY_DISABLED")) {
+if (isFeatureEnabled(Cypress.env("REPLAY_PLUGIN_FEATURES"), PluginFeature.Support)) {
   register();
 }


### PR DESCRIPTION
The minimal fix for supporting sending metrics while disabling everything else was just moving the `after:spec` handler up before the return. That works but felt a little strange to say we're disabled but then not really disable everything. So I went a little bigger than was absolutely necessary here but I think this is a better pattern for controlling the behavior of the plugin.

Usage:

Run without the plugin doing anything except capturing metrics:
```
CYPRESS_REPLAY_PLUGIN_FEATURES="metrics" npx cypress run
```

Run with the plugin truly doing nothing
```
CYPRESS_REPLAY_PLUGIN_FEATURES="none" npx cypress run
```

Run with the plugin truly doing everything but metrics
```
CYPRESS_REPLAY_PLUGIN_FEATURES="all,no-metrics" npx cypress run
```