### PR TITLE
Trim whitespace from api key in auth header

### DIFF
--- a/packages/test-utils/src/config.ts
+++ b/packages/test-utils/src/config.ts
@@ -9,7 +9,7 @@ async function query(apiKey: string, name: string, query: string, variables = {}
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
+      Authorization: `Bearer ${apiKey.trim()}`,
     },
     body: JSON.stringify({
       query,


### PR DESCRIPTION
The user may feed an API key from an env variable that includes trailing newlines which are not allowed. Trim those off before creating the auth header.