### PR TITLE
Add upload option to cypress plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           repository: replayio-public/flake
           path: e2e-repos/flake
+          ref: ryan/upload-test
       - name: Download latest earthly
         run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.6.19/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: build, lint and test

--- a/Earthfile
+++ b/Earthfile
@@ -37,17 +37,10 @@ flake:
   ENV REPLAY_API_KEY=${REPLAY_API_KEY}
   RUN npm i && npm link @replayio/cypress
   RUN DEBUG=replay:*,-replay:cypress:plugin:task,-replay:cypress:plugin:reporter:steps npm run start-and-test || exit 0
-  DO +UPLOAD --REPLAY_API_KEY=$REPLAY_API_KEY
+  RUN npx @replayio/replay ls --all
 
 e2e:
   BUILD +flake
-
-UPLOAD:
-  COMMAND
-  ARG --required REPLAY_API_KEY
-  RUN npx @replayio/replay ls --json | grep -q id 
-  RUN npx @replayio/replay upload-all --api-key ${REPLAY_API_KEY} || exit 0
-  RUN npx @replayio/replay ls --all
 
 ci:
   BUILD +lint

--- a/packages/cypress/src/features.ts
+++ b/packages/cypress/src/features.ts
@@ -2,7 +2,6 @@ export enum PluginFeature {
   Plugin = "plugin",
   Support = "support",
   Metrics = "metrics",
-  Upload = "upload",
 }
 
 type PluginFeatureOption = PluginFeature | `no-${PluginFeature}` | "none" | "all";

--- a/packages/cypress/src/features.ts
+++ b/packages/cypress/src/features.ts
@@ -2,6 +2,7 @@ export enum PluginFeature {
   Plugin = "plugin",
   Support = "support",
   Metrics = "metrics",
+  Upload = "upload",
 }
 
 type PluginFeatureOption = PluginFeature | `no-${PluginFeature}` | "none" | "all";

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -248,7 +248,7 @@ const plugin = (
     on("after:spec", (spec, result) => {
       onAfterSpec(spec, result);
 
-      if (options.upload === true) {
+      if (options.upload === true && cypressReporter.isFeatureEnabled(PluginFeature.Upload)) {
         pendingWork.push(startUpload(spec, options));
       }
     });
@@ -271,9 +271,7 @@ const plugin = (
       onBeforeBrowserLaunch(config, browser, launchOptions)
     );
     on("before:spec", onBeforeSpec);
-    on("after:run", () => {
-      onAfterRun();
-    });
+    on("after:run", onAfterRun);
 
     // make sure we have a config object with the keys we need to mutate
     config = config || {};
@@ -306,7 +304,7 @@ const plugin = (
 
     const firefoxPath = getPlaywrightBrowserPath("firefox");
     if (firefoxPath) {
-      debug("Adding firefox to cypress at %s", chromiumPath);
+      debug("Adding firefox to cypress at %s", firefoxPath);
       config.browsers = config.browsers.concat({
         name: "replay-firefox",
         channel: "stable",
@@ -319,7 +317,7 @@ const plugin = (
         isHeadless: false,
       });
     } else {
-      debug("Firefox not supported on this platform", chromiumPath);
+      debug("Firefox not supported on this platform", firefoxPath);
     }
   }
 

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -141,7 +141,11 @@ function onBeforeSpec(spec: Cypress.Spec) {
   cypressReporter.onBeforeSpec(spec);
 }
 
-function onAfterSpec(spec: Cypress.Spec, result: CypressCommandLine.RunResult) {
+function onAfterSpec(
+  spec: Cypress.Spec,
+  result: CypressCommandLine.RunResult,
+  options: PluginOptions = {}
+) {
   debugEvents("Handling after:spec %s", spec.relative);
   const metadata = cypressReporter.onAfterSpec(spec, result);
 
@@ -155,6 +159,10 @@ function onAfterSpec(spec: Cypress.Spec, result: CypressCommandLine.RunResult) {
     ) {
       missingSteps = true;
     }
+  }
+
+  if (options.upload === true) {
+    pendingWork.push(startUpload(spec, options));
   }
 }
 
@@ -291,13 +299,7 @@ const plugin = (
     cypressReporter.isFeatureEnabled(PluginFeature.Plugin) ||
     cypressReporter.isFeatureEnabled(PluginFeature.Metrics)
   ) {
-    on("after:spec", (spec, result) => {
-      onAfterSpec(spec, result);
-
-      if (options.upload === true && cypressReporter.isFeatureEnabled(PluginFeature.Upload)) {
-        pendingWork.push(startUpload(spec, options));
-      }
-    });
+    on("after:spec", (spec, result) => onAfterSpec(spec, result, options));
   }
 
   if (

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -221,8 +221,7 @@ async function startUpload(spec: Cypress.Spec, options: PluginOptions): Promise<
       }, {}),
     };
   } catch (e) {
-    console.error("Upload failed for", spec.relative);
-    debug(e);
+    warn(`Upload failed for ${spec.relative}`, e);
 
     return {
       error: e,

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -35,10 +35,13 @@ export interface MetadataOptions {
   keys?: string[];
   warn?: boolean;
   verbose?: boolean;
+  directory?: string;
 }
 
 export interface FilterOptions {
-  filter?: string;
+  filter?:
+    | string
+    | ((recordings: RecordingEntry, index: number, allRecordings: RecordingEntry[]) => boolean);
 }
 
 export interface ListOptions extends FilterOptions {

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -5,5 +5,6 @@ export { ReporterError } from "./reporter";
 export { pingTestMetrics } from "./metrics";
 export { removeAnsiCodes } from "./terminal";
 export { fetchWorkspaceConfig } from "./config";
+export * from "./logging";
 export { ReplayReporter };
 export { getMetadataFilePath, initMetadataFile } from "./metadata";

--- a/packages/test-utils/src/logging.ts
+++ b/packages/test-utils/src/logging.ts
@@ -1,3 +1,7 @@
+export function log(message: string) {
+  console.log("[replay.io]:", message);
+}
+
 export function warn(message: string, e: unknown) {
   console.warn("[replay.io]:", message);
   if (e instanceof Error) {


### PR DESCRIPTION
Add upload support after cypress run completes

Supporting changes:
* Supporting a function for `filter` in the node API in addition to the jsonata string
* Exporting `log` from test-utils logging
* Adding `directory` to `updateMetadata`

Fixes SCS-1407