### PR TITLE
Add --warn to CLI commands

### DIFF
--- a/packages/replay/src/bin.ts
+++ b/packages/replay/src/bin.ts
@@ -97,7 +97,9 @@ commandWithGlobalOptions("rm <id>")
   .description("Remove a specific recording.")
   .action(commandRemoveRecording);
 
-program.command("rm-all").description("Remove all recordings.").action(commandRemoveAllRecordings);
+commandWithGlobalOptions("rm-all")
+  .description("Remove all recordings.")
+  .action(commandRemoveAllRecordings);
 
 commandWithGlobalOptions("update-browsers")
   .description("Update browsers used in automation.")
@@ -131,8 +133,7 @@ commandWithGlobalOptions("metadata")
   .option("--filter <filter string>", "String to filter recordings")
   .action(commandMetadata);
 
-program
-  .command("login")
+commandWithGlobalOptions("login")
   .description("Log in interactively with your browser")
   .option("--directory <dir>", "Alternate recording directory.")
   .action(commandLogin);
@@ -359,9 +360,16 @@ async function commandMetadata(opts: MetadataOptions & FilterOptions) {
 }
 
 async function commandLogin(opts: CommandLineOptions) {
-  const ok = await maybeAuthenticateUser({
-    ...opts,
-    verbose: true,
-  });
-  process.exit(ok ? 0 : 1);
+  try {
+    const ok = await maybeAuthenticateUser({
+      ...opts,
+      verbose: true,
+    });
+    process.exit(ok || opts.warn ? 0 : 1);
+  } catch (e) {
+    console.error("Failed to login");
+    debug("maybeAuthenticateUser error %o", e);
+
+    process.exit(opts.warn ? 0 : 1);
+  }
 }

--- a/packages/replay/src/install.ts
+++ b/packages/replay/src/install.ts
@@ -5,7 +5,7 @@ import dbg from "debug";
 import fs from "fs";
 import https from "https";
 import path from "path";
-import { BrowserName, Options, Runner, NodeOptions } from "./types";
+import { BrowserName, Options } from "./types";
 import { defer, getDirectory, maybeLog } from "./utils";
 
 const debug = dbg("replay:cli:install");
@@ -235,7 +235,7 @@ async function installReplayBrowser(
   }
 }
 
-async function downloadReplayFile(downloadFile: string, opts: NodeOptions) {
+async function downloadReplayFile(downloadFile: string, opts: Options) {
   const options = {
     host: "static.replay.io",
     port: 443,

--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -682,15 +682,15 @@ async function updateMetadata({
             return await testMetadata.init(md.test || {});
         }
       } catch (e) {
+        debug("Metadata initialization error: %o", e);
         if (!warn) {
-          console.error("Unable to initialize metadata field", v);
-          console.error(e);
-
-          process.exit(1);
+          throw e;
         }
 
-        console.warn("Unable to initialize metadata field", v);
-        console.warn(String(e));
+        console.warn(`Unable to initialize metadata field: "${v}"`);
+        if (e instanceof Error) {
+          console.warn(" ->", e.message);
+        }
       }
 
       return null;

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -1,6 +1,6 @@
 export type UnstructuredMetadata = Record<string, unknown>;
 
-export interface CommandLineOptions {
+export interface Options {
   /**
    * Alternate recording directory
    */
@@ -15,19 +15,9 @@ export interface CommandLineOptions {
    * Authentication API Key
    */
   apiKey?: string;
-
-  /**
-   * JSON output
-   */
-  json?: boolean;
-}
-
-export interface NodeOptions {
   verbose?: boolean;
   agent?: any;
 }
-
-export type Options = CommandLineOptions & NodeOptions;
 
 export interface SourcemapUploadOptions {
   group: string;
@@ -57,6 +47,7 @@ export interface ListOptions extends FilterOptions {
 
 export interface UploadOptions extends FilterOptions {
   batchSize?: number;
+  warn?: boolean;
 }
 
 /**

--- a/packages/replay/src/utils.ts
+++ b/packages/replay/src/utils.ts
@@ -1,7 +1,7 @@
 import dbg from "debug";
 import path from "path";
 
-import { BrowserName, CommandLineOptions } from "./types";
+import { BrowserName, Options } from "./types";
 
 const debug = dbg("replay:cli");
 
@@ -22,7 +22,7 @@ function maybeLog(verbose: boolean | undefined, str: string) {
   }
 }
 
-function getDirectory(opts?: Pick<CommandLineOptions, "directory">) {
+function getDirectory(opts?: Pick<Options, "directory">) {
   const home = process.env.HOME || process.env.USERPROFILE;
   return (
     (opts && opts.directory) || process.env.RECORD_REPLAY_DIRECTORY || path.join(home!, ".replay")


### PR DESCRIPTION
When running the CLI in CI environments, users may want to suppress non-zero exit codes to prevent failing builds when steps like uploading replays fails. The --warn option was already supported by the metadata command so I have extended it to all commands and add try/catch blocks to ensure we are handling throw errors correctly.