### PR TITLE
Fix handling of playwright errors without a message

### DIFF
--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -27,10 +27,18 @@ export function getMetadataFilePath(workerIndex = 0) {
 }
 
 function extractErrorMessage(error: TestError) {
-  const errorMessageLines = removeAnsiCodes(error.message)!.split("\n");
-  let stackStart = errorMessageLines.findIndex(l => l.startsWith("Call log:"));
-  stackStart = stackStart == null || stackStart === -1 ? 10 : Math.min(stackStart, 10);
-  return errorMessageLines.slice(0, stackStart).join("\n");
+  if (error.message) {
+    // Error message. Set when [Error] (or its subclass) has been thrown.
+    const errorMessageLines = removeAnsiCodes(error.message)!.split("\n");
+    let stackStart = errorMessageLines.findIndex(l => l.startsWith("Call log:"));
+    stackStart = stackStart == null || stackStart === -1 ? 10 : Math.min(stackStart, 10);
+    return errorMessageLines.slice(0, stackStart).join("\n");
+  } else if (error.value != null) {
+    // The value that was thrown. Set when anything except the [Error] (or its subclass) has been thrown.
+    return error.value;
+  }
+
+  return "Unknown error";
 }
 
 function mapTestStepCategory(step: TestStep): UserActionEvent["data"]["category"] {

--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -27,9 +27,10 @@ export function getMetadataFilePath(workerIndex = 0) {
 }
 
 function extractErrorMessage(error: TestError) {
-  if (error.message) {
+  const message = removeAnsiCodes(error.message);
+  if (message) {
     // Error message. Set when [Error] (or its subclass) has been thrown.
-    const errorMessageLines = removeAnsiCodes(error.message)!.split("\n");
+    const errorMessageLines = message.split("\n");
     let stackStart = errorMessageLines.findIndex(l => l.startsWith("Call log:"));
     stackStart = stackStart == null || stackStart === -1 ? 10 : Math.min(stackStart, 10);
     return errorMessageLines.slice(0, stackStart).join("\n");


### PR DESCRIPTION
## Issue

The error message parsing wasn't handling cases in which non-Error objects were thrown causing a run-time error accessing  `.split()` on an undefined value.

## Resolution

Handle when either `value` or `message` is set with a fallback to "Unknown Error"

Fixes SCS-1413