### PR TITLE
Return entire display error message from cypress

### DIFF
--- a/packages/cypress/src/steps.ts
+++ b/packages/cypress/src/steps.ts
@@ -101,7 +101,7 @@ function getTestsFromResults(
       error: result.displayError
         ? {
             name: "DisplayError",
-            message: result.displayError.substring(0, result.displayError.indexOf("\n")),
+            message: result.displayError,
           }
         : null,
     }));


### PR DESCRIPTION
## Issue

We're sometimes truncating the error returned from cypress in a less-than-useful way
<img width="640" alt="image" src="https://github.com/replayio/replay-cli/assets/788456/ee8a3707-4d43-4822-b2b6-a17283fb59e5">

## Resolution

Return the entire message and allow clients to truncate/scroll/etc it themselves