### PR TITLE
Omit falsey and objects from args in cypress

### DIFF
--- a/packages/cypress/src/steps.ts
+++ b/packages/cypress/src/steps.ts
@@ -54,7 +54,7 @@ function shouldSkipStep(step: StepEvent, skippedSteps: string[]) {
 }
 
 function simplifyArgs(args?: any[]) {
-  return args?.map(a => String(a && typeof a === "object" ? {} : a)) || [];
+  return args?.filter(a => !!a && typeof a !== "object").map(a => String(a)) || [];
 }
 
 function getTestsFromResults(


### PR DESCRIPTION
## Issue

Sometimes Cypress gives us `null` as a value for `args` when using `each`, `then`, or `should` with a function callback.

## Resolution

* Filter out falsey values from args
* Stop showing `[object Object]` for an arg too. It's not helpful to show in the sidebar