### PR TITLE
Adjust event buffering logic

### DIFF
--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -43,6 +43,9 @@ let gLastTest: MochaTest | undefined;
 // it for retries
 let gLastOrder: number | undefined;
 
+let gBuffering = false;
+let gEventBuffer: StepEvent[] = [];
+
 // This lists cypress commands for which we don't need to track in metadata nor
 // create annotations because they are "internal plumbing" commands that aren't
 // user-facing
@@ -208,7 +211,12 @@ const makeEvent = (
     : null),
 });
 
-let eventBuffer: StepEvent[] = [];
+function sendStepsToPlugin(events: StepEvent[]) {
+  for (let i = 0; i < events.length; i += 500) {
+    const partialEvents = events.slice(i, i + 500);
+    cy.task(TASK_NAME, partialEvents, { log: false });
+  }
+}
 
 const handleCypressEvent = (
   testScope: CypressTestScope,
@@ -219,8 +227,13 @@ const handleCypressEvent = (
 ) => {
   if (cmd?.args?.[0] === TASK_NAME) return;
 
-  const arg = makeEvent(testScope, event, category, cmd, error);
-  eventBuffer.push(arg);
+  const stepEvent = makeEvent(testScope, event, category, cmd, error);
+
+  if (gBuffering) {
+    gEventBuffer.push(stepEvent);
+  } else {
+    sendStepsToPlugin([stepEvent]);
+  }
 };
 
 const idMap: Record<string, string> = {};
@@ -582,6 +595,7 @@ export default function register() {
   });
   beforeEach(() => {
     try {
+      gBuffering = true;
       currentTestScope = getCurrentTestScope();
       if (currentTestScope) {
         handleCypressEvent(currentTestScope, "test:start");
@@ -598,9 +612,10 @@ export default function register() {
         addAnnotation(currentTestScope, "test:end");
         handleCypressEvent(currentTestScope, "test:end");
 
-        cy.task(TASK_NAME, eventBuffer, { log: false });
+        sendStepsToPlugin(gEventBuffer);
 
-        eventBuffer = [];
+        gEventBuffer = [];
+        gBuffering = false;
       }
     } catch (e) {
       console.error("Replay: Failed to handle test:end event");


### PR DESCRIPTION
## Issue

We added an `eventBuffer` to reduce the number of tasks sent because it was causing performance issues for larger test suites. Recently, a customer's very large suite seems to be dropping events which I suspect is either caused by them coming in after the last flush or flushes that are too large and being truncated.

## Resolution

* Start and stop buffering in `beforeEach` and `afterEach`. Anything that occurs when not buffering is sent directly through the task. This should address missing events.
* Slice the buffer into 500 element arrays which are dispatched separately. This would address any truncation that could be happening with very large payloads