### PR TITLE
Fix filtering to skip when the filter is an empty string

### DIFF
--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -241,7 +241,7 @@ function updateStatus(recording: RecordingEntry, status: RecordingEntry["status"
 
 function filterRecordings(recordings: RecordingEntry[], filter?: FilterOptions["filter"]) {
   debug("Recording log contains %d replays", recordings.length);
-  if (typeof filter === "string") {
+  if (filter && typeof filter === "string") {
     debug("Using filter: %s", filter);
     const exp = jsonata(`$filter($, ${filter})[]`);
     recordings = exp.evaluate(recordings) || [];


### PR DESCRIPTION
Regression from #240.  `action-upload` passes an empty string to `filter` when its param isn't set which throws a jsonata error when fed through to `$filter()`