### PR TITLE
Allow view-server to be passed to `view-latest`

### DIFF
--- a/packages/replay/src/bin.ts
+++ b/packages/replay/src/bin.ts
@@ -90,11 +90,13 @@ commandWithGlobalOptions("upload-all")
 
 commandWithGlobalOptions("view <id>")
   .description("Load the devtools on a recording, uploading it if needed.")
+  .option("--view-server <view-server>", "Alternate server to view recording from.")
   .option("--api-key <key>", "Authentication API Key")
   .action(commandViewRecording);
 
 commandWithGlobalOptions("view-latest")
   .description("Load the devtools on the latest recording, uploading it if needed.")
+  .option("--view-server <view-server>", "Alternate server to view recording from.")
   .option("--api-key <key>", "Authentication API Key")
   .action(commandViewLatestRecording);
 

--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -559,7 +559,8 @@ async function doViewRecording(
   recording: RecordingEntry,
   verbose?: boolean,
   apiKey?: string,
-  agent?: any
+  agent?: any,
+  viewServer?: string
 ) {
   let recordingId;
   if (recording.status === "crashUploaded") {
@@ -577,9 +578,9 @@ async function doViewRecording(
       return true;
     }
   }
-
+  const devtools = viewServer ?? "https://app.replay.io";
   const dispatch = server != "wss://dispatch.replay.io" ? `&dispatch=${server}` : "";
-  spawn(openExecutable(), [`https://app.replay.io?id=${recordingId}${dispatch}`]);
+  spawn(openExecutable(), [`${devtools}?id=${recordingId}${dispatch}`]);
   return true;
 }
 
@@ -609,7 +610,8 @@ async function viewLatestRecording(opts: Options = {}) {
     recordings[recordings.length - 1],
     opts.verbose,
     opts.apiKey,
-    opts.agent
+    opts.agent,
+    opts.viewServer
   );
 }
 

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -12,6 +12,11 @@ export interface Options {
   server?: string;
 
   /**
+   * Alternate server to use for opening devtools
+   */
+  viewServer?: string;
+
+  /**
    * Authentication API Key
    */
   apiKey?: string;


### PR DESCRIPTION
To support the new dev-flow in https://github.com/replayio/backend/pull/8640