### PR TITLE
Add source metadata via test-utils

### DIFF
--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -104,15 +104,16 @@ class CypressReporter {
     this.reporter.onTestBegin(undefined, getMetadataFilePath());
   }
 
-  onAfterSpec(
-    spec: Cypress.Spec,
-    result: CypressCommandLine.RunResult
-  ): { test: TestRun } | undefined {
+  onAfterSpec(spec: Cypress.Spec, result: CypressCommandLine.RunResult) {
     appendToFixtureFile("spec:end", { spec, result });
 
     const tests = this.getTestResults(spec, result);
 
-    return this.reporter.onTestEnd({ tests, replayTitle: spec.relative, specFile: spec.relative });
+    this.reporter.onTestEnd({ tests, replayTitle: spec.relative, specFile: spec.relative });
+  }
+
+  onEnd() {
+    return this.reporter.onEnd();
   }
 
   getDiagnosticConfig() {

--- a/packages/jest/src/runner.ts
+++ b/packages/jest/src/runner.ts
@@ -85,7 +85,6 @@ const ReplayRunner = async (
   }
 
   function handleResult(test: Circus.TestEntry, passed: boolean) {
-    const title = test.name;
     const errorMessage = getErrorMessage(test.errors);
 
     reporter.onTestEnd({
@@ -117,6 +116,14 @@ const ReplayRunner = async (
 
   const handleTestEventForReplay = (original?: Circus.EventHandler) => {
     const replayHandler: Circus.EventHandler = (event, state) => {
+      if (event.name === "teardown") {
+        return (async () => {
+          await reporter.onEnd();
+
+          original?.(event as any, state);
+        })();
+      }
+
       switch (event.name) {
         case "test_fn_start":
           handleTestStart(event.test);

--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -217,6 +217,10 @@ class ReplayPlaywrightReporter implements Reporter {
       extraMetadata: playwrightMetadata,
     });
   }
+
+  async onEnd() {
+    await this.reporter?.onEnd();
+  }
 }
 
 export default ReplayPlaywrightReporter;

--- a/packages/test-utils/src/logging.ts
+++ b/packages/test-utils/src/logging.ts
@@ -2,9 +2,9 @@ export function log(message: string) {
   console.log("[replay.io]:", message);
 }
 
-export function warn(message: string, e: unknown) {
+export function warn(message: string, e?: unknown) {
   console.warn("[replay.io]:", message);
-  if (e instanceof Error) {
+  if (e && e instanceof Error) {
     console.warn("[replay.io]: Error:", e.message);
   }
 }


### PR DESCRIPTION
* Moves source metadata generation to test-utils so any plugin can take advantage
* Start migrating async work to a new `onEnd` handler in test-utils which can be initiated any time during the run but not block until the test run completes.