### PR TITLE
Add support to test runner plugins for new test run management

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -121,8 +121,9 @@ async function onAfterRun() {
 
   const utilsPendingWork = await cypressReporter.onEnd();
   utilsPendingWork.forEach(entry => {
-    if (entry.type === "recording") {
-      entry.recordings.forEach(recording => {
+    if (entry.type === "upload") {
+      if ("recording" in entry) {
+        const recording = entry.recording;
         if (recording.metadata.test) {
           const tests = (recording.metadata.test as TestMetadataV2.TestRun).tests;
           const completedTests = tests.filter(t =>
@@ -136,7 +137,7 @@ async function onAfterRun() {
             missingSteps = true;
           }
         }
-      });
+      }
     }
   });
 

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -121,22 +121,15 @@ async function onAfterRun() {
 
   const utilsPendingWork = await cypressReporter.onEnd();
   utilsPendingWork.forEach(entry => {
-    if (entry.type === "upload") {
-      if ("recording" in entry) {
-        const recording = entry.recording;
-        if (recording.metadata.test) {
-          const tests = (recording.metadata.test as TestMetadataV2.TestRun).tests;
-          const completedTests = tests.filter(t =>
-            ["passed", "failed", "timedOut"].includes(t.result)
-          );
+    if (entry.type === "upload" && "recording" in entry && entry.recording.metadata.test) {
+      const tests = (entry.recording.metadata.test as TestMetadataV2.TestRun).tests;
+      const completedTests = tests.filter(t => ["passed", "failed", "timedOut"].includes(t.result));
 
-          if (
-            completedTests.length > 0 &&
-            tests.flatMap(t => Object.values(t.events).flat()).length === 0
-          ) {
-            missingSteps = true;
-          }
-        }
+      if (
+        completedTests.length > 0 &&
+        tests.flatMap(t => Object.values(t.events).flat()).length === 0
+      ) {
+        missingSteps = true;
       }
     }
   });

--- a/packages/replay/src/graphql.ts
+++ b/packages/replay/src/graphql.ts
@@ -2,12 +2,12 @@ import dbg from "debug";
 
 const debug = dbg("replay:cli:graphql");
 
-export async function query(name: string, query: string, variables = {}) {
+export async function query(name: string, query: string, variables = {}, apiKey?: string) {
   const options = {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-    },
+    } as Record<string, string>,
     body: JSON.stringify({
       query,
       name,
@@ -15,8 +15,12 @@ export async function query(name: string, query: string, variables = {}) {
     }),
   };
 
+  if (apiKey) {
+    options.headers.Authorization = `Bearer ${apiKey.trim()}`;
+  }
+
   const server = process.env.REPLAY_API_SERVER || "https://api.replay.io";
-  debug("Querying %s graphql endpoint", server);
+  debug("Querying %s over %s graphql endpoint", name, server);
   const result = await fetch(`${server}/v1/graphql`, options);
 
   const json = await result.json();

--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -291,7 +291,12 @@ function uploadSkipReason(recording: RecordingEntry) {
 }
 
 function getServer(opts: Options) {
-  return opts.server || process.env.RECORD_REPLAY_SERVER || "wss://dispatch.replay.io";
+  return (
+    opts.server ||
+    process.env.RECORD_REPLAY_SERVER ||
+    process.env.REPLAY_SERVER ||
+    "wss://dispatch.replay.io"
+  );
 }
 
 function addRecordingEvent(dir: string, kind: string, id: string, tags = {}) {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -27,13 +27,13 @@
   "homepage": "https://github.com/replayio/replay-cli#readme",
   "dependencies": {
     "@replayio/replay": "^0.17.3",
-    "@types/node-fetch": "^2.6.2",
     "debug": "^4.3.4",
     "node-fetch": "^2.6.7",
     "uuid": "^8.3.2"
   },
   "gitHead": "00bd1b69ab1eacc33cb2204d5c0f1bd7ae7f3c40",
   "devDependencies": {
-    "@types/debug": "^4.1.7"
+    "@types/debug": "^4.1.7",
+    "@types/node-fetch": "^2.6.2"
   }
 }

--- a/packages/test-utils/src/logging.ts
+++ b/packages/test-utils/src/logging.ts
@@ -1,5 +1,5 @@
 export function log(message: string) {
-  console.log("[replay.io]:", message);
+  message.split("\n").forEach(m => console.log("[replay.io]:", m));
 }
 
 export function warn(message: string, e?: unknown) {

--- a/packages/test-utils/src/metrics.ts
+++ b/packages/test-utils/src/metrics.ts
@@ -1,7 +1,6 @@
 import dbg from "debug";
 import os from "os";
 import fetch from "node-fetch";
-import { Test } from "./reporter";
 import { TestMetadataV2 } from "@replayio/replay/metadata/test/v2";
 import { warn } from "./logging";
 

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -794,13 +794,18 @@ class ReplayReporter {
     }
 
     if (uploads.length > 0) {
-      log(`🚀 Successfully uploaded ${uploads.length} recordings:\n`);
-
+      const output = [`🚀 Successfully uploaded ${uploads.length} recordings:`];
       const sortedUploads = sortRecordingsByResult(uploads);
       sortedUploads.forEach(r => {
-        log(`${getTestResultEmoji(r)} ${(r.metadata.title as string | undefined) || "Unknown"}`);
-        log(`   ${process.env.REPLAY_VIEW_HOST || "https://app.replay.io"}/recording/${r.id}\n`);
+        output.push(
+          `${getTestResultEmoji(r)} ${(r.metadata.title as string | undefined) || "Unknown"}`
+        );
+        output.push(
+          `   ${process.env.REPLAY_VIEW_HOST || "https://app.replay.io"}/recording/${r.id}\n`
+        );
       });
+
+      log(output.join("\n"));
     }
 
     return results;


### PR DESCRIPTION
* Moves upload support to `test-utils`
* Notifies the backend when test runs start and end and adds tests to run
* Simplifies cypress plugin handlers to get `config` and `options` from module-scoped reporter rather than requiring additional arguments


Example output:

```
[test:replay] [replay.io]: 🕑 Completing some outstanding work ...
[test:replay] [replay.io]: 
[test:replay] [replay.io]: ❌ We encountered some unexpected errors creating your tests on replay.io
[test:replay] [replay.io]:    - Unexpected error starting test run shard: fetch failed
[test:replay] [replay.io]: 
[test:replay] [replay.io]: 🚀 Successfully uploaded 2 recordings:
[test:replay] [replay.io]: 
[test:replay] [replay.io]:    ❌ cypress/e2e/adding-spec.ts
[test:replay] [replay.io]:       https://app.replay.io/recording/2e993ea1-43a8-45e0-aa71-cda030a89faa
[test:replay] [replay.io]: 
[test:replay] [replay.io]:    ✅ cypress/e2e/cast-alias-spec.ts
[test:replay] [replay.io]:       https://app.replay.io/recording/19a10bbf-45dd-4a8c-b258-9bd1298391f1
[test:replay] [replay.io]: 
```