### PR TITLE
Prevent cypress support file from registering twice

### DIFF
--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -3,6 +3,7 @@ import { TASK_NAME } from "./constants";
 
 declare global {
   interface Window {
+    __RECORD_REPLAY_CYPRESS_SUPPORT_HOOK_INSTALLED__?: true;
     __RECORD_REPLAY_ANNOTATION_HOOK__?: (name: string, value: any) => void;
   }
 }
@@ -344,6 +345,14 @@ export default function register() {
   let lastCommand: Cypress.CommandQueue | undefined;
   let lastAssertionCommand: Cypress.CommandQueue | undefined;
   let currentTestScope: CypressTestScope | undefined;
+
+  if (window.top) {
+    if (window.top.__RECORD_REPLAY_CYPRESS_SUPPORT_HOOK_INSTALLED__) {
+      return;
+    }
+
+    window.top.__RECORD_REPLAY_CYPRESS_SUPPORT_HOOK_INSTALLED__ = true;
+  }
 
   Cypress.on("command:enqueued", cmd => {
     try {

--- a/packages/cypress/support.ts
+++ b/packages/cypress/support.ts
@@ -1,6 +1,12 @@
 import register from "./src/support";
 import { PluginFeature, isFeatureEnabled } from "./src/features";
 
+declare global {
+  interface Window {
+    __RECORD_REPLAY_CYPRESS_SUPPORT_HOOK_INSTALLED__?: true;
+  }
+}
+
 if (isFeatureEnabled(Cypress.env("REPLAY_PLUGIN_FEATURES"), PluginFeature.Support)) {
   register();
 }


### PR DESCRIPTION
## Issue

If a user inadvertently imports our support file twice (e.g. because they have a utility file in their support file that they use in a test), it can result it multiple event handlers being attached and multiple commands in the plugin.

## Resolution

Add a global flag indicating our support file was loaded and bail when that is already set.