### PR TITLE
Fix appending replay URLs to junit reports

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -63,6 +63,7 @@ function updateReporters(
   filter: PluginOptions["filter"]
 ) {
   const { reporter, reporterOptions } = config;
+  debug("updateReporter: %o", { reporter, reporterOptions });
   if (reporter !== "junit") {
     return;
   }

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -123,8 +123,19 @@ async function onAfterRun() {
   const utilsPendingWork = await cypressReporter.onEnd();
   utilsPendingWork.forEach(entry => {
     if (entry.type === "upload" && "recording" in entry && entry.recording.metadata.test) {
-      const tests = (entry.recording.metadata.test as TestMetadataV2.TestRun).tests;
+      const testRun = entry.recording.metadata.test as TestMetadataV2.TestRun;
+      const tests = testRun.tests;
       const completedTests = tests.filter(t => ["passed", "failed", "timedOut"].includes(t.result));
+
+      if (cypressReporter) {
+        const spec: Cypress.Spec = {
+          name: testRun.source.title,
+          relative: testRun.source.path,
+          absolute: testRun.source.path,
+        };
+
+        updateReporters(spec, cypressReporter.config, cypressReporter.options.filter);
+      }
 
       if (
         completedTests.length > 0 &&
@@ -156,8 +167,6 @@ function onAfterSpec(spec: Cypress.Spec, result: CypressCommandLine.RunResult) {
   debugEvents("Handling after:spec %s", spec.relative);
   assertReporter(cypressReporter);
   cypressReporter.onAfterSpec(spec, result);
-
-  updateReporters(spec, cypressReporter.config, cypressReporter.options.filter);
 }
 
 function onReplayTask(value: any) {

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -69,7 +69,7 @@ function updateReporters(
   }
 
   const projectBase = path.dirname(config.configFile);
-  const recordings = listAllRecordings({ filter: getSpecFilter(spec, filter) });
+  const recordings = listAllRecordings({ all: true, filter: getSpecFilter(spec, filter) });
   debug("Found %d recordings for %s", recordings.length, spec.relative);
   if (recordings.length === 0) {
     return;


### PR DESCRIPTION
Regression from #257 

After moving metadata to an async operation, the update reporter logic wasn't finding the target replay because the metadata hadn't been added by the time we tried to update the reporter.

Moving the reporter update to the other post-processing logic in `onAfterRun` resolves this.

<img width="1391" alt="image" src="https://github.com/replayio/replay-cli/assets/788456/af9f601e-d2ac-4fab-add9-a50df614cd3a">
