### PR TITLE
Update reporters independent of upload

### DIFF
--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -73,7 +73,13 @@ type UploadPendingWork = PendingWorkEntry<
     recording: RecordingEntry;
   }
 >;
-type PostTestPendingWork = PendingWorkEntry<"post-test">;
+type PostTestPendingWork = PendingWorkEntry<
+  "post-test",
+  {
+    recordings: RecordingEntry[];
+    testRun: TestRun;
+  }
+>;
 type PendingWork =
   | TestRunPendingWork
   | TestRunTestsPendingWork
@@ -736,6 +742,8 @@ class ReplayReporter {
 
     return {
       type: "post-test",
+      recordings,
+      testRun,
     };
   }
 


### PR DESCRIPTION
updateReporters was only triggered when uploading was enabled so non-upload workflows never saw the junit updates.

Added context to the "test-run" pending work so it could trigger the updateReporters call instead.