### PR TITLE
Send cypress events over internal websocket

### DIFF
--- a/packages/cypress/package-lock.json
+++ b/packages/cypress/package-lock.json
@@ -6,18 +6,19 @@
   "packages": {
     "": {
       "name": "@replayio/cypress",
-      "version": "1.3.5",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@replayio/replay": "^0.17.2",
-        "@replayio/test-utils": "^1.1.9",
+        "@replayio/replay": "^0.17.4",
+        "@replayio/test-utils": "^1.2.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
         "semver": "^7.5.2",
         "terminate": "^2.6.1",
         "txml": "^3.2.5",
-        "uuid": "^8.3.2"
+        "uuid": "^8.3.2",
+        "ws": "^8.14.2"
       },
       "bin": {
         "replayio-cypress": "bin/replayio-cypress.js"
@@ -27,6 +28,7 @@
         "@types/node": "^16.11.39",
         "@types/semver": "^7.3.13",
         "@types/uuid": "^9.0.1",
+        "@types/ws": "^8.5.8",
         "cypress": "^10.9.0"
       },
       "peerDependencies": {
@@ -82,9 +84,9 @@
       }
     },
     "node_modules/@replayio/replay": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@replayio/replay/-/replay-0.17.2.tgz",
-      "integrity": "sha512-vqH80tDVOC64bwH1SDngdoset5YllhAGOsRbEs4OjhH0sex3HcXFkLcHZf35xKnhFeBN8P+lIY0gxEqW5Nxl0Q==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@replayio/replay/-/replay-0.17.4.tgz",
+      "integrity": "sha512-UUUF3xl4DrUe2Iup+ZRuzjM3eOgVEZXZ0qduIx3eMWQXwFcowIasUNcTcva3QwPMhCxjHZr7I4KqULVz8prgFg==",
       "dependencies": {
         "@replayio/sourcemap-upload": "^1.1.1",
         "commander": "^7.2.0",
@@ -99,6 +101,26 @@
       },
       "bin": {
         "replay": "bin/replay.js"
+      }
+    },
+    "node_modules/@replayio/replay/node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@replayio/sourcemap-upload": {
@@ -117,12 +139,11 @@
       }
     },
     "node_modules/@replayio/test-utils": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@replayio/test-utils/-/test-utils-1.1.9.tgz",
-      "integrity": "sha512-ok80VPZMhJqvH7Cx7Vo5Az2itYA0Acx99gQ+3yifeLsLpwzgMcmH7PPTO6FXnRXUv2PG4IPlAvmpXkJyjzRzUw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@replayio/test-utils/-/test-utils-1.2.0.tgz",
+      "integrity": "sha512-l8cZvZ+g0pBjPlME6bqbg6vxCY5XYES1Ne4IGWXeK8mXVdGioxaFmfI0m6IzOdzO17Trupxam6Dp0x44TiSRsA==",
       "dependencies": {
-        "@replayio/replay": "^0.17.2",
-        "@types/node-fetch": "^2.6.2",
+        "@replayio/replay": "^0.17.4",
         "debug": "^4.3.4",
         "node-fetch": "^2.6.7",
         "uuid": "^8.3.2"
@@ -146,29 +167,8 @@
     "node_modules/@types/node": {
       "version": "16.11.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.39.tgz",
-      "integrity": "sha512-K0MsdV42vPwm9L6UwhIxMAOmcvH/1OoVkZyCgEtVu4Wx7sElGloy/W7kMBNe/oJ7V/jW9BVt1F6RahH6e7tPXw=="
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/@types/node-fetch/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
+      "integrity": "sha512-K0MsdV42vPwm9L6UwhIxMAOmcvH/1OoVkZyCgEtVu4Wx7sElGloy/W7kMBNe/oJ7V/jW9BVt1F6RahH6e7tPXw==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -193,6 +193,15 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
+      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.9.2",
@@ -351,7 +360,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -631,6 +641,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -819,6 +830,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1901,6 +1913,7 @@
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
       "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1909,6 +1922,7 @@
       "version": "2.1.34",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
       "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.51.0"
       },
@@ -2866,15 +2880,15 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -2950,9 +2964,9 @@
       }
     },
     "@replayio/replay": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@replayio/replay/-/replay-0.17.2.tgz",
-      "integrity": "sha512-vqH80tDVOC64bwH1SDngdoset5YllhAGOsRbEs4OjhH0sex3HcXFkLcHZf35xKnhFeBN8P+lIY0gxEqW5Nxl0Q==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@replayio/replay/-/replay-0.17.4.tgz",
+      "integrity": "sha512-UUUF3xl4DrUe2Iup+ZRuzjM3eOgVEZXZ0qduIx3eMWQXwFcowIasUNcTcva3QwPMhCxjHZr7I4KqULVz8prgFg==",
       "requires": {
         "@replayio/sourcemap-upload": "^1.1.1",
         "commander": "^7.2.0",
@@ -2964,6 +2978,14 @@
         "superstruct": "^0.15.4",
         "text-table": "^0.2.0",
         "ws": "^7.5.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "requires": {}
+        }
       }
     },
     "@replayio/sourcemap-upload": {
@@ -2979,12 +3001,11 @@
       }
     },
     "@replayio/test-utils": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@replayio/test-utils/-/test-utils-1.1.9.tgz",
-      "integrity": "sha512-ok80VPZMhJqvH7Cx7Vo5Az2itYA0Acx99gQ+3yifeLsLpwzgMcmH7PPTO6FXnRXUv2PG4IPlAvmpXkJyjzRzUw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@replayio/test-utils/-/test-utils-1.2.0.tgz",
+      "integrity": "sha512-l8cZvZ+g0pBjPlME6bqbg6vxCY5XYES1Ne4IGWXeK8mXVdGioxaFmfI0m6IzOdzO17Trupxam6Dp0x44TiSRsA==",
       "requires": {
-        "@replayio/replay": "^0.17.2",
-        "@types/node-fetch": "^2.6.2",
+        "@replayio/replay": "^0.17.4",
         "debug": "^4.3.4",
         "node-fetch": "^2.6.7",
         "uuid": "^8.3.2"
@@ -3008,28 +3029,8 @@
     "@types/node": {
       "version": "16.11.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.39.tgz",
-      "integrity": "sha512-K0MsdV42vPwm9L6UwhIxMAOmcvH/1OoVkZyCgEtVu4Wx7sElGloy/W7kMBNe/oJ7V/jW9BVt1F6RahH6e7tPXw=="
-    },
-    "@types/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==",
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
+      "integrity": "sha512-K0MsdV42vPwm9L6UwhIxMAOmcvH/1OoVkZyCgEtVu4Wx7sElGloy/W7kMBNe/oJ7V/jW9BVt1F6RahH6e7tPXw==",
+      "dev": true
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -3054,6 +3055,15 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
+    },
+    "@types/ws": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
+      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yauzl": {
       "version": "2.9.2",
@@ -3162,7 +3172,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -3360,6 +3371,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -3507,7 +3519,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "duplexer": {
       "version": "0.1.2",
@@ -4289,12 +4302,14 @@
     "mime-db": {
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.34",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
       "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "dev": true,
       "requires": {
         "mime-db": "1.51.0"
       }
@@ -5003,9 +5018,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "requires": {}
     },
     "yallist": {

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^16.11.39",
     "@types/semver": "^7.3.13",
     "@types/uuid": "^9.0.1",
+    "@types/ws": "^8.5.8",
     "cypress": "^10.9.0"
   },
   "dependencies": {
@@ -41,7 +42,8 @@
     "semver": "^7.5.2",
     "terminate": "^2.6.1",
     "txml": "^3.2.5",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "ws": "^8.14.2"
   },
   "peerDependencies": {
     "cypress": ">=5.3.0"

--- a/packages/cypress/src/constants.ts
+++ b/packages/cypress/src/constants.ts
@@ -1,2 +1,2 @@
-export const TASK_NAME = "replay-event";
+export const CONNECT_TASK_NAME = "replay-connect";
 export const AFTER_EACH_HOOK = `"after each" hook`;

--- a/packages/cypress/src/server.ts
+++ b/packages/cypress/src/server.ts
@@ -1,0 +1,35 @@
+import dbg from "debug";
+import http from "http";
+import { AddressInfo } from "net";
+import { WebSocketServer } from "ws";
+
+const debug = dbg("replay:cypress:server");
+
+export async function createServer() {
+  debug("Creating websocket server");
+
+  const server = http.createServer();
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on("upgrade", function upgrade(request, socket, head) {
+    debug("Upgrading request");
+    wss.handleUpgrade(request, socket, head, function done(ws) {
+      debug("Upgraded");
+      wss.emit("connection", ws, request);
+    });
+  });
+
+  return new Promise<{ server: WebSocketServer; port: number }>(resolve => {
+    server.listen(
+      {
+        port: 0,
+        host: "0.0.0.0",
+      },
+      () => {
+        const port = (server.address() as AddressInfo).port;
+        debug("Listening on %d", port);
+        resolve({ server: wss, port });
+      }
+    );
+  });
+}

--- a/packages/cypress/src/server.ts
+++ b/packages/cypress/src/server.ts
@@ -22,12 +22,16 @@ export async function createServer() {
   return new Promise<{ server: WebSocketServer; port: number }>(resolve => {
     server.listen(
       {
-        port: 0,
-        host: "0.0.0.0",
+        // Pick any available port unless set by user
+        port: process.env.REPLAY_CYPRESS_SOCKET_PORT
+          ? Number.parseInt(process.env.REPLAY_CYPRESS_SOCKET_PORT)
+          : 0,
+        // Explicitly use ipv4 unless set by user
+        host: process.env.REPLAY_CYPRESS_SOCKET_HOST || "0.0.0.0",
       },
       () => {
-        const port = (server.address() as AddressInfo).port;
-        debug("Listening on %d", port);
+        const { address, port } = server.address() as AddressInfo;
+        debug("Listening on %s on port %d", address, port);
         resolve({ server: wss, port });
       }
     );

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -215,6 +215,10 @@ const makeEvent = (
 });
 
 function sendStepsToPlugin(events: StepEvent[]) {
+  // If the connection to the server hasn't been initialized yet but we do have
+  // a port returned from the plugin, initialize it. Once the socket is open,
+  // send all buffered events and stop buffering so all future events are sent
+  // immediately.
   if (!gPluginServer && gServerPort != null) {
     gPluginServer = new WebSocket(`ws://localhost:${gServerPort}`);
     gPluginServer.onopen = () => {
@@ -224,6 +228,9 @@ function sendStepsToPlugin(events: StepEvent[]) {
   }
 
   if (gBuffering || !gPluginServer) {
+    // Checking gBuffering should be sufficient since it isn't set to false
+    // until the socket is open but for completeness (and to make TS happy) we
+    // buffer when gPluginServer is unset too
     gEventBuffer.push(...events);
   } else {
     gPluginServer.send(JSON.stringify({ events }));

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -1,5 +1,5 @@
 import type { TestMetadataV2 } from "@replayio/test-utils";
-import { TASK_NAME } from "./constants";
+import { CONNECT_TASK_NAME } from "./constants";
 
 declare global {
   interface Window {
@@ -44,8 +44,10 @@ let gLastTest: MochaTest | undefined;
 // it for retries
 let gLastOrder: number | undefined;
 
-let gBuffering = false;
+let gBuffering = true;
 let gEventBuffer: StepEvent[] = [];
+let gServerPort: number | undefined;
+let gPluginServer: WebSocket | undefined;
 
 // This lists cypress commands for which we don't need to track in metadata nor
 // create annotations because they are "internal plumbing" commands that aren't
@@ -213,9 +215,18 @@ const makeEvent = (
 });
 
 function sendStepsToPlugin(events: StepEvent[]) {
-  for (let i = 0; i < events.length; i += 500) {
-    const partialEvents = events.slice(i, i + 500);
-    cy.task(TASK_NAME, partialEvents, { log: false });
+  if (!gPluginServer && gServerPort != null) {
+    gPluginServer = new WebSocket(`ws://localhost:${gServerPort}`);
+    gPluginServer.onopen = () => {
+      gPluginServer!.send(JSON.stringify({ events: gEventBuffer }));
+      gBuffering = false;
+    };
+  }
+
+  if (gBuffering || !gPluginServer) {
+    gEventBuffer.push(...events);
+  } else {
+    gPluginServer.send(JSON.stringify({ events }));
   }
 }
 
@@ -226,15 +237,10 @@ const handleCypressEvent = (
   cmd?: CommandLike,
   error?: TestError
 ) => {
-  if (cmd?.args?.[0] === TASK_NAME) return;
+  if (cmd?.args?.[0] === CONNECT_TASK_NAME) return;
 
   const stepEvent = makeEvent(testScope, event, category, cmd, error);
-
-  if (gBuffering) {
-    gEventBuffer.push(stepEvent);
-  } else {
-    sendStepsToPlugin([stepEvent]);
-  }
+  sendStepsToPlugin([stepEvent]);
 };
 
 const idMap: Record<string, string> = {};
@@ -602,9 +608,20 @@ export default function register() {
       console.error(e);
     }
   });
+
+  before(() => {
+    if (gServerPort == null) {
+      cy.task(CONNECT_TASK_NAME, null, { log: false }).then(v => {
+        if (v && typeof v === "object" && "port" in v && typeof v.port === "number") {
+          gServerPort = v.port;
+        } else {
+          cy.log("[replay.io] Received unexpected response when connecting to plugin");
+        }
+      });
+    }
+  });
   beforeEach(() => {
     try {
-      gBuffering = true;
       currentTestScope = getCurrentTestScope();
       if (currentTestScope) {
         handleCypressEvent(currentTestScope, "test:start");
@@ -620,11 +637,6 @@ export default function register() {
       if (currentTestScope) {
         addAnnotation(currentTestScope, "test:end");
         handleCypressEvent(currentTestScope, "test:end");
-
-        sendStepsToPlugin(gEventBuffer);
-
-        gEventBuffer = [];
-        gBuffering = false;
       }
     } catch (e) {
       console.error("Replay: Failed to handle test:end event");


### PR DESCRIPTION
Fixes SCS-1490

We've worked around a few issues with using `cy.task()` to communicate between the browser and the plugin. Rather than continue to use that mechanism, we can switch to our own websocket channel for IPC.