### PR TITLE
Add runnerGroupId for cypress tests

### DIFF
--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -124,7 +124,12 @@ class CypressReporter {
 
     const tests = this.getTestResults(spec, result);
 
-    this.reporter.onTestEnd({ tests, replayTitle: spec.relative, specFile: spec.relative });
+    this.reporter.onTestEnd({
+      tests,
+      replayTitle: spec.relative,
+      specFile: spec.relative,
+      runnerGroupKey: spec.relative,
+    });
   }
 
   onEnd() {


### PR DESCRIPTION
Adds `runnerGroupId` to the graphql requests to add tests to a run