### PR TITLE
Add options to replay launch

### DIFF
--- a/packages/replay/src/bin.ts
+++ b/packages/replay/src/bin.ts
@@ -195,7 +195,7 @@ async function commandUploadRecording(id: string, opts: CommandLineOptions) {
 
 async function commandLaunchBrowser(
   url: string | undefined,
-  opts: Pick<CommandLineOptions, "warn"> & {
+  opts: Pick<CommandLineOptions, "warn" | "directory"> & {
     browser: string | undefined;
     attach: boolean | undefined;
   }
@@ -208,7 +208,7 @@ async function commandLaunchBrowser(
 
     const attach = opts.attach || false;
 
-    await launchBrowser(browser, [url || "about:blank"], attach);
+    await launchBrowser(browser, [url || "about:blank"], attach, { ...opts, verbose: true });
     process.exit(0);
   } catch (e) {
     console.error("Failed to launch browser");

--- a/packages/replay/src/install.ts
+++ b/packages/replay/src/install.ts
@@ -142,7 +142,7 @@ function getPlatformKey(browserName: BrowserName): PlatformKeys | undefined {
   return undefined;
 }
 
-function getExecutablePath(browserName: BrowserName) {
+function getExecutablePath(browserName: BrowserName, opts?: Options) {
   const overridePathKey = `REPLAY_${browserName.toUpperCase()}_EXECUTABLE_PATH`;
   const overridePath = process.env[overridePathKey];
   if (overridePath) {
@@ -156,7 +156,7 @@ function getExecutablePath(browserName: BrowserName) {
   }
 
   const executablePathParts = EXECUTABLE_PATHS[key];
-  return executablePathParts ? path.join(getRuntimesDirectory(), ...executablePathParts) : null;
+  return executablePathParts ? path.join(getRuntimesDirectory(opts), ...executablePathParts) : null;
 }
 
 /**
@@ -199,7 +199,7 @@ async function installReplayBrowser(
   force = false,
   opts: Options = {}
 ) {
-  const replayDir = getDirectory();
+  const replayDir = getDirectory(opts);
   const browserDir = getRuntimesDirectory(opts);
   const dstDir = path.join(browserDir, dstName);
   const dstExists = fs.existsSync(dstDir);


### PR DESCRIPTION
`replay-launch` will now log before installing a browser and supports specifying a directory into which the browser will be installed and where recordings will be saved.