### PR TITLE
Inherit `stdio` in `launch` + make `browsers` optional for `update-browsers`

### DIFF
--- a/packages/replay/src/bin.ts
+++ b/packages/replay/src/bin.ts
@@ -109,7 +109,7 @@ commandWithGlobalOptions("rm-all")
 
 commandWithGlobalOptions("update-browsers")
   .description("Update browsers used in automation.")
-  .arguments("<browsers...>")
+  .arguments("[<browsers...>]")
   .action(commandUpdateBrowsers);
 
 commandWithGlobalOptions("upload-sourcemaps")

--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -837,6 +837,20 @@ async function launchBrowser(
   if (!attach) {
     proc.unref();
   }
+  else {
+    // Wait for the browser process to finish.
+    await new Promise<void>((resolve, reject) => {
+      proc.on("error", reject);
+      proc.on("exit", (code, signal) => {
+        if (code || signal) {
+          reject(new Error(`Process failed code=${code}, signal=${signal}`));
+        }
+        else {
+          resolve();
+        }
+      });
+  });
+  }
 
   return proc;
 }

--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -832,8 +832,11 @@ async function launchBrowser(
   const proc = spawn(execPath, browserArgs[browserName], {
     detached: !attach,
     env: { ...process.env, RECORD_REPLAY_DIRECTORY: opts?.directory },
+    stdio: "inherit"
   });
-  proc.unref();
+  if (!attach) {
+    proc.unref();
+  }
 
   return proc;
 }


### PR DESCRIPTION
1. Inherit `stdio` in `launch`, s.t. those who want to debug it can (else `RECORD_REPLAY_VERBOSE` is sent to Nirvana).
   * Also, on my Linux machine, not inheriting `stdio` seems to deadlock the browsers. I tried to debug by enabling it, but that just fixes it...
   * Either way, it would be good to have an option for the user to have any chance to get debugging data out and forward it to us, if they are getting stuck :woman_shrugging:
2. Don't `unref` from the child process when `attach` is enabled, and instead wait for it to finish. This way, the `replay launch` process stays in sync with the lifecycle of the runtime. (I have a reason for this change that I will demo hopefully after the weekend.)
3. Make `browsers` optional for `update-browsers`, so its easier to use for the average lazy person (like myself 👀)