### PR TITLE
Allow non-uuids for test run id

### DIFF
--- a/packages/replay/metadata/test/v2.ts
+++ b/packages/replay/metadata/test/v2.ts
@@ -88,7 +88,7 @@ const v2_0_0 = object({
   run: defaulted(
     object({
       id: defaulted(
-        define("uuid", (v: any) => isUuid.v4(v)),
+        string(),
         firstEnvValueOf(
           "REPLAY_METADATA_TEST_RUN_ID",
           "RECORD_REPLAY_METADATA_TEST_RUN_ID",

--- a/packages/replay/metadata/test/v2.ts
+++ b/packages/replay/metadata/test/v2.ts
@@ -6,14 +6,11 @@ import {
   object,
   optional,
   string,
-  define,
   nullable,
   Infer,
   assign,
-  omit,
   record,
 } from "superstruct";
-const isUuid = require("is-uuid");
 
 import { firstEnvValueOf } from "../env";
 

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -155,11 +155,11 @@ export class ReporterError extends Error {
 }
 
 class ReplayReporter {
-  baseId = uuid.validate(
-    process.env.RECORD_REPLAY_METADATA_TEST_RUN_ID || process.env.RECORD_REPLAY_TEST_RUN_ID || ""
-  )
-    ? process.env.RECORD_REPLAY_METADATA_TEST_RUN_ID || process.env.RECORD_REPLAY_TEST_RUN_ID
-    : uuid.v4();
+  baseId =
+    process.env.REPLAY_METADATA_TEST_RUN_ID ||
+    process.env.RECORD_REPLAY_METADATA_TEST_RUN_ID ||
+    process.env.RECORD_REPLAY_TEST_RUN_ID ||
+    uuid.v4();
   testRunShardId: string | null = null;
   baseMetadata: Record<string, any> | null = null;
   schemaVersion: string;


### PR DESCRIPTION
The backend previously expected UUIDs for test run id but that restriction has changed so we can allow any arbitrary string for the test run id which will ease the DX for adoption.