### PR TITLE
Add other run title env variables as fallbacks

### DIFF
--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -247,7 +247,11 @@ class ReplayReporter {
   parseConfig(config: ReplayReporterConfig = {}, metadataKey?: string) {
     // always favor environment variables over config so the config can be
     // overwritten at runtime
-    this.runTitle = process.env.RECORD_REPLAY_TEST_RUN_TITLE || config.runTitle;
+    this.runTitle =
+      process.env.REPLAY_METADATA_TEST_RUN_TITLE ||
+      process.env.RECORD_REPLAY_TEST_RUN_TITLE ||
+      process.env.RECORD_REPLAY_METADATA_TEST_RUN_TITLE ||
+      config.runTitle;
 
     this.apiKey = process.env.REPLAY_API_KEY || process.env.RECORD_REPLAY_API_KEY || config.apiKey;
     this.upload = !!process.env.REPLAY_UPLOAD || !!config.upload;


### PR DESCRIPTION
We have a few different env variable formulas floating around. `test-utils` was only using the oldest for `runTitle` which meant that any users using the correct format would not have their title assigned in the db.