### PR TITLE
Add replay record command to launch and record

### DIFF
--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -831,13 +831,21 @@ async function launchBrowser(
     firefox: ["-foreground", ...args],
   };
 
+  const env = {
+    ...process.env,
+  };
+
+  if (record) {
+    env.RECORD_ALL_CONTENT = "1";
+  }
+
+  if (opts?.directory) {
+    env.RECORD_REPLAY_DIRECTORY = opts?.directory;
+  }
+
   const proc = spawn(execPath, browserArgs[browserName], {
     detached: !opts?.attach,
-    env: {
-      RECORD_ALL_CONTENT: record ? "1" : "",
-      ...process.env,
-      RECORD_REPLAY_DIRECTORY: opts?.directory,
-    },
+    env,
     stdio: "inherit",
   });
   if (!opts?.attach) {

--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -22,6 +22,7 @@ import {
   BrowserName,
   ExternalRecordingEntry,
   FilterOptions,
+  LaunchOptions,
   ListOptions,
   MetadataOptions,
   Options,
@@ -804,9 +805,10 @@ async function updateMetadata({
 async function launchBrowser(
   browserName: BrowserName,
   args: string[] = [],
-  attach: boolean = false,
-  opts?: Options
+  record: boolean = false,
+  opts?: Options & LaunchOptions
 ) {
+  debug("launchBrowser: %s %o %s %o", browserName, args, record, opts);
   const execPath = getExecutablePath(browserName, opts);
   if (!execPath) {
     throw new Error(`${browserName} not supported on the current platform`);
@@ -830,15 +832,15 @@ async function launchBrowser(
   };
 
   const proc = spawn(execPath, browserArgs[browserName], {
-    detached: !attach,
+    detached: !opts?.attach,
     env: {
+      RECORD_ALL_CONTENT: record ? "1" : "",
       ...process.env,
-      RECORD_ALL_CONTENT: "1",
       RECORD_REPLAY_DIRECTORY: opts?.directory,
     },
     stdio: "inherit",
   });
-  if (!attach) {
+  if (!opts?.attach) {
     proc.unref();
   } else {
     // Wait for the browser process to finish.

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -50,6 +50,11 @@ export interface FilterOptions {
   includeCrashes?: boolean;
 }
 
+export interface LaunchOptions {
+  browser?: string;
+  attach?: boolean;
+}
+
 export interface ListOptions extends FilterOptions {
   all?: boolean;
 }


### PR DESCRIPTION
Adds `replay record` command to launch and record and update `replay launch` to only launch the browser. Both now can be manually overridden by setting `RECORD_ALL_CONTENT` in the env.