### PR TITLE
Use CI workflow info for default test run id

### DIFF
--- a/packages/replay/metadata/source.ts
+++ b/packages/replay/metadata/source.ts
@@ -206,12 +206,8 @@ async function expandMergeMetadataFromGitHub(repo: string, pr?: string) {
   }
 }
 
-function buildTestRunId(
-  ciEnv: string | undefined,
-  repository: string | undefined,
-  runId: string | undefined
-) {
-  if (ciEnv) {
+function buildTestRunId(repository: string | undefined, runId: string | undefined) {
+  if (repository && runId) {
     return `${repository}--${runId}`;
   }
 }
@@ -223,22 +219,10 @@ function getTestRunIdFromEnvironment(env: NodeJS.ProcessEnv) {
     process.env.RECORD_REPLAY_TEST_RUN_ID;
 
   let ciTestRunId =
-    buildTestRunId(process.env.GITHUB, process.env.GITHUB_REPOSITORY, process.env.GITHUB_RUN_ID) ||
-    buildTestRunId(
-      process.env.CIRCLECI,
-      process.env.CIRCLE_PROJECT_REPONAME,
-      process.env.CIRCLE_WORKFLOW_ID
-    ) ||
-    buildTestRunId(
-      process.env.BUILDKITE,
-      getBuildkiteRepository(process.env),
-      process.env.BUILDKITE_BUILD_ID
-    ) ||
-    buildTestRunId(
-      process.env.SEMAPHORE,
-      process.env.SEMAPHORE_GIT_REPO_SLUG,
-      process.env.SEMAPHORE_WORKFLOW_ID
-    );
+    buildTestRunId(process.env.GITHUB_REPOSITORY, process.env.GITHUB_RUN_ID) ||
+    buildTestRunId(process.env.CIRCLE_PROJECT_REPONAME, process.env.CIRCLE_WORKFLOW_ID) ||
+    buildTestRunId(getBuildkiteRepository(process.env), process.env.BUILDKITE_BUILD_ID) ||
+    buildTestRunId(process.env.SEMAPHORE_GIT_REPO_SLUG, process.env.SEMAPHORE_WORKFLOW_ID);
 
   return userTestRunId || ciTestRunId;
 }

--- a/packages/replay/metadata/source.ts
+++ b/packages/replay/metadata/source.ts
@@ -77,6 +77,10 @@ function getBuildkiteMessage(env: NodeJS.ProcessEnv) {
   }
 }
 
+function getBuildkiteRepository(env: NodeJS.ProcessEnv) {
+  return env.BUILDKITE_REPO?.match(/.*:(.*)\.git/)?.[1];
+}
+
 let gGitHubEvent: Record<string, any> | null = null;
 
 function readGithubEvent(env: NodeJS.ProcessEnv) {
@@ -202,6 +206,43 @@ async function expandMergeMetadataFromGitHub(repo: string, pr?: string) {
   }
 }
 
+function buildTestRunId(
+  ciEnv: string | undefined,
+  repository: string | undefined,
+  runId: string | undefined
+) {
+  if (ciEnv) {
+    return `${repository}--${runId}`;
+  }
+}
+
+function getTestRunIdFromEnvironment(env: NodeJS.ProcessEnv) {
+  const userTestRunId =
+    process.env.REPLAY_METADATA_TEST_RUN_ID ||
+    process.env.RECORD_REPLAY_METADATA_TEST_RUN_ID ||
+    process.env.RECORD_REPLAY_TEST_RUN_ID;
+
+  let ciTestRunId =
+    buildTestRunId(process.env.GITHUB, process.env.GITHUB_REPOSITORY, process.env.GITHUB_RUN_ID) ||
+    buildTestRunId(
+      process.env.CIRCLECI,
+      process.env.CIRCLE_PROJECT_REPONAME,
+      process.env.CIRCLE_WORKFLOW_ID
+    ) ||
+    buildTestRunId(
+      process.env.BUILDKITE,
+      getBuildkiteRepository(process.env),
+      process.env.BUILDKITE_BUILD_ID
+    ) ||
+    buildTestRunId(
+      process.env.SEMAPHORE,
+      process.env.SEMAPHORE_GIT_REPO_SLUG,
+      process.env.SEMAPHORE_WORKFLOW_ID
+    );
+
+  return userTestRunId || ciTestRunId;
+}
+
 const versions: () => Record<number, Struct> = () => ({
   1: object({
     branch: optional(
@@ -241,8 +282,8 @@ const versions: () => Record<number, Struct> = () => ({
         envString(
           "RECORD_REPLAY_METADATA_SOURCE_TRIGGER_WORKFLOW",
           "GITHUB_RUN_ID",
-          "BUILDKITE_BUILD_NUMBER",
-          "CIRCLE_BUILD_NUM",
+          "BUILDKITE_BUILD_ID",
+          "CIRCLE_WORKFLOW_ID",
           "SEMAPHORE_WORKFLOW_ID"
         )
       ),
@@ -291,7 +332,7 @@ const versions: () => Record<number, Struct> = () => ({
       envString(
         "RECORD_REPLAY_METADATA_SOURCE_REPOSITORY",
         "GITHUB_REPOSITORY",
-        env => env.BUILDKITE_REPO?.match(/.*:(.*)\.git/)?.[1],
+        getBuildkiteRepository,
         getCircleCIRepository,
         "SEMAPHORE_GIT_REPO_SLUG"
       )
@@ -360,4 +401,4 @@ async function init(data: UnstructuredMetadata = {}) {
   }
 }
 
-export { validate, init };
+export { validate, init, getTestRunIdFromEnvironment };

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -155,11 +155,7 @@ export class ReporterError extends Error {
 }
 
 class ReplayReporter {
-  baseId =
-    process.env.REPLAY_METADATA_TEST_RUN_ID ||
-    process.env.RECORD_REPLAY_METADATA_TEST_RUN_ID ||
-    process.env.RECORD_REPLAY_TEST_RUN_ID ||
-    uuid.v4();
+  baseId = sourceMetadata.getTestRunIdFromEnvironment(process.env) || uuid.v4();
   testRunShardId: string | null = null;
   baseMetadata: Record<string, any> | null = null;
   schemaVersion: string;


### PR DESCRIPTION
Now that our backend supports non-UUID test run ids, we can use CI environment variables to construct a better default test run ID without requiring users to configure one manually when sharding their test run.