### PR TITLE
Sort recording log entries to ensure that createRecording is first

### DIFF
--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -33,225 +33,19 @@ import {
   UploadAllOptions,
 } from "./types";
 import { add, sanitize, source as sourceMetadata, test as testMetadata } from "../metadata";
-import { generateDefaultTitle } from "./generateDefaultTitle";
 import jsonata from "jsonata";
 import { readToken } from "./auth";
+import {
+  readRecordings,
+  removeRecordingsFile,
+  removeRecordingFromLog,
+  addRecordingEvent,
+} from "./recordingLog";
 export type { BrowserName, RecordingEntry } from "./types";
 
 const debug = dbg("replay:cli");
 
-function getRecordingsFile(dir: string) {
-  return path.join(dir, "recordings.log");
-}
-
-function readRecordingFile(dir: string) {
-  const file = getRecordingsFile(dir);
-  if (!fs.existsSync(file)) {
-    return [];
-  }
-
-  return fs.readFileSync(file, "utf8").split("\n");
-}
-
-function writeRecordingFile(dir: string, lines: string[]) {
-  // Add a trailing newline so the driver can safely append logs
-  fs.writeFileSync(getRecordingsFile(dir), lines.join("\n") + "\n");
-}
-
-function getBuildRuntime(buildId: string) {
-  const match = /.*?-(.*?)-/.exec(buildId);
-  return match ? match[1] : "unknown";
-}
-
-const RECORDING_LOG_KIND = [
-  "createRecording",
-  "addMetadata",
-  "writeStarted",
-  "sourcemapAdded",
-  "originalSourceAdded",
-  "writeFinished",
-  "uploadStarted",
-  "uploadFinished",
-  "recordingUnusable",
-  "crashed",
-  "crashData",
-  "crashUploaded",
-] as const;
-
-interface RecordingLogEntry {
-  [key: string]: any;
-  kind: typeof RECORDING_LOG_KIND[number];
-}
-
-function readRecordings(dir: string, includeHidden = false) {
-  const recordings: RecordingEntry[] = [];
-  const lines = readRecordingFile(dir)
-    .map(line => {
-      try {
-        return JSON.parse(line) as RecordingLogEntry;
-      } catch {
-        return null;
-      }
-    })
-    .filter((o): o is RecordingLogEntry => o != null)
-    .sort((a, b) => RECORDING_LOG_KIND.indexOf(a.kind) - RECORDING_LOG_KIND.indexOf(b.kind));
-
-  for (const obj of lines) {
-    switch (obj.kind) {
-      case "createRecording": {
-        const { id, timestamp, buildId } = obj;
-        recordings.push({
-          id,
-          createTime: new Date(timestamp),
-          buildId,
-          runtime: getBuildRuntime(buildId),
-          metadata: {},
-          sourcemaps: [],
-
-          // We use an unknown status after the createRecording event because
-          // there should always be later events describing what happened to the
-          // recording.
-          status: "unknown",
-        });
-        break;
-      }
-      case "addMetadata": {
-        const { id, metadata } = obj;
-        const recording = recordings.find(r => r.id == id);
-        if (recording) {
-          Object.assign(recording.metadata, metadata);
-
-          if (!recording.metadata.title) {
-            recording.metadata.title = generateDefaultTitle(recording.metadata);
-          }
-        }
-        break;
-      }
-      case "writeStarted": {
-        const { id, path } = obj;
-        const recording = recordings.find(r => r.id == id);
-        if (recording) {
-          updateStatus(recording, "startedWrite");
-          recording.path = path;
-        }
-        break;
-      }
-      case "writeFinished": {
-        const { id } = obj;
-        const recording = recordings.find(r => r.id == id);
-        if (recording) {
-          updateStatus(recording, "onDisk");
-        }
-        break;
-      }
-      case "uploadStarted": {
-        const { id, server, recordingId } = obj;
-        const recording = recordings.find(r => r.id == id);
-        if (recording) {
-          updateStatus(recording, "startedUpload");
-          recording.server = server;
-          recording.recordingId = recordingId;
-        }
-        break;
-      }
-      case "uploadFinished": {
-        const { id } = obj;
-        const recording = recordings.find(r => r.id == id);
-        if (recording) {
-          updateStatus(recording, "uploaded");
-        }
-        break;
-      }
-      case "recordingUnusable": {
-        const { id, reason } = obj;
-        const recording = recordings.find(r => r.id == id);
-        if (recording) {
-          updateStatus(recording, "unusable");
-          recording.unusableReason = reason;
-        }
-        break;
-      }
-      case "crashed": {
-        const { id } = obj;
-        const recording = recordings.find(r => r.id == id);
-        if (recording) {
-          updateStatus(recording, "crashed");
-        }
-        break;
-      }
-      case "crashData": {
-        const { id, data } = obj;
-        const recording = recordings.find(r => r.id == id);
-        if (recording) {
-          if (!recording.crashData) {
-            recording.crashData = [];
-          }
-          recording.crashData.push(data);
-        }
-        break;
-      }
-      case "crashUploaded": {
-        const { id } = obj;
-        const recording = recordings.find(r => r.id == id);
-        if (recording) {
-          updateStatus(recording, "crashUploaded");
-        }
-        break;
-      }
-      case "sourcemapAdded": {
-        const {
-          id,
-          recordingId,
-          path,
-          baseURL,
-          targetContentHash,
-          targetURLHash,
-          targetMapURLHash,
-        } = obj;
-        const recording = recordings.find(r => r.id == recordingId);
-        if (recording) {
-          recording.sourcemaps.push({
-            id,
-            path,
-            baseURL,
-            targetContentHash,
-            targetURLHash,
-            targetMapURLHash,
-            originalSources: [],
-          });
-        }
-        break;
-      }
-      case "originalSourceAdded": {
-        const { recordingId, path, parentId, parentOffset } = obj;
-        const recording = recordings.find(r => r.id === recordingId);
-        if (recording) {
-          const sourcemap = recording.sourcemaps.find(s => s.id === parentId);
-          if (sourcemap) {
-            sourcemap.originalSources.push({
-              path,
-              parentOffset,
-            });
-          }
-        }
-        break;
-      }
-    }
-  }
-
-  if (includeHidden) {
-    return recordings;
-  }
-
-  // There can be a fair number of recordings from gecko/chromium content
-  // processes which never loaded any interesting content. These are ignored by
-  // most callers. Note that we're unable to avoid generating these entries in
-  // the first place because the recordings log is append-only and we don't know
-  // when a recording process starts if it will ever do anything interesting.
-  return recordings.filter(r => !(r.unusableReason || "").includes("No interesting content"));
-}
-
-function updateStatus(recording: RecordingEntry, status: RecordingEntry["status"]) {
+export function updateStatus(recording: RecordingEntry, status: RecordingEntry["status"]) {
   // Once a recording enters an unusable or crashed status, don't change it
   // except to mark crashes as uploaded.
   if (
@@ -303,8 +97,7 @@ function listRecording(recording: RecordingEntry): ExternalRecordingEntry {
 }
 
 function listAllRecordings(opts: Options & ListOptions = {}) {
-  const dir = getDirectory(opts);
-  const recordings = readRecordings(dir);
+  const recordings = readRecordings(opts.directory);
 
   if (opts.all) {
     return filterRecordings(recordings, opts.filter, opts.includeCrashes).map(listRecording);
@@ -337,19 +130,6 @@ function getServer(opts: Options) {
     process.env.REPLAY_SERVER ||
     "wss://dispatch.replay.io"
   );
-}
-
-function addRecordingEvent(dir: string, kind: string, id: string, tags = {}) {
-  const event = {
-    kind,
-    id,
-    timestamp: Date.now(),
-    ...tags,
-  };
-  debug("Writing event to recording log %o", event);
-  const lines = readRecordingFile(dir);
-  lines.push(JSON.stringify(event));
-  writeRecordingFile(dir, lines);
 }
 
 async function doUploadCrash(
@@ -707,20 +487,7 @@ function removeRecording(id: string, opts: Options = {}) {
     return false;
   }
   removeRecordingAssets(recording, opts);
-
-  const lines = readRecordingFile(dir).filter(line => {
-    try {
-      const obj = JSON.parse(line);
-      if (obj.id == id) {
-        return false;
-      }
-    } catch (e) {
-      return false;
-    }
-    return true;
-  });
-
-  writeRecordingFile(dir, lines);
+  removeRecordingFromLog(dir, id);
   return true;
 }
 
@@ -754,15 +521,12 @@ function removeRecordingAssets(recording: RecordingEntry, opts?: Pick<Options, "
   });
 }
 
-function removeAllRecordings(opts = {}) {
+function removeAllRecordings(opts: Options = {}) {
   const dir = getDirectory(opts);
   const recordings = readRecordings(dir);
   recordings.forEach(r => removeRecordingAssets(r, opts));
 
-  const file = getRecordingsFile(dir);
-  if (fs.existsSync(file)) {
-    fs.unlinkSync(file);
-  }
+  removeRecordingsFile(dir);
 }
 
 function addLocalRecordingMetadata(recordingId: string, metadata: Record<string, unknown>) {

--- a/packages/replay/src/recordingLog.test.ts
+++ b/packages/replay/src/recordingLog.test.ts
@@ -1,0 +1,35 @@
+import { readRecordings } from "./recordingLog";
+import { tmpdir } from "os";
+import path from "path";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+
+describe("recordingLog", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = path.join(tmpdir(), Math.floor(Math.random() * 100000).toString(16));
+    mkdirSync(dir);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { force: true, recursive: true });
+  });
+
+  function writeTestCase(testCase: string) {
+    writeFileSync(path.join(dir, "recordings.log"), testCase, "utf-8");
+  }
+
+  it("should handle source map events before createRecording", async () => {
+    writeTestCase(`
+      {"kind":"sourcemapAdded","path":"/Users/ryan/.replay/sourcemap-eabb79b2a92a89eee953c1c052e614ad0ae19cdfafba598576b250d8cadb2140.map","recordingId":"60e36c77-3aad-46d5-902f-cf37bd3bff92","id":"eabb79b2a92a89eee953c1c052e614ad0ae19cdfafba598576b250d8cadb2140","url":"https://devtools-git-2023-11-29-testsuites-nux-1-recordreplay.vercel.app/_next/static/chunks/webpack-2b35d1198a807748.js.map","baseURL":"https://devtools-git-2023-11-29-testsuites-nux-1-recordreplay.vercel.app/_next/static/chunks/webpack-2b35d1198a807748.js.map","targetContentHash":"sha256:eabb79b2a92a89eee953c1c052e614ad0ae19cdfafba598576b250d8cadb2140","targetURLHash":"sha256:126ef596a4efc04607a183402a919a81e4057d7188cdc875746d5b25e3b614fc","targetMapURLHash":"sha256:ff0dccd318786108b6ea2c5824cd4ac5091cb3d5217cb24abb883f742a872f33"}
+      {"buildId":"macOS-chromium-20231130-d0df72d13090-718eb1da92df","driverVersion":"linker-macOS-12424-718eb1da92df","id":"60e36c77-3aad-46d5-902f-cf37bd3bff92","kind":"createRecording","timestamp":1701729042262}
+      {"id":"60e36c77-3aad-46d5-902f-cf37bd3bff92","kind":"addMetadata","metadata":{"uri":"https://devtools-git-2023-11-29-testsuites-nux-1-recordreplay.vercel.app/team/dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI=/runs/961a049e-a7db-46db-9d0c-c3954626b75e?param=dzowNDAyOGMwYS05ZjM1LTQ2ZjktYTkwYi1jNzJkMTIzNzUxOTI%3D&param=runs"},"timestamp":1701729042262}
+      {"id":"60e36c77-3aad-46d5-902f-cf37bd3bff92","kind":"writeStarted","path":"/Users/ryan/.replay/recording-60e36c77-3aad-46d5-902f-cf37bd3bff92.dat","timestamp":1701729042262}
+      {"id":"60e36c77-3aad-46d5-902f-cf37bd3bff92","kind":"writeFinished","timestamp":1701729046248}
+    `);
+
+    const recordings = readRecordings(dir);
+    expect(recordings[0]).not.toBeNull();
+    expect(recordings[0].sourcemaps.length).toBe(1);
+  });
+});

--- a/packages/replay/src/recordingLog.ts
+++ b/packages/replay/src/recordingLog.ts
@@ -1,0 +1,253 @@
+import dbg from "debug";
+import fs from "fs";
+import path from "path";
+import { RecordingEntry } from "./types";
+import { generateDefaultTitle } from "./generateDefaultTitle";
+import { updateStatus } from "./main";
+import { getDirectory } from "./utils";
+
+const debug = dbg("replay:cli:recording-log");
+
+function getRecordingsFile(dir: string) {
+  return path.join(dir, "recordings.log");
+}
+function readRecordingFile(dir: string) {
+  const file = getRecordingsFile(dir);
+  if (!fs.existsSync(file)) {
+    return [];
+  }
+
+  return fs.readFileSync(file, "utf8").split("\n");
+}
+function writeRecordingFile(dir: string, lines: string[]) {
+  // Add a trailing newline so the driver can safely append logs
+  fs.writeFileSync(getRecordingsFile(dir), lines.join("\n") + "\n");
+}
+function getBuildRuntime(buildId: string) {
+  const match = /.*?-(.*?)-/.exec(buildId);
+  return match ? match[1] : "unknown";
+}
+const RECORDING_LOG_KIND = [
+  "createRecording",
+  "addMetadata",
+  "writeStarted",
+  "sourcemapAdded",
+  "originalSourceAdded",
+  "writeFinished",
+  "uploadStarted",
+  "uploadFinished",
+  "recordingUnusable",
+  "crashed",
+  "crashData",
+  "crashUploaded",
+] as const;
+interface RecordingLogEntry {
+  [key: string]: any;
+  kind: typeof RECORDING_LOG_KIND[number];
+}
+export function readRecordings(dir?: string, includeHidden = false) {
+  dir = getDirectory({ directory: dir });
+  const recordings: RecordingEntry[] = [];
+  const lines = readRecordingFile(dir)
+    .map(line => {
+      try {
+        return JSON.parse(line) as RecordingLogEntry;
+      } catch {
+        return null;
+      }
+    })
+    .filter((o): o is RecordingLogEntry => o != null)
+    .sort((a, b) => RECORDING_LOG_KIND.indexOf(a.kind) - RECORDING_LOG_KIND.indexOf(b.kind));
+
+  for (const obj of lines) {
+    switch (obj.kind) {
+      case "createRecording": {
+        const { id, timestamp, buildId } = obj;
+        recordings.push({
+          id,
+          createTime: new Date(timestamp),
+          buildId,
+          runtime: getBuildRuntime(buildId),
+          metadata: {},
+          sourcemaps: [],
+
+          // We use an unknown status after the createRecording event because
+          // there should always be later events describing what happened to the
+          // recording.
+          status: "unknown",
+        });
+        break;
+      }
+      case "addMetadata": {
+        const { id, metadata } = obj;
+        const recording = recordings.find(r => r.id == id);
+        if (recording) {
+          Object.assign(recording.metadata, metadata);
+
+          if (!recording.metadata.title) {
+            recording.metadata.title = generateDefaultTitle(recording.metadata);
+          }
+        }
+        break;
+      }
+      case "writeStarted": {
+        const { id, path } = obj;
+        const recording = recordings.find(r => r.id == id);
+        if (recording) {
+          updateStatus(recording, "startedWrite");
+          recording.path = path;
+        }
+        break;
+      }
+      case "writeFinished": {
+        const { id } = obj;
+        const recording = recordings.find(r => r.id == id);
+        if (recording) {
+          updateStatus(recording, "onDisk");
+        }
+        break;
+      }
+      case "uploadStarted": {
+        const { id, server, recordingId } = obj;
+        const recording = recordings.find(r => r.id == id);
+        if (recording) {
+          updateStatus(recording, "startedUpload");
+          recording.server = server;
+          recording.recordingId = recordingId;
+        }
+        break;
+      }
+      case "uploadFinished": {
+        const { id } = obj;
+        const recording = recordings.find(r => r.id == id);
+        if (recording) {
+          updateStatus(recording, "uploaded");
+        }
+        break;
+      }
+      case "recordingUnusable": {
+        const { id, reason } = obj;
+        const recording = recordings.find(r => r.id == id);
+        if (recording) {
+          updateStatus(recording, "unusable");
+          recording.unusableReason = reason;
+        }
+        break;
+      }
+      case "crashed": {
+        const { id } = obj;
+        const recording = recordings.find(r => r.id == id);
+        if (recording) {
+          updateStatus(recording, "crashed");
+        }
+        break;
+      }
+      case "crashData": {
+        const { id, data } = obj;
+        const recording = recordings.find(r => r.id == id);
+        if (recording) {
+          if (!recording.crashData) {
+            recording.crashData = [];
+          }
+          recording.crashData.push(data);
+        }
+        break;
+      }
+      case "crashUploaded": {
+        const { id } = obj;
+        const recording = recordings.find(r => r.id == id);
+        if (recording) {
+          updateStatus(recording, "crashUploaded");
+        }
+        break;
+      }
+      case "sourcemapAdded": {
+        const {
+          id,
+          recordingId,
+          path,
+          baseURL,
+          targetContentHash,
+          targetURLHash,
+          targetMapURLHash,
+        } = obj;
+        const recording = recordings.find(r => r.id == recordingId);
+        if (recording) {
+          recording.sourcemaps.push({
+            id,
+            path,
+            baseURL,
+            targetContentHash,
+            targetURLHash,
+            targetMapURLHash,
+            originalSources: [],
+          });
+        }
+        break;
+      }
+      case "originalSourceAdded": {
+        const { recordingId, path, parentId, parentOffset } = obj;
+        const recording = recordings.find(r => r.id === recordingId);
+        if (recording) {
+          const sourcemap = recording.sourcemaps.find(s => s.id === parentId);
+          if (sourcemap) {
+            sourcemap.originalSources.push({
+              path,
+              parentOffset,
+            });
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  if (includeHidden) {
+    return recordings;
+  }
+
+  // There can be a fair number of recordings from gecko/chromium content
+  // processes which never loaded any interesting content. These are ignored by
+  // most callers. Note that we're unable to avoid generating these entries in
+  // the first place because the recordings log is append-only and we don't know
+  // when a recording process starts if it will ever do anything interesting.
+  return recordings.filter(r => !(r.unusableReason || "").includes("No interesting content"));
+}
+
+function addRecordingEvent(dir: string, kind: string, id: string, tags = {}) {
+  const event = {
+    kind,
+    id,
+    timestamp: Date.now(),
+    ...tags,
+  };
+  debug("Writing event to recording log %o", event);
+  const lines = readRecordingFile(dir);
+  lines.push(JSON.stringify(event));
+  writeRecordingFile(dir, lines);
+}
+
+function removeRecordingsFile(dir: string) {
+  const file = getRecordingsFile(dir);
+  if (fs.existsSync(file)) {
+    fs.unlinkSync(file);
+  }
+}
+
+function removeRecordingFromLog(dir: string, id: string) {
+  const lines = readRecordingFile(dir).filter(line => {
+    try {
+      const obj = JSON.parse(line);
+      if (obj.id == id) {
+        return false;
+      }
+    } catch (e) {
+      return false;
+    }
+    return true;
+  });
+
+  writeRecordingFile(dir, lines);
+}
+
+export { readRecordingFile, removeRecordingFromLog, removeRecordingsFile, addRecordingEvent };


### PR DESCRIPTION
* Sorts events in the recording log by type so we ensure we handle the `createRecording` first
* Refactors the recording log functions into a separate file and adds a test for this bug