### PR TITLE
Catch errors from recording upload

### DIFF
--- a/packages/replay/src/utils.test.ts
+++ b/packages/replay/src/utils.test.ts
@@ -1,19 +1,31 @@
 import { exponentialBackoffRetry } from "./utils";
 
 describe("exponentialBackoffRetry", () => {
-  it("retries up to five times", () => {
-    const failingFunction = jest.fn(() => {
+  it("retries up to five times", async () => {
+    const failingFunction = jest.fn(async () => {
       throw Error("ExpectedError");
     });
 
-    expect(async () => await exponentialBackoffRetry(failingFunction)).rejects.toThrow();
+    await expect(async () => await exponentialBackoffRetry(failingFunction)).rejects.toThrow();
+
+    expect(failingFunction).toHaveBeenCalledTimes(5);
+  });
+
+  it("retries with an async callback", async () => {
+    const failingFunction = jest.fn(() => {
+      throw new Error("ExpectedError");
+    });
+
+    await expect(
+      async () => await exponentialBackoffRetry(async () => await failingFunction())
+    ).rejects.toThrow();
 
     expect(failingFunction).toHaveBeenCalledTimes(5);
   });
 
   it("retries until it succeeds", async () => {
     let i = 0;
-    const failingFunction = jest.fn(() => {
+    const failingFunction = jest.fn(async () => {
       i++;
       if (i < 3) {
         throw Error("ExpectedError");

--- a/packages/replay/src/utils.ts
+++ b/packages/replay/src/utils.ts
@@ -80,7 +80,7 @@ export async function exponentialBackoffRetry<T>(
   while (currentAttempt <= MAX_ATTEMPTS) {
     currentAttempt++;
     try {
-      return fn();
+      return await fn();
     } catch (e) {
       if (onFail) {
         onFail(e);


### PR DESCRIPTION
## Issue

When the `PUT` fails, the response will be a non-200 status but that doesn't cause `fetch` to throw so we were reporting successful uploads when they had actually failed.

## Resolution

* Adds response status handling which throws on non-200 errors
* Fixes `exponentialBackOff` to `await` its callback