### PR TITLE
Wait for trailing events from cypress support file before ending spec

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -165,7 +165,7 @@ function onBeforeSpec(spec: Cypress.Spec) {
 function onAfterSpec(spec: Cypress.Spec, result: CypressCommandLine.RunResult) {
   debugEvents("Handling after:spec %s", spec.relative);
   assertReporter(cypressReporter);
-  cypressReporter.onAfterSpec(spec, result);
+  return cypressReporter.onAfterSpec(spec, result);
 }
 
 function onReplayTask(value: any) {


### PR DESCRIPTION
## Issue

Step events from cypress can sometimes be delayed such that they arrive after Cypress calls `after:spec` causing the metadata to be missing tests or steps.

## Resolution

Add some retry logic to wait (in 250ms increments) until the count of steps stabilizes as an indicator that all the steps have arrived.