### PR TITLE
Fix test id lookup for cypress tests

### DIFF
--- a/packages/cypress/src/steps.ts
+++ b/packages/cypress/src/steps.ts
@@ -67,7 +67,7 @@ function getTestsFromResults(
 
   function getIdForTest(result: CypressCommandLine.TestResult) {
     const startEventIndex = startEvents.findIndex(
-      e => e.test.every((t, i) => result.title[i]) && e.test.length === result.title.length
+      e => e.test.every((t, i) => t === result.title[i]) && e.test.length === result.title.length
     );
     if (startEventIndex !== -1) {
       const startEvent = startEvents.splice(startEventIndex, 1)[0];


### PR DESCRIPTION
## Issue

When a spec file contains a skipped test, the plugin was incorrectly linking steps to the wrong test.

## Analysis

This was caused by bad logic finding the `test:start` event for the test because it was supposed to be comparing the titles of the test and the step but was actually just asserting that the test title was valued and had the same number of parts as the step. The result of this is that (generally) the next remaining test was always returned. This generally worked because the `test:start` events match the order of the results and tests are skipped.

When a test is skipped in the middle of the spec file, the plugin would use this faulty logic and incorrectly associate the skipped test with the test id for the next valid test. This is already wrong but would then cause a future test to throw unexpectedly in devtools because it had a `passed` result but an `id` that doesn't match up to a `test:start` annotation.

## Resolution

Compare titles correctly