### PR TITLE
Ignore replay-connect callback event

### DIFF
--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -62,16 +62,19 @@ function handleReplayConnectResponse(v: unknown) {
   }
 }
 
+function isReplayConnectCallbackCommand(cmd: Cypress.EnqueuedCommand) {
+  return (
+    cmd.name === "then" && Array.isArray(cmd.args) && cmd.args[0] === handleReplayConnectResponse
+  );
+}
+
 function shouldIgnoreCommand(cmd: Cypress.EnqueuedCommand | Cypress.CommandQueue) {
   if (isCommandQueue(cmd)) {
     cmd = cmd.toJSON() as any as Cypress.EnqueuedCommand;
   }
 
-  if (
-    cmd.name === "then" &&
-    Array.isArray(cmd.args) &&
-    cmd.args[0] === handleReplayConnectResponse
-  ) {
+  if (isReplayConnectCallbackCommand(cmd)) {
+    // We don't want to track the `then` callback from our replay-connect task
     return true;
   }
 


### PR DESCRIPTION
## Issue

The plugin is adding `then` commands from our `replay-connect` callback to the `beforeAll` steps for each test. This wasn't currently visible to users because we aren't showing `beforeAll` and `afterAll` yet but it was introducing some confusion in troubleshooting SCS-1642 because there were events in places we didn't expect them to be.

## Resolution

Suppress our `handleReplayConnectResponse` handler called by `then` from being added to steps and from creating annotations.