### PR TITLE
Add attempt to test id context

### DIFF
--- a/packages/jest/src/runner.ts
+++ b/packages/jest/src/runner.ts
@@ -6,6 +6,7 @@ import {
   removeAnsiCodes,
   getMetadataFilePath as getMetadataFilePathBase,
   initMetadataFile,
+  TestIdContext,
 } from "@replayio/test-utils";
 import type Runtime from "jest-runtime";
 import path from "path";
@@ -62,6 +63,14 @@ const ReplayRunner = async (
     };
   }
 
+  function getTestIdContext(test: Circus.TestEntry): TestIdContext {
+    const source = getSource(test);
+    return {
+      ...source,
+      attempt: test.invocations,
+    };
+  }
+
   function getWorkerIndex() {
     return +(process.env.JEST_WORKER_ID || 0);
   }
@@ -73,7 +82,7 @@ const ReplayRunner = async (
   }
 
   function handleTestStart(test: Circus.TestEntry) {
-    reporter.onTestBegin(getSource(test), getMetadataFilePath(getWorkerIndex()));
+    reporter.onTestBegin(getTestIdContext(test), getMetadataFilePath(getWorkerIndex()));
   }
 
   function getErrorMessage(errors: any[]) {

--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -14,6 +14,7 @@ import {
   removeAnsiCodes,
   TestMetadataV2,
   getMetadataFilePath as getMetadataFilePathBase,
+  TestIdContext,
 } from "@replayio/test-utils";
 
 type UserActionEvent = TestMetadataV2.UserActionEvent;
@@ -108,6 +109,13 @@ class ReplayPlaywrightReporter implements Reporter {
     };
   }
 
+  getTestIdContext(test: TestCase, testResult: TestResult): TestIdContext {
+    return {
+      ...this.getSource(test),
+      attempt: testResult.retry + 1,
+    };
+  }
+
   onBegin(config: FullConfig) {
     const cfg = this.parseConfig(config);
     this.reporter = new ReplayReporter(
@@ -126,7 +134,10 @@ class ReplayPlaywrightReporter implements Reporter {
   }
 
   onTestBegin(test: TestCase, testResult: TestResult) {
-    this.reporter?.onTestBegin(this.getSource(test), getMetadataFilePath(testResult.workerIndex));
+    this.reporter?.onTestBegin(
+      this.getTestIdContext(test, testResult),
+      getMetadataFilePath(testResult.workerIndex)
+    );
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
@@ -191,7 +202,7 @@ class ReplayPlaywrightReporter implements Reporter {
       tests: [
         {
           id: 0,
-          attempt: 1,
+          attempt: result.retry + 1,
           approximateDuration: test.results.reduce((acc, r) => acc + r.duration, 0),
           source: this.getSource(test),
           result: (status as any) === "interrupted" ? "unknown" : status,

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,6 +1,11 @@
 import ReplayReporter from "./reporter";
 
-export type { TestMetadataV1, TestMetadataV2, ReplayReporterConfig } from "./reporter";
+export type {
+  TestMetadataV1,
+  TestMetadataV2,
+  ReplayReporterConfig,
+  TestIdContext,
+} from "./reporter";
 export { ReporterError } from "./reporter";
 export { pingTestMetrics } from "./metrics";
 export { removeAnsiCodes } from "./terminal";

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -28,6 +28,12 @@ interface TestRunTestInputModel {
   recordingIds: string[];
 }
 
+export interface TestIdContext {
+  title: string;
+  scope: string[];
+  attempt: number;
+}
+
 export interface ReplayReporterConfig {
   runTitle?: string;
   metadata?: Record<string, any> | string;
@@ -232,12 +238,12 @@ class ReplayReporter {
     return { approximateDuration, resultCounts };
   }
 
-  getTestId(source?: Test["source"]) {
+  getTestId(source?: TestIdContext) {
     if (!source) {
       return this.baseId;
     }
 
-    return `${this.baseId}-${[...source.scope, source.title].join("-")}`;
+    return `${this.baseId}-${[...source.scope, source.title].join("-")}-${source.attempt}`;
   }
 
   parseConfig(config: ReplayReporterConfig = {}, metadataKey?: string) {
@@ -516,10 +522,13 @@ class ReplayReporter {
     }
   }
 
-  onTestBegin(source?: Test["source"], metadataFilePath = getMetadataFilePath("REPLAY_TEST", 0)) {
-    debug("onTestBegin: %o", source);
+  onTestBegin(
+    testIdContext?: TestIdContext,
+    metadataFilePath = getMetadataFilePath("REPLAY_TEST", 0)
+  ) {
+    debug("onTestBegin: %o", testIdContext);
 
-    const id = this.getTestId(source);
+    const id = this.getTestId(testIdContext);
     this.errors = [];
     const metadata = {
       ...(this.baseMetadata || {}),
@@ -609,7 +618,12 @@ class ReplayReporter {
 
   getRecordingsForTest(tests: Test[], includeUploaded: boolean) {
     const filter = `function($v) { $v.metadata.\`x-replay-test\`.id in ${JSON.stringify([
-      ...tests.map(test => this.getTestId(test.source)),
+      ...tests.map(test =>
+        this.getTestId({
+          ...test.source,
+          attempt: test.attempt,
+        })
+      ),
       this.getTestId(),
     ])} and $not($exists($v.metadata.test)) }`;
 


### PR DESCRIPTION
## Issue

Retries of playwright tests can overwrite metadata from previous runs because the `x-replay-test` data is the same for every retry.

## Resolution

* Properly populate `attempt` for playwright tests
* Include `attempt` in the test id context value used to generate the `x-replay-test` data so every attempt has a unique value