### PR TITLE
Fix cypress plugin step event ordering

### DIFF
--- a/packages/cypress/src/steps.ts
+++ b/packages/cypress/src/steps.ts
@@ -61,9 +61,7 @@ function getTestsFromResults(
   resultTests: CypressCommandLine.TestResult[],
   testStartSteps: StepEvent[]
 ) {
-  const startEvents = [...testStartSteps].sort(
-    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
-  );
+  const startEvents = sortSteps(testStartSteps);
 
   function getIdForTest(result: CypressCommandLine.TestResult) {
     const startEventIndex = startEvents.findIndex(
@@ -118,16 +116,7 @@ function getTestsFromResults(
 
 function sortSteps(steps: StepEvent[]) {
   // The steps can come in out of order but are sortable by timestamp
-  const sortedSteps = [...steps].sort((a, b) => {
-    const tsCompare = a.timestamp.localeCompare(b.timestamp);
-    if (tsCompare === 0) {
-      return toEventOrder(a) - toEventOrder(b);
-    }
-
-    return tsCompare;
-  });
-
-  return sortedSteps;
+  return [...steps].sort((a, b) => a.index - b.index);
 }
 
 function isTestForStep(test: Test, step: StepEvent) {


### PR DESCRIPTION
## Issue

Sometimes events show up out of order when a test is retried

## Resolution

Events were previously sorted by timestamp and then event type. This works most of the time but it is possible to have the same timestamp if the event happen soon enough after one another.

I don't know if this will fix the retry ordering problem but it should ensure that events maintain the same order they occurred.