### PR TITLE
Add hashed testId to cypress annotation payload

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -12,7 +12,7 @@ import CypressReporter, { PluginOptions, getMetadataFilePath, isStepEvent } from
 import run from "./run";
 import { PluginFeature } from "./features";
 import { updateJUnitReports } from "./junit";
-import { StepEvent } from "./support";
+import type { StepEvent } from "./support";
 import { createServer } from "./server";
 
 export type { PluginOptions } from "./reporter";

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -38,18 +38,22 @@ interface CypressTestScope {
   test: string[];
   testId: number | null;
   attempt: number;
-  v2:
-    | {
-        scope: string[];
-        title: string;
-        attempt: number;
-        index: number;
-        testId: string;
-      }
-    | {
-        scope: string[];
-        hook: string;
-      };
+  v2: CypressMainTestScope | CypressHookTestScope;
+}
+
+interface CypressMainTestScope {
+  scope: string[];
+  title: string;
+  attempt: number;
+  index: number;
+  testId: string;
+}
+
+// beforeAll/afterAll hooks are not associated with a particular test nor
+// attempt so this interface omits those members
+interface CypressHookTestScope {
+  scope: string[];
+  hook: string;
 }
 
 let gLastTest: MochaTest | undefined;
@@ -523,7 +527,7 @@ export default function register() {
       console.error(e);
     }
   });
-  Cypress.on("log:added", async log => {
+  Cypress.on("log:added", log => {
     const assertionCurrentTest = currentTestScope;
 
     if (!assertionCurrentTest) {

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -1,4 +1,4 @@
-import { buildTestId } from "@replayio/test-utils";
+import { buildTestId } from "@replayio/test-utils/src/testId";
 import type { TestMetadataV2 } from "@replayio/test-utils";
 import { CONNECT_TASK_NAME } from "./constants";
 

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,6 +1,7 @@
 import ReplayReporter from "./reporter";
 
 export type { TestMetadataV1, TestMetadataV2, ReplayReporterConfig } from "./reporter";
+export { buildTestId } from "./testId";
 export { ReporterError } from "./reporter";
 export { pingTestMetrics } from "./metrics";
 export { removeAnsiCodes } from "./terminal";

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -11,6 +11,7 @@ const uuid = require("uuid");
 import { getMetadataFilePath } from "./metadata";
 import { pingTestMetrics } from "./metrics";
 import { log, warn } from "./logging";
+import { buildTestId, generateOpaqueId } from "./testId";
 
 const debug = dbg("replay:test-utils:reporter");
 
@@ -565,16 +566,6 @@ class ReplayReporter {
     );
   }
 
-  buildTestId(sourcePath: string, test: Test) {
-    return this.generateOpaqueId(
-      [sourcePath, test.id, ...test.source.scope, test.source.title].join("-")
-    );
-  }
-
-  generateOpaqueId(contents: string) {
-    return createHash("sha1").update(contents).digest("hex");
-  }
-
   async uploadRecording(recording: RecordingEntry): Promise<UploadPendingWork> {
     debug("Starting upload of %s", recording.id);
 
@@ -702,31 +693,31 @@ class ReplayReporter {
     replayTitle?: string,
     extraMetadata?: Record<string, unknown>
   ): Promise<PendingWork> {
-    const runnerGroupId = runnerGroupKey ? this.generateOpaqueId(runnerGroupKey) : null;
+    const runnerGroupId = runnerGroupKey ? await generateOpaqueId(runnerGroupKey) : null;
     const recordings = this.getRecordingsForTest(tests, false);
 
     if (this.testRunShardId) {
       const recordingIds = recordings.map(r => r.id);
-      this.pendingWork.push(
-        this.addTestsToShard(
-          tests.map<TestRunTestInputModel>(t => {
-            const testId = this.buildTestId(specFile, t);
-            return {
-              testId,
-              runnerGroupId: runnerGroupId,
-              index: t.id,
-              attempt: t.attempt,
-              scope: t.source.scope,
-              title: t.source.title,
-              sourcePath: specFile,
-              result: t.result,
-              error: t.error ? t.error.message : null,
-              duration: t.approximateDuration,
-              recordingIds,
-            };
-          })
-        )
+      const testInputs = await Promise.all(
+        tests.map<Promise<TestRunTestInputModel>>(async t => {
+          const testId = await buildTestId(specFile, t);
+          return {
+            testId,
+            runnerGroupId: runnerGroupId,
+            index: t.id,
+            attempt: t.attempt,
+            scope: t.source.scope,
+            title: t.source.title,
+            sourcePath: specFile,
+            result: t.result,
+            error: t.error ? t.error.message : null,
+            duration: t.approximateDuration,
+            recordingIds,
+          };
+        })
       );
+
+      this.pendingWork.push(this.addTestsToShard(testInputs));
     } else {
       debug("Skipping adding tests to test run: test run shard ID not found");
     }

--- a/packages/test-utils/src/testId.ts
+++ b/packages/test-utils/src/testId.ts
@@ -3,7 +3,7 @@ import type { Test } from "./reporter";
 export async function buildTestId(
   sourcePath: string,
   test: Pick<Test, "id" | "source">
-): Promise<string | null> {
+): Promise<string> {
   const id = await generateOpaqueId(
     [sourcePath, test.id, ...test.source.scope, test.source.title].join("-")
   );

--- a/packages/test-utils/src/testId.ts
+++ b/packages/test-utils/src/testId.ts
@@ -1,0 +1,16 @@
+import type { Test } from "./reporter";
+
+export function buildTestId(
+  sourcePath: string,
+  test: Pick<Test, "id" | "source">
+): Promise<string> {
+  return generateOpaqueId([sourcePath, test.id, ...test.source.scope, test.source.title].join("-"));
+}
+
+export async function generateOpaqueId(contents: string): Promise<string> {
+  const enc = new TextEncoder();
+  const hash = await crypto.subtle.digest("SHA-1", enc.encode(contents));
+  return Array.from(new Uint8Array(hash))
+    .map(v => v.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/packages/test-utils/src/testId.ts
+++ b/packages/test-utils/src/testId.ts
@@ -1,10 +1,14 @@
 import type { Test } from "./reporter";
 
-export function buildTestId(
+export async function buildTestId(
   sourcePath: string,
   test: Pick<Test, "id" | "source">
-): Promise<string> {
-  return generateOpaqueId([sourcePath, test.id, ...test.source.scope, test.source.title].join("-"));
+): Promise<string | null> {
+  const id = await generateOpaqueId(
+    [sourcePath, test.id, ...test.source.scope, test.source.title].join("-")
+  );
+
+  return id;
 }
 
 export async function generateOpaqueId(contents: string): Promise<string> {

--- a/packages/test-utils/src/testId.ts
+++ b/packages/test-utils/src/testId.ts
@@ -8,13 +8,15 @@ export function buildTestId(
 }
 
 export async function generateOpaqueId(contents: string): Promise<string> {
-  if (globalThis.window) {
+  if (globalThis.crypto) {
+    // In the browser, use the global crypto obj to generate the sha-1 hash
     const enc = new TextEncoder();
     const hash = await crypto.subtle.digest("SHA-1", enc.encode(contents));
     return Array.from(new Uint8Array(hash))
       .map(v => v.toString(16).padStart(2, "0"))
       .join("");
   } else {
+    // In node, rely on the crypto package instead
     return require("crypto").createHash("sha1").update(contents).digest("hex");
   }
 }

--- a/packages/test-utils/src/testId.ts
+++ b/packages/test-utils/src/testId.ts
@@ -8,9 +8,13 @@ export function buildTestId(
 }
 
 export async function generateOpaqueId(contents: string): Promise<string> {
-  const enc = new TextEncoder();
-  const hash = await crypto.subtle.digest("SHA-1", enc.encode(contents));
-  return Array.from(new Uint8Array(hash))
-    .map(v => v.toString(16).padStart(2, "0"))
-    .join("");
+  if (globalThis.window) {
+    const enc = new TextEncoder();
+    const hash = await crypto.subtle.digest("SHA-1", enc.encode(contents));
+    return Array.from(new Uint8Array(hash))
+      .map(v => v.toString(16).padStart(2, "0"))
+      .join("");
+  } else {
+    return require("crypto").createHash("sha1").update(contents).digest("hex");
+  }
 }


### PR DESCRIPTION
Add the hashed `testId` to the cypress annotation payload so we can deep link to tests or steps from the dashboard