### PR TITLE
Add retries to test run graphql calls

### DIFF
--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -141,7 +141,9 @@ function parseRuntime(runtime?: string) {
 
 function throwGraphqlErrors(operation: string, errors: any) {
   errors.forEach((e: any) => debug("Error from GraphQL operation %s: %o", operation, e));
-  throw new Error(`GraphQL Errors: ${errors.map(getErrorMessage).join(", ")}`);
+  throw new Error(
+    `GraphQL request for ${operation} failed (${errors.map(getErrorMessage).join(", ")})`
+  );
 }
 
 export class ReporterError extends Error {

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -139,7 +139,7 @@ function parseRuntime(runtime?: string) {
   return ["chromium", "gecko", "node"].find(r => runtime?.includes(r));
 }
 
-function throwGraphqlErrors(operation: string; errors: any) {
+function throwGraphqlErrors(operation: string, errors: any) {
   errors.forEach((e: any) => debug("Error from GraphQL operation %s: %o", operation, e));
   throw new Error(`GraphQL Errors: ${errors.map(getErrorMessage).join(", ")}`);
 }
@@ -411,7 +411,7 @@ class ReplayReporter {
 
       return {
         type: "test-run",
-        id: this.testRunShardId,
+        id: this.testRunShardId!,
         phase: "start",
       };
     } catch (e) {


### PR DESCRIPTION
## Issue

GraphQL can sometimes fail unexpectedly

## Resolution

Add retries to avoid dropping data due to intermittent connectivity or graphql issues