### PR TITLE
Fix socket host to use same logic on client and server

### DIFF
--- a/packages/cypress/src/server.ts
+++ b/packages/cypress/src/server.ts
@@ -20,20 +20,21 @@ export async function createServer() {
   });
 
   return new Promise<{ server: WebSocketServer; port: number }>(resolve => {
-    server.listen(
-      {
-        // Pick any available port unless set by user
-        port: process.env.REPLAY_CYPRESS_SOCKET_PORT
-          ? Number.parseInt(process.env.REPLAY_CYPRESS_SOCKET_PORT)
-          : 0,
-        // Explicitly use ipv4 unless set by user
-        host: process.env.REPLAY_CYPRESS_SOCKET_HOST || "0.0.0.0",
-      },
-      () => {
-        const { address, port } = server.address() as AddressInfo;
-        debug("Listening on %s on port %d", address, port);
-        resolve({ server: wss, port });
-      }
-    );
+    const config = {
+      // Pick any available port unless set by user
+      port: process.env.CYPRESS_REPLAY_SOCKET_PORT
+        ? Number.parseInt(process.env.CYPRESS_REPLAY_SOCKET_PORT)
+        : 0,
+      // Explicitly use ipv4 unless set by user
+      host: process.env.CYPRESS_REPLAY_SOCKET_HOST || "0.0.0.0",
+    };
+
+    debug("Server config: %o", config);
+
+    server.listen(config, () => {
+      const { address, port } = server.address() as AddressInfo;
+      debug("Listening on %s on port %d", address, port);
+      resolve({ server: wss, port });
+    });
   });
 }

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -282,7 +282,9 @@ function sendStepToPlugin(event: StepEvent) {
   // send all buffered events and stop buffering so all future events are sent
   // immediately.
   if (!gPluginServer && gServerPort != null) {
-    gPluginServer = new WebSocket(`ws://localhost:${gServerPort}`);
+    gPluginServer = new WebSocket(
+      `ws://${Cypress.env("REPLAY_SOCKET_PORT") ?? "0.0.0.0"}:${gServerPort}`
+    );
     gPluginServer.onopen = () => {
       gPluginServer!.send(JSON.stringify({ events: gEventBuffer }));
       gBuffering = false;


### PR DESCRIPTION
Fixes the logic for selecting the websocket host to use the same default (`0.0.0.0`) and the same env variable (`CYPRESS_REPLAY_SOCKET_HOST`) to override to default.

Noting that we switch from `REPLAY_CYPRESS_SOCKET_HOST` to `CYPRESS_REPLAY_SOCKET_HOST` because Cypress requires that environment variables exposed to the spec file (and the support files) be prefixed with `CYPRESS_`. The variable is then referred to by the unprefixed name (`REPLAY_SOCKET_HOST`).