### PR TITLE
put our package versions in the User-Agent header

### DIFF
--- a/packages/replay/src/graphql.ts
+++ b/packages/replay/src/graphql.ts
@@ -1,5 +1,6 @@
 import dbg from "./debug";
 import fetch from "node-fetch";
+import { getUserAgent } from "./utils";
 
 const debug = dbg("replay:cli:graphql");
 
@@ -8,6 +9,7 @@ export async function query(name: string, query: string, variables = {}, apiKey?
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      "User-Agent": getUserAgent(),
     } as Record<string, string>,
     body: JSON.stringify({
       query,

--- a/packages/replay/src/main.test.ts
+++ b/packages/replay/src/main.test.ts
@@ -32,7 +32,7 @@ describe("filterRecordings", () => {
     const filtered = filterRecordings(recordings, r => r.id === "3", false);
     expect(filtered).toHaveLength(1);
   });
-  it("inclues crash reports when includeCrashes is set", () => {
+  it("includes crash reports when includeCrashes is set", () => {
     const recordings: RecordingEntry[] = [
       {
         status: "crashed",

--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import { getPackument } from "query-registry";
 import { compare } from "semver";
+import { getCurrentVersion } from "./utils";
 
 // requiring v4 explicitly because it's the last version with commonjs support.
 // Should be upgraded to the latest when converting this code to es modules.
@@ -697,8 +698,7 @@ async function launchBrowser(
 }
 
 async function version() {
-  const pkg = require(path.join(__dirname, "../package.json"));
-  const v = pkg.version;
+  const version = getCurrentVersion();
   let update = false;
   let latest: string | null = null;
 
@@ -706,7 +706,7 @@ async function version() {
     const data = await getPackument({ name: "@replayio/replay" });
     latest = data.distTags.latest;
 
-    if (compare(v, latest) < 0) {
+    if (compare(version, latest) < 0) {
       update = true;
     }
   } catch (e) {
@@ -714,9 +714,9 @@ async function version() {
   }
 
   return {
-    version: v,
+    version,
     update,
-    latest: latest,
+    latest,
   };
 }
 

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -1,3 +1,5 @@
+import { Agent } from "http";
+
 export type UnstructuredMetadata = Record<string, unknown>;
 
 export interface Options {
@@ -21,7 +23,7 @@ export interface Options {
    */
   apiKey?: string;
   verbose?: boolean;
-  agent?: any;
+  agent?: Agent;
 }
 
 export interface SourcemapUploadOptions {

--- a/packages/replay/src/upload.ts
+++ b/packages/replay/src/upload.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import crypto from "crypto";
 import fetch from "node-fetch";
 import ProtocolClient from "./client";
-import { defer, maybeLog, isValidUUID } from "./utils";
+import { defer, maybeLog, isValidUUID, getUserAgent } from "./utils";
 import { sanitize as sanitizeMetadata } from "../metadata";
 import { Options, OriginalSourceEntry, RecordingMetadata, SourceMapEntry } from "./types";
 import dbg from "./debug";
@@ -141,7 +141,7 @@ class ReplayClient {
     const file = fs.createReadStream(path);
     const resp = await fetch(uploadLink, {
       method: "PUT",
-      headers: { "Content-Length": size.toString() },
+      headers: { "Content-Length": size.toString(), "User-Agent": getUserAgent() },
       body: file,
     });
 

--- a/packages/replay/src/utils.ts
+++ b/packages/replay/src/utils.ts
@@ -113,4 +113,27 @@ function assertValidBrowserName(browser?: string): asserts browser is BrowserNam
   }
 }
 
-export { assertValidBrowserName, fuzzyBrowserName, defer, maybeLog, getDirectory, isValidUUID };
+function getCurrentVersion() {
+  const pkg = require(path.join(__dirname, "../package.json"));
+  return pkg.version;
+}
+
+function getNameAndVersion() {
+  const pkg = require(path.join(__dirname, "../package.json"));
+  return `${pkg.name}/${pkg.version}`;
+}
+
+function getUserAgent() {
+  return getNameAndVersion();
+}
+
+export {
+  assertValidBrowserName,
+  fuzzyBrowserName,
+  defer,
+  maybeLog,
+  getDirectory,
+  isValidUUID,
+  getCurrentVersion,
+  getUserAgent,
+};

--- a/packages/sourcemap-upload-webpack-plugin/src/index.ts
+++ b/packages/sourcemap-upload-webpack-plugin/src/index.ts
@@ -7,6 +7,7 @@ import {
   LogCallback,
 } from "@replayio/sourcemap-upload";
 import assert from "assert";
+import path from "path";
 
 export interface PluginOptions extends UploadOptions {
   logLevel?: "quiet" | "normal" | "verbose";
@@ -43,6 +44,7 @@ export default class ReplaySourceMapUploadWebpackPlugin {
     this.options = {
       ...restOpts,
       log,
+      userAgentAddition: getNameAndVersion(),
     };
   }
 
@@ -67,4 +69,9 @@ export default class ReplaySourceMapUploadWebpackPlugin {
       }
     });
   }
+}
+
+function getNameAndVersion() {
+  const pkg = require(path.join(__dirname, "../package.json"));
+  return `${pkg.name}/${pkg.version}`;
 }


### PR DESCRIPTION
we can gain a lot of intel in server o11y by including version numbers in requests made by the cli/plugins.  

basically everywhere except auth we call `fetch()`, give it a package-specific user-agent.  `sourcemap-upload/` also takes a `userAgentAddition` argument and prepends it to its own user-agent.  `sourcemap-upload-webpack-plugin/` uses that to make sure its upload contain both package versions.

This does mean that our User-Agent header will change from the current `node-fetch/1.0 (+https://github.com/bitinn/node-fetch)` to list the cli/plugin package versions, but I think that is outweighed by the gains.