### PR TITLE
fix: remove npm from install script

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -8,7 +8,7 @@
     "if:dist": "npm run if:exists -- src/index.js",
     "if:source": "npm run if:exists -- src/index.ts",
     "prepare": "npm run if:source -- npm run build",
-    "install": "npm run if:dist -- node ./bin/replayio-cypress first-run",
+    "install": "node ./bin/replayio-cypress first-run",
     "build": "rm -rf dist/ && tsc && chmod 755 dist/bin/* && cp package.json README.md dist/",
     "test": "echo \"Error: no test specified\"",
     "typecheck": "tsc --noEmit"

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -4,12 +4,12 @@
   "description": "Configuration utilities for using the Replay browsers with playwright",
   "main": "src/index.js",
   "scripts": {
-    "if:exists": "node -e \"require('fs').existsSync(process.argv[1]) ? require('child_process').spawnSync(process.argv[2], process.argv.slice(3), {shell: true, stdio: 'inherit'}) : 0\"",
+    "if:exists": "node -e \"console.log(process.argv);require('fs').existsSync(process.argv[1]) ? require('child_process').spawnSync(process.argv[2], process.argv.slice(3), {shell: true, stdio: 'inherit'}) : 0\"",
     "if:source": "npm run if:exists -- src/index.ts",
     "if:dist": "npm run if:exists -- src/index.js",
     "prepare": "npm run if:source -- npm run build",
-    "install": "npm run if:dist -- node ./bin/replayio-playwright first-run",
-    "build": "rm -rf dist/ && tsc && chmod 755 dist/bin/* && cp package.json README.md dist/",
+    "install": "node ./bin/replayio-playwright first-run",
+    "build": "npm run if:dist -- node -p 'wow'",
     "test": "echo \"Error: no test specified\"",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -8,7 +8,7 @@
     "if:source": "npm run if:exists -- src/index.ts",
     "if:dist": "npm run if:exists -- src/index.js",
     "prepare": "npm run if:source -- npm run build",
-    "install": "npm run if:dist -- node ./bin/replayio-puppeteer first-run",
+    "install": "node ./bin/replayio-puppeteer first-run",
     "build": "rm -rf dist/ && tsc && chmod 755 dist/bin/* && cp package.json README.md dist/",
     "test": "echo \"Error: no test specified\"",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
The [`install` script](https://docs.npmjs.com/cli/v10/using-npm/scripts#examples) is executed when running `pnpm add @replayio/playwright` and it can cause a failure if `npm` is missing from the PATH, or if the `packageManager` field is not `npm` (see [corepack](https://nodejs.org/api/corepack.html)).