### PR TITLE
Omit source control merge id on buildkite when not in a pull request

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -21,13 +21,13 @@ setup:
   RUN apt update && apt install xz-utils
   RUN npx @replayio/playwright install
   # download binary openssl packages from Impish builds
-  RUN wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_1.1.1f-1ubuntu2.21_amd64.deb
-  RUN wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1f-1ubuntu2.21_amd64.deb
-  RUN wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.21_amd64.deb
+  RUN wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/openssl_1.1.1f-1ubuntu2.22_amd64.deb
+  RUN wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1f-1ubuntu2.22_amd64.deb
+  RUN wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb
   # install downloaded binary packages
-  RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2.21_amd64.deb
-  RUN dpkg -i libssl-dev_1.1.1f-1ubuntu2.21_amd64.deb
-  RUN dpkg -i openssl_1.1.1f-1ubuntu2.21_amd64.deb
+  RUN dpkg -i libssl1.1_1.1.1f-1ubuntu2.22_amd64.deb
+  RUN dpkg -i libssl-dev_1.1.1f-1ubuntu2.22_amd64.deb
+  RUN dpkg -i openssl_1.1.1f-1ubuntu2.22_amd64.deb
 
 flake:
   FROM +setup

--- a/packages/replay/metadata/source.test.ts
+++ b/packages/replay/metadata/source.test.ts
@@ -1,0 +1,23 @@
+import { init } from "./source";
+
+describe("source", () => {
+  describe("init", () => {
+    describe("buildkite", () => {
+      it("omits merge.id when BUILDKITE_PULL_REQUEST is false", async () => {
+        process.env.BUILDKITE_COMMIT = "abc";
+        process.env.BUILDKITE_PULL_REQUEST = "false";
+
+        const source = await init();
+        expect(source).toHaveProperty("source.merge.id", undefined);
+      });
+
+      it("includes merge.id when BUILDKITE_PULL_REQUEST is valued", async () => {
+        process.env.BUILDKITE_COMMIT = "abc";
+        process.env.BUILDKITE_PULL_REQUEST = "123";
+
+        const source = await init();
+        expect(source).toHaveProperty("source.merge.id", "123");
+      });
+    });
+  });
+});

--- a/packages/replay/metadata/source.ts
+++ b/packages/replay/metadata/source.ts
@@ -296,7 +296,10 @@ const versions: () => Record<number, Struct> = () => ({
       id: optional(
         envString(
           "RECORD_REPLAY_METADATA_SOURCE_MERGE_ID",
-          "BUILDKITE_PULL_REQUEST",
+          env =>
+            env.BUILDKITE_PULL_REQUEST && env.BUILDKITE_PULL_REQUEST !== "false"
+              ? env.BUILDKITE_PULL_REQUEST
+              : undefined,
           getCircleCIMergeId,
           "SEMAPHORE_GIT_PR_NUMBER"
         )


### PR DESCRIPTION
On Buildkite, `BUILDKITE_PULL_REQUEST` is set to "false" when running a job that is not tied to a pull request. The current metadata handler treats that as the merge id and should instead omit the data.