### PR TITLE
Log a protocol error when upload fails

### DIFF
--- a/packages/replay/src/client.ts
+++ b/packages/replay/src/client.ts
@@ -13,6 +13,31 @@ interface Callbacks {
   onError: (socket: WebSocket) => void;
 }
 
+type ErrorDataValue = string | number | boolean | null;
+type ErrorData = Record<string, ErrorDataValue>;
+type ProtocolErrorBase = {
+  code: number;
+  message: string;
+  data: ErrorData;
+};
+
+export class ProtocolError extends Error {
+  readonly protocolCode: number;
+  readonly protocolMessage: string;
+  readonly protocolData: unknown;
+
+  constructor(err: ProtocolErrorBase) {
+    super(`protocol error ${err.code}: ${err.message}`);
+    this.protocolCode = err.code;
+    this.protocolMessage = err.message;
+    this.protocolData = err.data ?? {};
+  }
+
+  toString() {
+    return `Protocol error ${this.protocolCode}: ${this.protocolMessage}`;
+  }
+}
+
 class ProtocolClient {
   socket: WebSocket;
   callbacks: Callbacks;
@@ -96,6 +121,8 @@ class ProtocolClient {
       this.pendingMessages.delete(msg.id);
       if (msg.result) {
         resolve(msg.result);
+      } else if (msg.error) {
+        reject(new ProtocolError(msg.error));
       } else {
         reject(`Channel error: ${JSON.stringify(msg)}`);
       }


### PR DESCRIPTION
SCS-1564

I have studied code here and the code in the backend to see how things are roughly handled. I think it should be quite a strong guarantee that `msg.error` can exist and that it's of a certain shape when it's there. I left the `else` branch as-is though - just in case.

I've copy-pasted `ProtocolError` from the backend as I find it helpful to have such a custom error class in situations like this. The CLI doesn't define the codes and messages though so I decided to slim down the original and just passthrough what is received from the backend.

I looked through the error handling in the repo here and I think it could be improved. I think it would be worth cleaning this up as it would make it easier to deal with this stuff in a consistent manner. Right now a boolean result sometimes means an error, sometimes means a success, sometimes a string-as-error gets *returned*, sometimes an error is thrown. Similarly, promises are sometimes rejected with strings and sometimes with errors

