### PR TITLE
Add factories for reporter configs to improve contextual types

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -187,17 +187,6 @@ function onReplayTask(value: any) {
   return true;
 }
 
-function getSpecFilter(relativePath: string, filter: PluginOptions["filter"]) {
-  return (r: RecordingEntry) => {
-    const testMetadata = r.metadata.test as TestMetadataV2.TestRun | undefined;
-    if (testMetadata?.source?.path !== relativePath) {
-      return false;
-    }
-
-    return filter ? filter(r) : true;
-  };
-}
-
 const cypressOnWrapper = (base: Cypress.PluginEvents): Cypress.PluginEvents => {
   const handlers: any = {};
 

--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -17,7 +17,13 @@ import type { StepEvent } from "./support";
 import { PluginFeature, getFeatures, isFeatureEnabled } from "./features";
 
 type Test = TestMetadataV2.Test;
-export type PluginOptions = ReplayReporterConfig;
+
+type ReplayCypressRecordingMetadata = {
+  title: string;
+  test: TestMetadataV2.TestRun;
+};
+
+export interface PluginOptions extends ReplayReporterConfig<ReplayCypressRecordingMetadata> {}
 
 const debug = dbg("replay:cypress:reporter");
 const MAX_WAIT = 20_000;
@@ -39,7 +45,7 @@ function isStepEvent(value: unknown): value is StepEvent {
 class CypressReporter {
   public config: Cypress.PluginConfigOptions;
   public options: PluginOptions;
-  reporter: ReplayReporter;
+  reporter: ReplayReporter<ReplayCypressRecordingMetadata>;
   startTime: number | undefined;
   steps: StepEvent[] = [];
   selectedBrowser: string | undefined;

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -1,7 +1,7 @@
 import { getPlaywrightBrowserPath, BrowserName } from "@replayio/replay";
 import { initMetadataFile } from "@replayio/test-utils";
 
-import { getMetadataFilePath } from "./reporter";
+import { ReplayPlaywrightConfig, getMetadataFilePath } from "./reporter";
 
 function getDeviceConfig(browserName: BrowserName) {
   const executablePath = getExecutablePath(browserName);
@@ -57,5 +57,9 @@ export const devices = {
     return getDeviceConfig("chromium");
   },
 };
+
+export function createReplayReporterConfig(config: ReplayPlaywrightConfig) {
+  return ["@replayio/playwright/reporter", config];
+}
 
 export { getMetadataFilePath };

--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -66,12 +66,18 @@ function mapTestStepHook(step: TestStep): "beforeEach" | "afterEach" | undefined
   }
 }
 
-interface ReplayPlaywrightConfig extends ReplayReporterConfig {
+type ReplayPlaywrightRecordingMetadata = {
+  title: string;
+  test: TestMetadataV2.TestRun;
+};
+
+export interface ReplayPlaywrightConfig
+  extends ReplayReporterConfig<ReplayPlaywrightRecordingMetadata> {
   captureTestFile?: boolean;
 }
 
 class ReplayPlaywrightReporter implements Reporter {
-  reporter?: ReplayReporter;
+  reporter?: ReplayReporter<ReplayPlaywrightRecordingMetadata>;
   captureTestFile = ["1", "true"].includes(
     process.env.PLAYWRIGHT_REPLAY_CAPTURE_TEST_FILE?.toLowerCase() || "true"
   );

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -108,11 +108,11 @@ export interface SourceMapEntry {
   originalSources: OriginalSourceEntry[];
 }
 
-export interface RecordingEntry {
+export interface RecordingEntry<TMetadata extends UnstructuredMetadata = UnstructuredMetadata> {
   id: string;
   createTime: Date;
   runtime: string;
-  metadata: UnstructuredMetadata;
+  metadata: TMetadata;
   sourcemaps: SourceMapEntry[];
   buildId?: string;
   status:
@@ -131,4 +131,6 @@ export interface RecordingEntry {
   unusableReason?: string;
 }
 
-export type ExternalRecordingEntry = Omit<RecordingEntry, "buildId" | "crashData">;
+export type ExternalRecordingEntry<
+  TRecordingMetadata extends UnstructuredMetadata = UnstructuredMetadata
+> = Omit<RecordingEntry<TRecordingMetadata>, "buildId" | "crashData">;


### PR DESCRIPTION
Fixes SCS-1898

The goal of the task is to improve types for `filter` so the user can use the **known** metadata more easily. 

To do that I decided to make this per-recording metadata generic. It's the `@replayio/test-utils` that is actually responsible for:
- setting this metadata on the recording~
- calling the user-provided `filter`

However, it's not the one that defines what the metadata is. So we can either thread some extra generics between those layers or... cast stuff 😉 My preference is to use the former. End users shouldn't really interact with any generic code here so it's mostly used for internal purposes (with the caveat that **technically** `@replayio/test-utils` is a public package).

In addition to that, I have added `createReplayReporterConfig` util that should help people to get access to those improved types. I've seen @ryanjduffy using `as` to get contextual typing in some configs and I think this would be a safer and easier way to do that (a safe alternative to `as` would be to use `satisfies`). 

TODO:
- [x] apply the same changes in `@replayio/cypress`