### PR TITLE
Setup TS project references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 dist
 lerna-debug.log
 e2e-repos
+tsconfig.tsbuildinfo
 
 .pnp.*
 .yarn/*

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "example": "examples"
   },
   "scripts": {
-    "bootstrap": "yarn workspaces foreach --all --topological run build",
+    "bootstrap": "tsc -b",
     "test": "yarn run test:unit",
     "test:unit": "yarn workspaces foreach --all --exclude=. --topological run test",
     "typecheck": "yarn workspaces foreach --all run typecheck",

--- a/packages/cypress/tsconfig.json
+++ b/packages/cypress/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
     /* Basic Options */
@@ -70,5 +71,6 @@
     "useDefineForClassFields": true
   },
   "include": ["src", "bin", "types", "*.ts"],
-  "exclude": ["node_modules/cypress/types/mocha"]
+  "exclude": ["node_modules/cypress/types/mocha"],
+  "references": [{ "path": "../replay" }, { "path": "../test-utils" }]
 }

--- a/packages/jest/tsconfig.json
+++ b/packages/jest/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
     /* Basic Options */
@@ -69,5 +70,6 @@
     // Use ECMA-standard behavior for class properties.
     "useDefineForClassFields": true
   },
-  "include": ["src", "bin", "*.ts"]
+  "include": ["src", "bin", "*.ts"],
+  "references": [{ "path": "../replay" }, { "path": "../test-utils" }]
 }

--- a/packages/playwright/tsconfig.json
+++ b/packages/playwright/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
     /* Basic Options */
@@ -70,5 +71,6 @@
     "useDefineForClassFields": true,
     "skipLibCheck": true
   },
-  "include": ["src", "bin", "types", "reporter.ts"]
+  "include": ["src", "bin", "types", "reporter.ts"],
+  "references": [{ "path": "../replay" }, { "path": "../test-utils" }]
 }

--- a/packages/puppeteer/tsconfig.json
+++ b/packages/puppeteer/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
     /* Basic Options */
@@ -69,5 +70,6 @@
     // Use ECMA-standard behavior for class properties.
     "useDefineForClassFields": true
   },
-  "include": ["src", "bin", "types", "reporter.ts"]
+  "include": ["src", "bin", "types", "reporter.ts"],
+  "references": [{ "path": "../replay" }, { "path": "../test-utils" }]
 }

--- a/packages/replay/tsconfig.json
+++ b/packages/replay/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
     /* Basic Options */
@@ -72,5 +73,6 @@
     "types": ["node", "jest"]
   },
   "include": ["src", "bin", "metadata", "types"],
-  "exclude": ["**/*.test.ts"]
+  "exclude": ["**/*.test.ts"],
+  "references": [{ "path": "../sourcemap-upload" }]
 }

--- a/packages/sourcemap-upload-webpack-plugin/tsconfig.json
+++ b/packages/sourcemap-upload-webpack-plugin/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     // Target Node > 10 since that is still in use in Google Firestore and
     // some clients use 10.x everywhere to be consistent with it.
     "target": "es2018",
@@ -18,5 +19,6 @@
     "outDir": "./lib/",
     "rootDir": "./src/"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../sourcemap-upload" }]
 }

--- a/packages/sourcemap-upload/tsconfig.json
+++ b/packages/sourcemap-upload/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     // Target Node > 10 since that is still in use in Google Firestore and
     // some clients use 10.x everywhere to be consistent with it.
     "target": "es2018",

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
     /* Basic Options */
@@ -69,5 +70,6 @@
     // Use ECMA-standard behavior for class properties.
     "useDefineForClassFields": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../replay" }]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/cypress" },
+    { "path": "./packages/jest" },
+    { "path": "./packages/playwright" },
+    { "path": "./packages/puppeteer" },
+    { "path": "./packages/replay" },
+    { "path": "./packages/sourcemap-upload" },
+    { "path": "./packages/sourcemap-upload-webpack-plugin" },
+    { "path": "./packages/test-utils" }
+  ]
+}


### PR DESCRIPTION
This one brings a snappy IDE experience. A change in pkg A should immediately be reflected in pkg B - even without re-building the packages. To run tests you should still run a watcher in the background though to ensure that you are always running with the most up-to-date versions of your in-monorepo dependencies.