### PR TITLE
Make yarn.lock immutable in CI

### DIFF
--- a/.github/actions/playwright/action.yml
+++ b/.github/actions/playwright/action.yml
@@ -19,7 +19,7 @@ runs:
       with:
         node-version: "18"
         cache: "yarn"
-    - run: yarn
+    - run: yarn --immutable
       shell: bash
       working-directory: ${{ inputs.working-directory }}
     - uses: replayio/action-playwright@main

--- a/Earthfile
+++ b/Earthfile
@@ -5,7 +5,7 @@ WORKDIR /usr/build
 
 build:
   COPY . .
-  RUN yarn && yarn run bootstrap
+  RUN yarn --immutable && yarn run bootstrap
   RUN npm link --prefix ./packages/cypress
 
 lint:


### PR DESCRIPTION
CI env is getting lost between Github CI -> Earthly / Docker -> yarn install step, resulting yarn continuing even if the lock file update was needed, which is the default behavior in CI envs.

Tested here: https://github.com/replayio/replay-cli/actions/runs/8394619455/job/22992164149?pr=338