### PR TITLE
Support passing along additional browser arguments

### DIFF
--- a/packages/replay/src/bin.ts
+++ b/packages/replay/src/bin.ts
@@ -91,7 +91,7 @@ commandWithGlobalOptions("launch [url]")
 commandWithGlobalOptions("record [url]")
   .description("Launch the replay browser and start recording")
   .option("-b, --browser <browser>", "Browser to launch", "chromium")
-  .option("-a --browser-args <args>", "Browser arguments", "")
+  .option("--browser-args <args>", "Browser arguments", "")
   .option(
     "--attach <true|false>",
     "Whether to attach to the browser process after launching",

--- a/packages/replay/src/bin.ts
+++ b/packages/replay/src/bin.ts
@@ -38,6 +38,11 @@ export interface CommandLineOptions extends Options {
    * Warn of failures but do not quit with a non-zero exit code
    */
   warn?: boolean;
+
+  /**
+   * Pass along browser commandline arguments
+   */
+  browserArgs: string;
 }
 
 const debug = dbg("replay:cli");
@@ -86,6 +91,7 @@ commandWithGlobalOptions("launch [url]")
 commandWithGlobalOptions("record [url]")
   .description("Launch the replay browser and start recording")
   .option("-b, --browser <browser>", "Browser to launch", "chromium")
+  .option("-a --browser-args <args>", "Browser arguments", "")
   .option(
     "--attach <true|false>",
     "Whether to attach to the browser process after launching",
@@ -251,7 +257,7 @@ async function commandLaunchBrowser(
 
 async function commandLaunchBrowserAndRecord(
   url: string | undefined,
-  opts: Pick<CommandLineOptions, "warn" | "directory"> & LaunchOptions
+  opts: Pick<CommandLineOptions, "warn" | "directory" | "browserArgs"> & LaunchOptions
 ) {
   try {
     debug("Options", opts);
@@ -259,7 +265,7 @@ async function commandLaunchBrowserAndRecord(
     const browser = fuzzyBrowserName(opts.browser) || "chromium";
     assertValidBrowserName(browser);
 
-    await launchBrowser(browser, [url || "about:blank"], true, { ...opts, verbose: true });
+    await launchBrowser(browser, [url || "about:blank", opts.browserArgs], true, { ...opts, verbose: true, });
     await exitCommand(0);
   } catch (e) {
     console.error("Failed to launch browser");

--- a/packages/replay/src/bin.ts
+++ b/packages/replay/src/bin.ts
@@ -265,7 +265,10 @@ async function commandLaunchBrowserAndRecord(
     const browser = fuzzyBrowserName(opts.browser) || "chromium";
     assertValidBrowserName(browser);
 
-    await launchBrowser(browser, [url || "about:blank", opts.browserArgs], true, { ...opts, verbose: true, });
+    await launchBrowser(browser, [url || "about:blank", opts.browserArgs], true, {
+      ...opts,
+      verbose: true,
+    });
     await exitCommand(0);
   } catch (e) {
     console.error("Failed to launch browser");


### PR DESCRIPTION
Adds support for passing along additional browser arguments

```
replay record -a "--load-extension=~/src/_daily/Mar-22/chrome-extensions-samples/functional-samples/tutorial.hello-world/"
```