### PR TITLE
replayio: new CLI package

### DIFF
--- a/packages/replay/src/upload.ts
+++ b/packages/replay/src/upload.ts
@@ -1,15 +1,15 @@
+import crypto from "crypto";
 import fs from "fs";
+import type { Agent, AgentOptions } from "http";
+import fetch from "node-fetch";
+import pMap from "p-map";
 import path from "path";
 import { Worker } from "worker_threads";
-import crypto from "crypto";
-import fetch from "node-fetch";
 import ProtocolClient from "./client";
-import { defer, maybeLog, isValidUUID, getUserAgent, linearBackoffRetry } from "./utils";
+import dbg, { logPath } from "./debug";
 import { sanitize as sanitizeMetadata } from "./metadata";
 import { Options, OriginalSourceEntry, RecordingMetadata, SourceMapEntry } from "./types";
-import dbg, { logPath } from "./debug";
-import pMap from "p-map";
-import type { Agent, AgentOptions } from "http";
+import { defer, getUserAgent, isValidUUID, linearBackoffRetry, maybeLog } from "./utils";
 
 const debug = dbg("replay:cli:upload");
 

--- a/packages/replayio/.eslintrc.json
+++ b/packages/replayio/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["prettier"],
+  "rules": {
+    "prettier/prettier": "error"
+  }
+}

--- a/packages/replayio/.prettierignore
+++ b/packages/replayio/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+**/dist/
+**/lib/index.d.ts
+**/lib/index.js
+package-lock.json
+e2e-repos

--- a/packages/replayio/jest.config.js
+++ b/packages/replayio/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/(*.)+(spec|test).[jt]s?(x)"],
+  moduleNameMapper: {
+    uuid: require.resolve("uuid"),
+  },
+};

--- a/packages/replayio/package.json
+++ b/packages/replayio/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "replayio",
+  "version": "0.0.1",
+  "description": "CLI tool for uploading and managing recordings",
+  "bin": "./replayio.js",
+  "scripts": {
+    "build": "rm -rf dist/ metadata/ tsconfig.tsbuildinfo && tsc",
+    "lint": "prettier --write .",
+    "test": "jest --ci",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --noEmit --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/replayio/replay-cli.git"
+  },
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/replayio/replay-cli/issues"
+  },
+  "homepage": "https://github.com/replayio/replay-cli/blob/main/packages/replay/README.md",
+  "dependencies": {
+    "@replayio/sourcemap-upload": "workspace:^",
+    "@types/semver": "^7.5.6",
+    "assert": "latest",
+    "bvaughn-enquirer": "2.4.2",
+    "cli-spinners": "^2.9.2",
+    "commander": "^12.0.0",
+    "date-fns": "^2.28.0",
+    "debug": "^4.3.4",
+    "fs-extra": "latest",
+    "inquirer": "^8.0.0",
+    "is-uuid": "^1.0.2",
+    "jsonata": "^1.8.6",
+    "launchdarkly-node-client-sdk": "^3.1.0",
+    "lodash.padstart": "^4.6.1",
+    "log-update": "^6.0.0",
+    "node-fetch": "^2.6.8",
+    "p-map": "^4.0.0",
+    "pretty-ms": "^7.0.1",
+    "query-registry": "^2.6.0",
+    "semver": "^7.5.4",
+    "superstruct": "^0.15.4",
+    "table": "^6.8.2",
+    "ws": "^7.5.0"
+  },
+  "devDependencies": {
+    "@replay-cli/tsconfig": "workspace:^",
+    "@types/debug": "^4.1.7",
+    "@types/fs-extra": "latest",
+    "@types/inquirer": "^9",
+    "@types/jest": "^28.1.5",
+    "@types/lodash.padstart": "^4.6.9",
+    "@types/node-fetch": "^2.6.3",
+    "@types/table": "^6.3.2",
+    "@types/ws": "^8.5.10",
+    "jest": "^28.1.3",
+    "prettier": "^2.7.1",
+    "ts-jest": "^28.0.6",
+    "typescript": "^5.4.2"
+  }
+}

--- a/packages/replayio/replayio.js
+++ b/packages/replayio/replayio.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+"use strict";
+
+require("./dist/index.js");

--- a/packages/replayio/src/commands/list.ts
+++ b/packages/replayio/src/commands/list.ts
@@ -1,0 +1,23 @@
+import { registerAuthenticatedCommand } from "../utils/commander";
+import { exitProcess } from "../utils/exitProcess";
+import { getRecordings } from "../utils/recordings/getRecordings";
+import { printRecordings } from "../utils/recordings/printRecordings";
+
+registerAuthenticatedCommand("list")
+  .description("List all local recordings")
+  .option("--json", "Format output as JSON")
+  .action(list);
+
+async function list({ json = false }: { json?: boolean }) {
+  const recordings = getRecordings();
+
+  if (json) {
+    console.log(JSON.stringify(recordings, null, 2));
+  } else if (recordings.length === 0) {
+    console.log("No recordings found");
+  } else {
+    console.log(printRecordings(recordings));
+  }
+
+  await exitProcess(0);
+}

--- a/packages/replayio/src/commands/login.ts
+++ b/packages/replayio/src/commands/login.ts
@@ -1,0 +1,13 @@
+import { requireAuthentication } from "../utils/authentication/requireAuthentication";
+import { registerCommand } from "../utils/commander";
+import { exitProcess } from "../utils/exitProcess";
+
+registerCommand("login")
+  .description("Sign in to your Replay account with your browser")
+  .action(login);
+
+async function login() {
+  await requireAuthentication(true);
+
+  await exitProcess(0);
+}

--- a/packages/replayio/src/commands/logout.ts
+++ b/packages/replayio/src/commands/logout.ts
@@ -1,0 +1,19 @@
+import { getAccessToken } from "../utils/authentication/getAccessToken";
+import { logoutIfAuthenticated } from "../utils/authentication/logoutIfAuthenticated";
+import { registerCommand } from "../utils/commander";
+import { exitProcess } from "../utils/exitProcess";
+
+registerCommand("logout").description("Sign out of your Replay account").action(logout);
+
+async function logout() {
+  await logoutIfAuthenticated();
+
+  const token = await getAccessToken();
+  if (token) {
+    console.log("Cannot sign out sessions authenticated with an API_KEY");
+  } else {
+    console.log("You are now signed out");
+  }
+
+  await exitProcess(0);
+}

--- a/packages/replayio/src/commands/record.ts
+++ b/packages/replayio/src/commands/record.ts
@@ -1,0 +1,54 @@
+import { launchBrowser } from "../utils/browser/launchBrowser";
+import { registerAuthenticatedCommand } from "../utils/commander";
+import { confirm } from "../utils/confirm";
+import { exitProcess } from "../utils/exitProcess";
+import { promptForUpdate } from "../utils/installation/promptForUpdate";
+import { getRecordings } from "../utils/recordings/getRecordings";
+import { processUploadedRecordings } from "../utils/recordings/processUploadedRecordings";
+import { selectRecordings } from "../utils/recordings/selectRecordings";
+import { uploadRecordings } from "../utils/recordings/uploadRecordings";
+
+registerAuthenticatedCommand("record [url]")
+  .description("Launch the replay browser in recording mode")
+  .action(record);
+
+async function record(url: string = "about:blank") {
+  await promptForUpdate();
+
+  const recordingsBefore = await getRecordings();
+
+  await launchBrowser(url);
+
+  const recordingsAfter = await getRecordings();
+  const recordingsNew = recordingsAfter.filter(
+    recording => !recordingsBefore.some(({ id }) => id === recording.id)
+  );
+
+  console.log(""); // Spacing for readability
+
+  if (recordingsNew.length > 0) {
+    const selectedRecordings = await selectRecordings(recordingsNew, {
+      prompt: "New recording(s) found. Which would you like to upload?",
+      selectionMessage: "The following recording(s) will be uploaded:",
+    });
+
+    if (selectedRecordings.length > 0) {
+      const shouldProcess = await confirm(
+        "Would you like the selected recording(s) to be processed?"
+      );
+      if (shouldProcess) {
+        console.log("After upload, the selected recording(s) will be processed.\n");
+      }
+
+      await uploadRecordings(selectedRecordings);
+
+      if (shouldProcess) {
+        await processUploadedRecordings(selectedRecordings);
+      }
+    }
+  } else {
+    console.log("No new recordings were created");
+  }
+
+  await exitProcess(0);
+}

--- a/packages/replayio/src/commands/remove.ts
+++ b/packages/replayio/src/commands/remove.ts
@@ -1,0 +1,33 @@
+import { registerCommand } from "../utils/commander";
+import { exitProcess } from "../utils/exitProcess";
+import { getRecordings } from "../utils/recordings/getRecordings";
+import { removeFromDisk } from "../utils/recordings/removeFromDisk";
+
+registerCommand("remove [id]")
+  .option("--all", "Remove all recordings")
+  .description("Delete one or more recordings from disk")
+  .action(remove);
+
+async function remove(id: string | undefined, { all = false }: { all?: boolean }) {
+  if (id == null && all == false) {
+    console.log(
+      "Please specify a recording ID or use the --all flag to remove all recordings from disk."
+    );
+
+    await exitProcess(1);
+  }
+
+  const countBefore = (await getRecordings()).length;
+
+  await removeFromDisk(id);
+
+  const countAfter = (await getRecordings()).length;
+
+  if (countAfter < countBefore) {
+    console.log("%s recording(s) removed", countBefore - countAfter);
+  } else {
+    console.log("No recordings removed");
+  }
+
+  await exitProcess(0);
+}

--- a/packages/replayio/src/commands/update.ts
+++ b/packages/replayio/src/commands/update.ts
@@ -1,0 +1,19 @@
+import { registerAuthenticatedCommand } from "../utils/commander";
+import { exitProcess } from "../utils/exitProcess";
+import { installLatestRelease } from "../utils/installation/installLatestRelease";
+
+registerAuthenticatedCommand("update")
+  .description("Update your installed Replay browser")
+  .action(update);
+
+async function update() {
+  try {
+    await installLatestRelease();
+
+    await exitProcess(0);
+  } catch (error) {
+    console.error(error);
+
+    await exitProcess(1);
+  }
+}

--- a/packages/replayio/src/commands/upload-source-maps.ts
+++ b/packages/replayio/src/commands/upload-source-maps.ts
@@ -1,0 +1,41 @@
+import chalk from "chalk";
+import { requireAuthentication } from "../utils/authentication/requireAuthentication";
+import { registerCommand } from "../utils/commander";
+import { exitProcess } from "../utils/exitProcess";
+
+registerCommand("upload-source-maps <paths...>")
+  .description("Upload source-maps for a Workspace")
+  .requiredOption(
+    "-g, --group <name>",
+    "The name to group this sourcemap into, e.g. A commit SHA or release version."
+  )
+  .option("    --api-key <key>", "Authentication API Key")
+  .option(
+    "    --batch-size <batchSize>",
+    `Number of sourcemaps to upload in parallel; ${chalk.dim("max 25")}`
+  )
+  .option("    --dry-run", "Perform all of the usual CLI logic, but the final sourcemap upload.")
+  .option(
+    "-x, --extensions <exts>",
+    `A comma-separated list of extensions to process; ${chalk.dim('default ".js,.map"')}`,
+    (value: string) => value.split(",")
+  )
+  .option(
+    "-i, --ignore <pattern>",
+    "Ignore files that match this pattern",
+    (value: string, previous: Array<string> = []) => {
+      return previous.concat([value]);
+    }
+  )
+  .option("    --root <dirname>", "The base directory to use when computing relative paths")
+  .option("-q, --quiet", "Silence all stdout logging.")
+  .option("-v, --verbose", "Output extra data to stdout when processing files.")
+  .action(uploadSourceMaps);
+
+async function uploadSourceMaps() {
+  await requireAuthentication(true);
+
+  // TODO [PRO-*] Implement source-map upload
+
+  await exitProcess(0);
+}

--- a/packages/replayio/src/commands/upload.ts
+++ b/packages/replayio/src/commands/upload.ts
@@ -1,0 +1,62 @@
+import chalk from "chalk";
+import { requireAuthentication } from "../utils/authentication/requireAuthentication";
+import { registerCommand } from "../utils/commander";
+import { confirm } from "../utils/confirm";
+import { exitProcess } from "../utils/exitProcess";
+import { getRecordings } from "../utils/recordings/getRecordings";
+import { processUploadedRecordings } from "../utils/recordings/processUploadedRecordings";
+import { selectRecordings } from "../utils/recordings/selectRecordings";
+import { LocalRecording } from "../utils/recordings/types";
+import { uploadRecordings } from "../utils/recordings/uploadRecordings";
+
+registerCommand("upload")
+  .argument("[ids]", `Recording ids ${chalk.dim("(comma-separated)")}`)
+  .option("-a, --all", "Upload all recordings")
+  .option("-p, --process", "Process uploaded recording(s)")
+  .description("Upload recording(s)")
+  .action(upload);
+
+async function upload(
+  ids: string[] | undefined,
+  {
+    all = false,
+    process: shouldProcess,
+  }: {
+    all?: boolean;
+    process?: boolean;
+  } = {}
+) {
+  await requireAuthentication(false);
+
+  const recordings = await getRecordings();
+
+  let selectedRecordings: LocalRecording[] = [];
+  if (ids && ids.length > 0) {
+    selectedRecordings = recordings.filter(recording => ids.includes(recording.id));
+  } else if (all) {
+    selectedRecordings = recordings;
+  } else {
+    selectedRecordings = await selectRecordings(recordings, {
+      maxRecordingsToDisplay: 10,
+      prompt: "Which recordings would you like to upload?",
+      selectionMessage: "The following recording(s) will be uploaded:",
+    });
+  }
+
+  if (selectedRecordings.length > 0) {
+    if (shouldProcess == null) {
+      shouldProcess = await confirm("Would you like the selected recording(s) to be processed?");
+      if (shouldProcess) {
+        console.log("After upload, the selected recording(s) will be processed.\n");
+      }
+    }
+
+    await uploadRecordings(selectedRecordings);
+
+    if (shouldProcess) {
+      await processUploadedRecordings(selectedRecordings);
+    }
+  }
+
+  await exitProcess(0);
+}

--- a/packages/replayio/src/commands/view.ts
+++ b/packages/replayio/src/commands/view.ts
@@ -1,0 +1,14 @@
+import { spawn } from "child_process";
+import { registerCommand } from "../utils/commander";
+import { exitProcess } from "../utils/exitProcess";
+import { getSystemOpenCommand } from "../utils/getSystemOpenCommand";
+
+registerCommand("view <id>").description("Upload one or more recordings").action(view);
+
+async function view(id: string) {
+  const url = `https://app.replay.io/recording/${id}`;
+
+  spawn(getSystemOpenCommand(), [url]);
+
+  await exitProcess(0);
+}

--- a/packages/replayio/src/config.ts
+++ b/packages/replayio/src/config.ts
@@ -1,0 +1,2 @@
+export const replayAppHost = process.env.REPLAY_APP_SERVER || "https://app.replay.io";
+export const graphQLServer = process.env.REPLAY_API_SERVER || "https://api.replay.io";

--- a/packages/replayio/src/index.ts
+++ b/packages/replayio/src/index.ts
@@ -1,0 +1,14 @@
+import { finalizeCommander } from "./utils/commander";
+
+// Commands self-register with "commander"
+import "./commands/list";
+import "./commands/login";
+import "./commands/logout";
+import "./commands/record";
+import "./commands/remove";
+import "./commands/update";
+import "./commands/upload";
+import "./commands/upload-source-maps";
+import "./commands/view";
+
+finalizeCommander();

--- a/packages/replayio/src/utils/authentication/config.ts
+++ b/packages/replayio/src/utils/authentication/config.ts
@@ -1,0 +1,5 @@
+import { getReplayPath } from "../getReplayPath";
+
+export const authClientId = process.env.REPLAY_AUTH_CLIENT_ID || "4FvFnJJW4XlnUyrXQF8zOLw6vNAH1MAo";
+export const authHost = process.env.REPLAY_AUTH_HOST || "webreplay.us.auth0.com";
+export const cachedAuthPath = getReplayPath("profile", "auth.json");

--- a/packages/replayio/src/utils/authentication/debug.ts
+++ b/packages/replayio/src/utils/authentication/debug.ts
@@ -1,0 +1,3 @@
+import { createLog } from "../createLog";
+
+export const debug = createLog("login");

--- a/packages/replayio/src/utils/authentication/getAccessToken.ts
+++ b/packages/replayio/src/utils/authentication/getAccessToken.ts
@@ -1,0 +1,72 @@
+import { readFromCache, writeToCache } from "../cache";
+import { updateLaunchDarklyCache } from "../launch-darkly/updateLaunchDarklyCache";
+import { maskString } from "../maskString";
+import { cachedAuthPath } from "./config";
+import { debug } from "./debug";
+import { refreshAccessTokenOrThrow } from "./refreshAccessTokenOrThrow";
+import { CachedAuthDetails } from "./types";
+
+export async function getAccessToken(): Promise<string | undefined> {
+  if (process.env.REPLAY_API_KEY) {
+    debug("Using token from env (REPLAY_API_KEY)");
+    return process.env.REPLAY_API_KEY;
+  } else if (process.env.RECORD_REPLAY_API_KEY) {
+    debug("Using token from env (RECORD_REPLAY_API_KEY)");
+    return process.env.RECORD_REPLAY_API_KEY;
+  }
+
+  let { accessToken, refreshToken } = readFromCache<CachedAuthDetails>(cachedAuthPath) ?? {};
+  if (typeof accessToken !== "string") {
+    debug("Unexpected accessToken value: " + accessToken);
+    return;
+  } else if (typeof refreshToken !== "string") {
+    debug("Unexpected refreshToken: " + accessToken);
+    return;
+  }
+
+  const [_, encodedToken, __] = accessToken.split(".", 3);
+  if (typeof encodedToken !== "string") {
+    debug("Token did not contain a valid payload: %s", maskString(accessToken));
+    return;
+  }
+
+  let payload: any;
+  try {
+    payload = JSON.parse(Buffer.from(encodedToken, "base64").toString());
+  } catch (error) {
+    debug("Failed to decode token: %s %e", maskString(accessToken), error);
+    return;
+  }
+
+  if (typeof payload !== "object") {
+    debug("Token payload was not an object");
+    return;
+  }
+
+  const expiration = (payload?.exp ?? 0) * 1000;
+  const expirationDate = new Date(expiration);
+  const hasTokenExpired = expiration - Date.now() <= 0;
+  if (hasTokenExpired) {
+    debug(
+      "Access token expired at",
+      expirationDate.toLocaleDateString(),
+      expirationDate.toLocaleTimeString()
+    );
+
+    try {
+      accessToken = await refreshAccessTokenOrThrow(refreshToken);
+    } catch (error) {
+      writeToCache(cachedAuthPath, undefined);
+      updateLaunchDarklyCache(accessToken, undefined);
+      return;
+    }
+  } else {
+    debug(
+      "Access token valid until",
+      expirationDate.toLocaleDateString(),
+      expirationDate.toLocaleTimeString()
+    );
+  }
+
+  return accessToken;
+}

--- a/packages/replayio/src/utils/authentication/logoutIfAuthenticated.ts
+++ b/packages/replayio/src/utils/authentication/logoutIfAuthenticated.ts
@@ -1,0 +1,13 @@
+import { readFromCache, writeToCache } from "../cache";
+import { updateLaunchDarklyCache } from "../launch-darkly/updateLaunchDarklyCache";
+import { cachedAuthPath } from "./config";
+import { CachedAuthDetails } from "./types";
+
+export async function logoutIfAuthenticated() {
+  let { accessToken } = readFromCache<CachedAuthDetails>(cachedAuthPath) ?? {};
+  if (accessToken) {
+    updateLaunchDarklyCache(accessToken, undefined);
+  }
+
+  writeToCache(cachedAuthPath, undefined);
+}

--- a/packages/replayio/src/utils/authentication/refreshAccessTokenOrThrow.ts
+++ b/packages/replayio/src/utils/authentication/refreshAccessTokenOrThrow.ts
@@ -1,0 +1,40 @@
+import { maskString } from "../maskString";
+import { authClientId, authHost } from "./config";
+import { debug } from "./debug";
+
+export async function refreshAccessTokenOrThrow(refreshToken: string): Promise<string> {
+  const resp = await fetch(`https://${authHost}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      audience: "https://api.replay.io",
+      scope: "openid profile",
+      grant_type: "refresh_token",
+      client_id: authClientId,
+      refresh_token: refreshToken,
+    }),
+  });
+
+  const json: any = await resp.json();
+
+  if (json.error) {
+    debug("OAuth token request failed: %O", json.error);
+
+    throw {
+      id: "auth0-error",
+      message: json.error,
+      refreshToken: maskString(refreshToken),
+    };
+  }
+
+  if (!json.access_token) {
+    debug("OAuth token request was missing access token: %O", json);
+
+    throw {
+      id: "no-access-token",
+      refreshToken: maskString(refreshToken),
+    };
+  }
+
+  return json.access_token as string;
+}

--- a/packages/replayio/src/utils/authentication/requireAuthentication.ts
+++ b/packages/replayio/src/utils/authentication/requireAuthentication.ts
@@ -1,0 +1,115 @@
+import { spawn } from "child_process";
+import { replayAppHost } from "../../config";
+import { writeToCache } from "../cache";
+import { exitProcess } from "../exitProcess";
+import { getSystemOpenCommand } from "../getSystemOpenCommand";
+import { queryGraphQL } from "../graphql/queryGraphQL";
+import { hashValue } from "../hashValue";
+import { initLaunchDarklyFromAccessToken } from "../launch-darkly/initLaunchDarklyFromAccessToken";
+import { wait } from "../wait";
+import { cachedAuthPath } from "./config";
+import { debug } from "./debug";
+import { getAccessToken } from "./getAccessToken";
+import { refreshAccessTokenOrThrow } from "./refreshAccessTokenOrThrow";
+
+// TODO [PRO-24] Change authentication to remove polling and GraphQL mutation
+
+export async function requireAuthentication(verbose: boolean) {
+  let savedAccessToken = await getAccessToken();
+  if (savedAccessToken) {
+    if (verbose) {
+      console.log("You are already signed in!");
+    }
+
+    return savedAccessToken;
+  }
+
+  const key = hashValue(String(globalThis.performance.now()));
+
+  console.log("Please sign-in to Replay in your browser to continue.");
+
+  debug(`Launching browser to sign into Replay: ${replayAppHost}`);
+  spawn(getSystemOpenCommand(), [`${replayAppHost}/api/browser/auth?key=${key}&source=cli`]);
+
+  const { accessToken, refreshToken } = await pollForAuthentication(key);
+
+  writeToCache(cachedAuthPath, { accessToken, refreshToken });
+
+  if (verbose) {
+    console.log("You have been signed in successfully!");
+  }
+
+  // (Re)initialize LaunchDarkly for the newly authenticated user
+  await initLaunchDarklyFromAccessToken(accessToken);
+
+  return accessToken;
+}
+
+async function fetchRefreshTokenFromGraphQLOrThrow(key: string) {
+  const { data, errors } = await queryGraphQL(
+    "CloseAuthRequest",
+    `
+        mutation CloseAuthRequest($key: String!) {
+          closeAuthRequest(input: {key: $key}) {
+            success
+            token
+          }
+        }
+      `,
+    {
+      key,
+    }
+  );
+
+  if (errors) {
+    if (errors.length === 1 && errors[0].message === "Authentication request does not exist") {
+      throw {
+        id: "missing-request",
+      };
+    } else {
+      throw {
+        id: "close-graphql-error",
+        message: errors
+          .map((e: any) => e.message)
+          .filter(Boolean)
+          .join(", "),
+      };
+    }
+  } else if (!data.closeAuthRequest.token) {
+    throw {
+      id: "close-missing-token",
+      message: JSON.stringify(data),
+    };
+  }
+
+  return data.closeAuthRequest.token as string;
+}
+
+async function pollForAuthentication(key: string) {
+  const timeout = setTimeout(() => {
+    debug("Timed out waiting for authentication");
+
+    exitProcess(1);
+  }, 60_000);
+
+  let refreshToken: string | undefined = undefined;
+  while (!refreshToken) {
+    try {
+      refreshToken = await fetchRefreshTokenFromGraphQLOrThrow(key);
+    } catch (error: any) {
+      if (error?.id === "missing-request") {
+        debug("Auth request was not found. Retrying in a few seconds...");
+
+        await wait(2_500);
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  const accessToken = await refreshAccessTokenOrThrow(refreshToken);
+
+  clearTimeout(timeout);
+
+  return { accessToken, refreshToken };
+}

--- a/packages/replayio/src/utils/authentication/types.ts
+++ b/packages/replayio/src/utils/authentication/types.ts
@@ -1,0 +1,4 @@
+export type CachedAuthDetails = {
+  accessToken: string;
+  refreshToken: string;
+};

--- a/packages/replayio/src/utils/browser/debug.ts
+++ b/packages/replayio/src/utils/browser/debug.ts
@@ -1,0 +1,3 @@
+import { createLog } from "../createLog";
+
+export const debug = createLog("browser");

--- a/packages/replayio/src/utils/browser/launchBrowser.ts
+++ b/packages/replayio/src/utils/browser/launchBrowser.ts
@@ -1,0 +1,46 @@
+import chalk from "chalk";
+import { ensureDirSync } from "fs-extra";
+import { join } from "path";
+import { runtimeMetadata, runtimePath } from "../installation/config";
+import { spawnProcess } from "../spawnProcess";
+import { debug } from "./debug";
+
+export async function launchBrowser(
+  url: string,
+  options: {
+    directory?: string;
+    headless?: boolean;
+  } = {}
+) {
+  const { path: executablePath, runtime } = runtimeMetadata;
+
+  const profileDir = join(runtimePath, "profiles", runtime);
+  ensureDirSync(profileDir);
+
+  const runtimeExecutablePath = join(runtimePath, ...executablePath);
+  const args = [
+    url,
+    "--no-first-run",
+    "--no-default-browser-check",
+    `--user-data-dir=${profileDir}`,
+  ];
+  const processOptions = {
+    detached: options.headless,
+    env: {
+      RECORD_ALL_CONTENT: "1",
+      RECORD_REPLAY_DIRECTORY: options.directory,
+    },
+    stdio: undefined,
+  };
+
+  debug(
+    `Launching browser: ${runtimeExecutablePath} with args:\n`,
+    args.join("\n"),
+    "\n",
+    processOptions
+  );
+
+  console.log(`Recording ${chalk.dim("(quit browser to continue)")}`);
+
+  await spawnProcess(runtimeExecutablePath, args, processOptions);
+}

--- a/packages/replayio/src/utils/cache.ts
+++ b/packages/replayio/src/utils/cache.ts
@@ -1,0 +1,26 @@
+import { ensureFileSync, existsSync, readFileSync, removeSync, writeFileSync } from "fs-extra";
+
+export function readFromCache<Type>(path: string): Type | undefined {
+  if (existsSync(path)) {
+    const text = readFileSync(path, { encoding: "utf-8" });
+    return JSON.parse(text) as Type;
+  }
+}
+
+export function writeToCache<Type>(path: string, value: Type | undefined) {
+  if (value) {
+    const data = JSON.stringify(
+      {
+        "// WARNING": "This file contains sensitive information; do not share!",
+        ...value,
+      },
+      null,
+      2
+    );
+
+    ensureFileSync(path);
+    writeFileSync(path, data, { encoding: "utf-8" });
+  } else {
+    removeSync(path);
+  }
+}

--- a/packages/replayio/src/utils/commander.test.ts
+++ b/packages/replayio/src/utils/commander.test.ts
@@ -1,0 +1,137 @@
+import { program } from "commander";
+import strip from "strip-ansi";
+import { formatOutput, registerCommand } from "./commander";
+
+function addTestCommand(name: string) {
+  return registerCommand(name).action(() => {});
+}
+
+describe("commander", () => {
+  describe("formatOutput", () => {
+    beforeAll(() => {
+      addTestCommand("command-one").description("This command has no arguments or options");
+      addTestCommand("command-two")
+        .description("This command has one option and one optional argument")
+        .option("-o, --optional", "An optional flag")
+        .argument("[optional]", "An optional argument");
+      addTestCommand("command-three")
+        .description("This command has options and a required argument")
+        .option("-o, --optional", "An optional flag")
+        .option("--optional-two", "Another optional flag", true)
+        .option("-z", "Short flag only", false)
+        .argument("<required>", "A required argument");
+      addTestCommand("command-four")
+        .description("This command required arguments")
+        .argument("[optional]", "An optional argument")
+        .argument("<required...>", "A required argument");
+    });
+
+    it("should gracefully handle empty or short strings", () => {
+      expect(formatOutput("")).toBe("");
+      expect(formatOutput("Single line")).toBe("Single line");
+    });
+
+    it("should format the command directory", () => {
+      const text = program.helpInformation();
+      const formatted = formatOutput(text);
+
+      expect(strip(formatted)).toMatchInlineSnapshot(`
+        "Usage:  [options] [command]
+
+        ┌ Options ──────────────────────────────────────────────────────────┐
+        │  -h, --help                             display help for command  │
+        └───────────────────────────────────────────────────────────────────┘
+
+        ┌ Commands ──────────────────────────────────────────────────────────────────────────────────────┐
+        │  command-one                            This command has no arguments or options               │
+        │  command-two [options] [optional]       This command has one option and one optional argument  │
+        │  command-three [options] <required>     This command has options and a required argument       │
+        │  command-four [optional] <required...>  This command required arguments                        │
+        │  help [command]                         display help for command                               │
+        └────────────────────────────────────────────────────────────────────────────────────────────────┘
+        "
+      `);
+    });
+
+    it("should format a command with no arguments or options", () => {
+      const text = program.commands[0].helpInformation();
+      const formatted = formatOutput(text);
+
+      expect(strip(formatted)).toMatchInlineSnapshot(`
+        "Usage:  command-one [options]
+
+        This command has no arguments or options
+
+        ┌ Options ───────────────────────────────┐
+        │  -h, --help  display help for command  │
+        └────────────────────────────────────────┘
+        "
+      `);
+    });
+
+    it("should format a command with options and an optional argument", () => {
+      const text = program.commands[1].helpInformation();
+      const formatted = formatOutput(text);
+
+      expect(strip(formatted)).toMatchInlineSnapshot(`
+        "Usage:  command-two [options] [optional]
+
+        This command has one option and one optional argument
+
+        ┌ Arguments ─────────────────────────────┐
+        │  optional        An optional argument  │
+        └────────────────────────────────────────┘
+
+        ┌ Options ───────────────────────────────────┐
+        │  -o, --optional  An optional flag          │
+        │  -h, --help      display help for command  │
+        └────────────────────────────────────────────┘
+        "
+      `);
+    });
+
+    it("should format a command with options and a required argument", () => {
+      const text = program.commands[2].helpInformation();
+      const formatted = formatOutput(text);
+
+      expect(strip(formatted)).toMatchInlineSnapshot(`
+        "Usage:  command-three [options] <required>
+
+        This command has options and a required argument
+
+        ┌ Arguments ────────────────────────────┐
+        │  required        A required argument  │
+        └───────────────────────────────────────┘
+
+        ┌ Options ────────────────────────────────────────────────┐
+        │  -o, --optional  An optional flag                       │
+        │  --optional-two  Another optional flag (default: true)  │
+        │  -z              Short flag only (default: false)       │
+        │  -h, --help      display help for command               │
+        └─────────────────────────────────────────────────────────┘
+        "
+      `);
+    });
+
+    it("should format a command with a required argument array", () => {
+      const text = program.commands[3].helpInformation();
+      const formatted = formatOutput(text);
+
+      expect(strip(formatted)).toMatchInlineSnapshot(`
+        "Usage:  command-four [options] [optional] <required...>
+
+        This command required arguments
+
+        ┌ Arguments ─────────────────────────┐
+        │  optional    An optional argument  │
+        │  required    A required argument   │
+        └────────────────────────────────────┘
+
+        ┌ Options ───────────────────────────────┐
+        │  -h, --help  display help for command  │
+        └────────────────────────────────────────┘
+        "
+      `);
+    });
+  });
+});

--- a/packages/replayio/src/utils/commander.ts
+++ b/packages/replayio/src/utils/commander.ts
@@ -1,0 +1,101 @@
+import chalk from "chalk";
+import { Help, program } from "commander";
+import { getAccessToken } from "./authentication/getAccessToken";
+import { drawBoxAroundText } from "./formatting";
+import { initLaunchDarklyFromAccessToken } from "./launch-darkly/initLaunchDarklyFromAccessToken";
+import { promptNpmUpdate } from "./promptNpmUpdate";
+
+type Block = {
+  label: string;
+  lines: string[];
+};
+
+export function finalizeCommander() {
+  try {
+    program.configureHelp({
+      formatHelp: (command, helper) => {
+        const help = new Help();
+        const helpText = help.formatHelp(command, helper);
+        return formatOutput(helpText);
+      },
+    });
+    program.configureOutput({
+      writeErr: (text: string) => process.stderr.write(formatOutput(text)),
+      writeOut: (text: string) => process.stdout.write(formatOutput(text)),
+    });
+    program.hook("preAction", async () => {
+      await promptNpmUpdate();
+    });
+    program.helpCommand("help [command]", "Display help for command");
+    program.helpOption("-h, --help", "Display help for command");
+    program.parse();
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+export function formatOutput(originalText: string): string {
+  const blocks: Block[] = [];
+
+  let currentBlock: null | Block = null;
+  let lines: string[] = [];
+
+  originalText.split("\n").forEach(line => {
+    if (currentBlock != null) {
+      if (!line.trim()) {
+        blocks.push(currentBlock);
+        currentBlock = null;
+      } else {
+        currentBlock.lines.push(formatCommandOrOptionLine(line));
+      }
+    } else if (
+      line.startsWith("Arguments:") ||
+      line.startsWith("Commands:") ||
+      line.startsWith("Options:")
+    ) {
+      currentBlock = {
+        label: line.replace(":", "").trim(),
+        lines: [],
+      };
+    } else if (line.startsWith("Usage:")) {
+      line = line.replace(/ (-{1,2}[a-zA-Z0-9\-\_]+)/g, chalk.blueBright(" $1"));
+      line = line.replace(/ ([<\[][a-zA-Z0-9\-\_\.]+[>\]])/g, chalk.yellowBright(" $1"));
+
+      lines.push(line);
+    } else {
+      lines.push(line);
+    }
+  });
+
+  blocks.forEach(block => {
+    const blockText = block.lines.map(line => `${line}  `).join("\n");
+    const boxedText =
+      drawBoxAroundText(blockText, {
+        headerLabel: block.label,
+      }) + "\n";
+
+    lines.push(...boxedText.split("\n"));
+  });
+
+  return lines.join("\n");
+}
+
+export function registerAuthenticatedCommand(commandName: string) {
+  return program.command(commandName).hook("preAction", async () => {
+    const accessToken = await getAccessToken();
+    if (accessToken) {
+      await initLaunchDarklyFromAccessToken(accessToken);
+    }
+  });
+}
+
+export function registerCommand(commandName: string) {
+  return program.command(commandName);
+}
+
+function formatCommandOrOptionLine(line: string): string {
+  line = line.replace(/ (-{1,2}[a-zA-Z0-9\-\_]+)/g, chalk.blueBright(" $1"));
+  line = line.replace(/ ([<\[][a-zA-Z0-9\-\_\.]+[>\]])/g, chalk.yellowBright(" $1"));
+  line = line.replace(/\(default: ([^)]+)\)/, `(default: ${chalk.yellowBright("$1")})`);
+  return line;
+}

--- a/packages/replayio/src/utils/confirm.ts
+++ b/packages/replayio/src/utils/confirm.ts
@@ -1,0 +1,13 @@
+// @ts-ignore TS types are busted; see github.com/enquirer/enquirer/issues/212
+import { Confirm } from "bvaughn-enquirer";
+
+export async function confirm(message: string) {
+  const confirm = new Confirm({
+    hideAfterSubmit: true,
+    hideHelp: true,
+    hideOutput: true,
+    message,
+    name: "confirmation",
+  });
+  return await confirm.run();
+}

--- a/packages/replayio/src/utils/createLog.ts
+++ b/packages/replayio/src/utils/createLog.ts
@@ -1,0 +1,35 @@
+import debug from "debug";
+import { appendFileSync, ensureFileSync } from "fs-extra";
+import util from "util";
+import { getReplayPath } from "./getReplayPath";
+
+export function createLog(name: string, logFilePath?: string) {
+  const logger = debug(`replayio:${name}`);
+
+  if (logFilePath) {
+    logFilePath = getReplayPath(logFilePath);
+  }
+
+  if (logFilePath) {
+    try {
+      ensureFileSync(logFilePath);
+    } catch (error) {
+      logFilePath = undefined;
+      logger("Failed to create log directory %o", error);
+    }
+  }
+
+  return function log(formatter: string, ...args: any[]) {
+    logger(formatter, ...args);
+
+    if (logFilePath) {
+      try {
+        const formatted = util.format(formatter, ...args);
+
+        appendFileSync(logFilePath, `${formatted}\n`);
+      } catch (error) {
+        logger("Failed to write log %o", error);
+      }
+    }
+  };
+}

--- a/packages/replayio/src/utils/date.ts
+++ b/packages/replayio/src/utils/date.ts
@@ -1,0 +1,47 @@
+import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
+import differenceInMinutes from "date-fns/differenceInMinutes";
+import differenceInMonths from "date-fns/differenceInMonths";
+import differenceInWeeks from "date-fns/differenceInWeeks";
+import differenceInYears from "date-fns/differenceInYears";
+import padStart from "lodash.padstart";
+import prettyMilliseconds from "pretty-ms";
+
+export function formatDuration(ms: number) {
+  return prettyMilliseconds(ms, { millisecondsDecimalDigits: 1 });
+}
+
+export function formatRelativeDate(date: Date): string {
+  const minutes = differenceInMinutes(Date.now(), date);
+  const days = differenceInCalendarDays(Date.now(), date);
+  const weeks = differenceInWeeks(Date.now(), date);
+  const months = differenceInMonths(Date.now(), date);
+  const years = differenceInYears(Date.now(), date);
+
+  if (years > 0) {
+    return `${years}y ago`;
+  } else if (months > 0) {
+    return `${months}mo ago`;
+  } else if (weeks > 0) {
+    return `${weeks}w ago`;
+  } else if (days > 0) {
+    return `${days}d ago`;
+  } else if (minutes >= 60) {
+    return `${Math.floor(minutes / 60)}h ago`;
+  } else if (minutes > 0) {
+    return `${minutes}m ago`;
+  }
+
+  return "Now";
+}
+
+export function formatTimestamp(ms: number, showHighPrecision: boolean = false) {
+  const seconds = showHighPrecision ? Math.floor(ms / 1000) : Math.round(ms / 1000.0);
+  const minutesString = Math.floor(seconds / 60);
+  const secondsString = padStart(String(seconds % 60), 2, "0");
+  if (showHighPrecision) {
+    const millisecondsString = padStart(`${Math.round(ms) % 1000}`, 3, "0");
+    return `${minutesString}:${secondsString}.${millisecondsString}`;
+  } else {
+    return `${minutesString}:${secondsString}`;
+  }
+}

--- a/packages/replayio/src/utils/exitProcess.ts
+++ b/packages/replayio/src/utils/exitProcess.ts
@@ -1,0 +1,7 @@
+import { close } from "./launch-darkly/close";
+
+export async function exitProcess(code?: number) {
+  await close();
+
+  process.exit(code);
+}

--- a/packages/replayio/src/utils/formatting.ts
+++ b/packages/replayio/src/utils/formatting.ts
@@ -1,0 +1,45 @@
+import chalk from "chalk";
+import strip from "strip-ansi";
+
+export function drawBoxAroundText(
+  text: string,
+  options: {
+    headerLabel?: string;
+  }
+) {
+  const { headerLabel } = options;
+
+  const lines = text.split("\n");
+  const lineLength = lines.reduce((maxLength, line) => {
+    const length = strip(line).length;
+    return Math.max(maxLength, length);
+  }, 0);
+
+  if (lineLength + 2 > process.stdout.columns) {
+    if (headerLabel) {
+      return headerLabel ? `${chalk.dim(`${headerLabel}:`)}\n${text}` : text;
+    }
+  }
+
+  let formatted: string[] = [];
+  if (headerLabel) {
+    const headerWithPadding = ` ${headerLabel} `;
+    formatted.push(
+      chalk.dim(
+        `${"┌"}${headerWithPadding}${"─".repeat(lineLength - headerWithPadding.length)}${"┐"}`
+      )
+    );
+  } else {
+    formatted.push(chalk.dim(`${"┌"}${"─".repeat(lineLength)}${"┐"}`));
+  }
+
+  lines.filter(Boolean).map(line => {
+    const delta = lineLength - strip(line).length;
+    const padding = delta > 0 ? " ".repeat(delta) : "";
+    formatted.push(`${chalk.dim("│")}${line}${padding}${chalk.dim("│")}`);
+  });
+
+  formatted.push(chalk.dim(`${"└"}${"─".repeat(lineLength)}${"┘"}`));
+
+  return formatted.join("\n");
+}

--- a/packages/replayio/src/utils/getReplayPath.ts
+++ b/packages/replayio/src/utils/getReplayPath.ts
@@ -1,0 +1,16 @@
+import assert from "assert";
+import { join, resolve } from "path";
+
+export function getReplayPath(...path: string[]) {
+  let basePath;
+  if (process.env.RECORD_REPLAY_DIRECTORY) {
+    basePath = process.env.RECORD_REPLAY_DIRECTORY;
+  } else {
+    const homeDirectory = process.env.HOME || process.env.USERPROFILE;
+    assert(homeDirectory, "HOME or USERPROFILE environment variable must be set");
+
+    basePath = join(homeDirectory, ".replay");
+  }
+
+  return resolve(join(basePath, ...path));
+}

--- a/packages/replayio/src/utils/getSystemOpenCommand.ts
+++ b/packages/replayio/src/utils/getSystemOpenCommand.ts
@@ -1,0 +1,10 @@
+export function getSystemOpenCommand() {
+  switch (process.platform) {
+    case "darwin":
+      return "open";
+    case "linux":
+      return "xdg-open";
+    default:
+      throw new Error("Unsupported platform");
+  }
+}

--- a/packages/replayio/src/utils/getUserAgent.ts
+++ b/packages/replayio/src/utils/getUserAgent.ts
@@ -1,0 +1,5 @@
+import { name, version } from "../../package.json";
+
+export function getUserAgent() {
+  return `${name}/${version}`;
+}

--- a/packages/replayio/src/utils/graphql/GraphQLError.ts
+++ b/packages/replayio/src/utils/graphql/GraphQLError.ts
@@ -1,0 +1,9 @@
+export class GraphQLError extends Error {
+  code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+
+    this.code = code;
+  }
+}

--- a/packages/replayio/src/utils/graphql/debug.ts
+++ b/packages/replayio/src/utils/graphql/debug.ts
@@ -1,0 +1,3 @@
+import { createLog } from "../createLog";
+
+export const debug = createLog("graphql");

--- a/packages/replayio/src/utils/graphql/queryGraphQL.ts
+++ b/packages/replayio/src/utils/graphql/queryGraphQL.ts
@@ -1,0 +1,31 @@
+import fetch from "node-fetch";
+import { graphQLServer } from "../../config";
+import { getUserAgent } from "../getUserAgent";
+import { debug } from "./debug";
+
+export async function queryGraphQL(name: string, query: string, variables = {}, apiKey?: string) {
+  const options = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": getUserAgent(),
+    } as Record<string, string>,
+    body: JSON.stringify({
+      query,
+      name,
+      variables,
+    }),
+  };
+
+  if (apiKey) {
+    options.headers.Authorization = `Bearer ${apiKey.trim()}`;
+  }
+
+  debug("Querying %s over %s graphql endpoint", name, graphQLServer);
+  const result = await fetch(`${graphQLServer}/v1/graphql`, options);
+
+  const json: any = await result.json();
+  debug("GraphQL Response: %O", json);
+
+  return json;
+}

--- a/packages/replayio/src/utils/hashValue.ts
+++ b/packages/replayio/src/utils/hashValue.ts
@@ -1,0 +1,7 @@
+import { createHash } from "crypto";
+
+export function hashValue(value: string) {
+  const hash = createHash("sha256");
+  hash.write(value);
+  return hash.digest("hex").toString();
+}

--- a/packages/replayio/src/utils/installation/config.ts
+++ b/packages/replayio/src/utils/installation/config.ts
@@ -1,0 +1,58 @@
+import { getReplayPath } from "../getReplayPath";
+import { Platform, Runtime } from "./types";
+
+type Metadata = {
+  destinationName: string;
+  downloadFileName: string;
+  path: string[];
+  platform: Platform;
+  runtime: Runtime;
+  sourceName: string;
+};
+
+export let runtimeMetadata: Metadata;
+
+switch (process.platform) {
+  case "darwin":
+    runtimeMetadata = {
+      destinationName: "Replay-Chromium.app",
+      downloadFileName:
+        process.env.RECORD_REPLAY_CHROMIUM_DOWNLOAD_FILE ||
+        (process.arch.startsWith("arm")
+          ? "macOS-replay-chromium-arm.tar.xz"
+          : "macOS-replay-chromium.tar.xz"),
+      path: ["Replay-Chromium.app", "Contents", "MacOS", "Chromium"],
+      platform: "macOS",
+      runtime: "chromium",
+      sourceName: "Replay-Chromium.app",
+    };
+    break;
+  case "linux":
+    runtimeMetadata = {
+      destinationName: "chrome-linux",
+      downloadFileName:
+        process.env.RECORD_REPLAY_CHROMIUM_DOWNLOAD_FILE || "linux-replay-chromium.tar.xz",
+      path: ["chrome-linux", "chrome"],
+      platform: "linux",
+      runtime: "chromium",
+      sourceName: "replay-chromium",
+    };
+    break;
+  case "win32":
+    runtimeMetadata = {
+      destinationName: "replay-chromium",
+      downloadFileName:
+        process.env.RECORD_REPLAY_CHROMIUM_DOWNLOAD_FILE || "windows-replay-chromium.zip",
+      path: ["replay-chromium", "chrome.exe"],
+      platform: "windows",
+      runtime: "chromium",
+      sourceName: "replay-chromium",
+    };
+    break;
+  default: {
+    throw Error(`Unsupported platform "${process.platform}"`);
+  }
+}
+
+export const runtimePath = getReplayPath("runtimes");
+export const metadataPath = getReplayPath("runtimes", "metadata.json");

--- a/packages/replayio/src/utils/installation/debug.ts
+++ b/packages/replayio/src/utils/installation/debug.ts
@@ -1,0 +1,3 @@
+import { createLog } from "../createLog";
+
+export const debug = createLog("installation");

--- a/packages/replayio/src/utils/installation/getLatestReleases.ts
+++ b/packages/replayio/src/utils/installation/getLatestReleases.ts
@@ -1,0 +1,29 @@
+import assert from "assert";
+import { replayAppHost } from "../../config";
+import { runtimeMetadata } from "./config";
+import { Release } from "./types";
+import { debug } from "./debug";
+
+const { platform, runtime } = runtimeMetadata;
+
+export async function getLatestRelease() {
+  debug("Fetching release metadata");
+
+  const response = await fetch(`${replayAppHost}/api/releases`);
+  const json = (await response.json()) as Release[];
+  const latestRelease = json.find(release => {
+    if (release.platform === platform && release.runtime === runtime) {
+      if (platform === "macOS") {
+        return process.arch.startsWith("arm") === release.releaseFile.includes("arm");
+      } else {
+        return true;
+      }
+    }
+  });
+
+  assert(latestRelease, `No release found for ${platform}:${runtime}`);
+
+  debug("Latest release on", new Date(latestRelease.time).toLocaleDateString());
+
+  return latestRelease;
+}

--- a/packages/replayio/src/utils/installation/installLatestRelease.ts
+++ b/packages/replayio/src/utils/installation/installLatestRelease.ts
@@ -1,0 +1,110 @@
+import chalk from "chalk";
+import { spawnSync } from "child_process";
+import { ensureDirSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs-extra";
+import { get } from "https";
+import { join } from "path";
+import { writeToCache } from "../cache";
+import { getReplayPath } from "../getReplayPath";
+import { metadataPath, runtimeMetadata } from "./config";
+import { debug } from "./debug";
+import { getLatestRelease } from "./getLatestReleases";
+import { MetadataJSON } from "./types";
+
+export async function installLatestRelease() {
+  const runtimeBaseDir = getReplayPath("runtimes");
+  const runtimePath = getReplayPath("runtimes", runtimeMetadata.destinationName);
+  const downloadFilePath = getReplayPath("runtimes", runtimeMetadata.downloadFileName);
+
+  debug("Removing previous installation at %s", runtimePath);
+  rmSync(runtimePath, { force: true, recursive: true });
+
+  const buffers = await downloadReplayFile();
+
+  ensureDirSync(runtimeBaseDir);
+
+  debug("Writing downloaded file data to %s", downloadFilePath);
+  writeFileSync(downloadFilePath, buffers);
+
+  extractBrowserArchive(runtimeBaseDir, runtimePath);
+
+  debug("Deleting downloaded file %s", downloadFilePath);
+  unlinkSync(downloadFilePath);
+
+  // TODO This seems unnecessary; why don't we just use the file name that was downloaded?
+  if (runtimeMetadata.sourceName !== runtimeMetadata.destinationName) {
+    renameSync(
+      join(runtimePath, runtimeMetadata.sourceName),
+      join(runtimePath, runtimeMetadata.destinationName)
+    );
+  }
+
+  console.log("Download complete!");
+
+  const latestRelease = await getLatestRelease();
+  const latestBuildId = latestRelease.buildId;
+
+  // Write version metadata to disk so we can compare against the latest release and prompt to update
+  debug("Saving release metadata to %s", metadataPath);
+  writeToCache<MetadataJSON>(metadataPath, {
+    chromium: {
+      buildId: latestBuildId,
+      installDate: new Date().toISOString(),
+    },
+  });
+}
+
+async function downloadReplayFile() {
+  const options = {
+    host: "static.replay.io",
+    port: 443,
+    path: `/downloads/${runtimeMetadata.downloadFileName}`,
+  };
+
+  for (let i = 0; i < 5; i++) {
+    console.log(
+      `Downloading ${runtimeMetadata.runtime} from replay.io ${chalk.dim(
+        `(attempt ${i + 1} of 5)`
+      )}`
+    );
+
+    const buffers = await new Promise<Buffer[] | null>((resolve, reject) => {
+      const request = get(options, response => {
+        if (response.statusCode != 200) {
+          console.log(`Download received status code ${response.statusCode}, retrying...`);
+          request.destroy();
+          resolve(null);
+          return;
+        }
+
+        const buffers: Buffer[] = [];
+        response.on("data", data => buffers.push(data));
+        response.on("end", () => resolve(buffers));
+      });
+      request.on("error", error => {
+        console.error(`Download error ${error}, retrying...`);
+        request.destroy();
+        resolve(null);
+      });
+    });
+
+    if (buffers) {
+      return Buffer.concat(buffers);
+    }
+  }
+
+  throw new Error("Download failed, giving up");
+}
+
+async function extractBrowserArchive(runtimeBaseDir: string, downloadFilePath: string) {
+  debug("Extracting archived file at %s", downloadFilePath);
+
+  const tarResult = spawnSync("tar", ["xf", runtimeMetadata.downloadFileName], {
+    cwd: runtimeBaseDir,
+  });
+  if (tarResult.status !== 0) {
+    console.error("Failed to extract", downloadFilePath);
+    console.error(String(tarResult.stderr));
+
+    throw new Error("Unable to extract browser archive");
+  }
+}

--- a/packages/replayio/src/utils/installation/parseBuildId.ts
+++ b/packages/replayio/src/utils/installation/parseBuildId.ts
@@ -1,0 +1,11 @@
+export function parseBuildId(buildId: string) {
+  const [os, runtime, releaseDateString] = buildId.split("-");
+
+  const releaseDate = new Date(
+    parseInt(releaseDateString.slice(0, 4)),
+    parseInt(releaseDateString.slice(4, 6)) - 1,
+    parseInt(releaseDateString.slice(6, 8))
+  );
+
+  return { os, runtime, releaseDate };
+}

--- a/packages/replayio/src/utils/installation/promptForUpdate.ts
+++ b/packages/replayio/src/utils/installation/promptForUpdate.ts
@@ -1,0 +1,51 @@
+import chalk from "chalk";
+import { readFromCache } from "../cache";
+import { prompt } from "../prompt/prompt";
+import { shouldPrompt } from "../prompt/shouldPrompt";
+import { metadataPath } from "./config";
+import { debug } from "./debug";
+import { getLatestRelease } from "./getLatestReleases";
+import { installLatestRelease } from "./installLatestRelease";
+import { parseBuildId } from "./parseBuildId";
+import { MetadataJSON } from "./types";
+
+const PROMPT_ID = "runtime-update";
+
+export async function promptForUpdate() {
+  if (!shouldPrompt(PROMPT_ID)) {
+    return;
+  }
+
+  const latestRelease = await getLatestRelease();
+  const latestBuildId = latestRelease?.buildId ?? null;
+  if (latestBuildId == null) {
+    debug("No release found; skipping update check");
+    return;
+  }
+
+  const metadata = readFromCache<MetadataJSON>(metadataPath);
+  const currentBuildId = metadata?.chromium?.buildId;
+  if (currentBuildId) {
+    debug("Current build id: %s", currentBuildId);
+  } else {
+    debug("Installed version metadata not found");
+  }
+
+  if (currentBuildId !== latestBuildId) {
+    const { releaseDate } = parseBuildId(latestBuildId);
+    console.log("");
+    console.log("A new version of Replay is available!");
+    console.log("  Release date:", chalk.blueBright(releaseDate.toLocaleDateString()));
+    console.log("  Version:", chalk.blueBright(latestRelease.version));
+    console.log("");
+    console.log(`Press ${chalk.bold("[Enter]")} to upgrade`);
+    console.log("Press any other key to skip");
+    console.log("");
+
+    const confirmed = await prompt(PROMPT_ID);
+    if (confirmed) {
+      await installLatestRelease();
+      console.log("");
+    }
+  }
+}

--- a/packages/replayio/src/utils/installation/types.ts
+++ b/packages/replayio/src/utils/installation/types.ts
@@ -1,0 +1,24 @@
+export type Executable = "darwin:chromium" | "linux:chromium" | "win32:chromium";
+export type Platform = "macOS" | "linux" | "windows";
+
+// This CLI only supports Chromium for the time being
+export type Runtime = "chromium" | "gecko" | "node";
+
+export type Release = {
+  buildFile: string;
+  buildId: string;
+  platform: Platform;
+  releaseFile: string;
+  runtime: Runtime;
+  time: string;
+
+  // Gecko releases don't have a version string
+  version: string | null;
+};
+
+export type MetadataJSON = {
+  chromium: {
+    buildId: string;
+    installDate: string;
+  };
+};

--- a/packages/replayio/src/utils/launch-darkly/close.ts
+++ b/packages/replayio/src/utils/launch-darkly/close.ts
@@ -1,0 +1,13 @@
+import { debug } from "./debug";
+import { getLaunchDarklyClient } from "./getLaunchDarklyClient";
+
+export async function close() {
+  const client = getLaunchDarklyClient(false);
+  if (client) {
+    try {
+      await client.close();
+    } catch (error) {
+      debug("Failed to close LaunchDarkly client %j", error);
+    }
+  }
+}

--- a/packages/replayio/src/utils/launch-darkly/config.ts
+++ b/packages/replayio/src/utils/launch-darkly/config.ts
@@ -1,0 +1,3 @@
+import { getReplayPath } from "../getReplayPath";
+
+export const cachePath = getReplayPath("profile", "launchDarkly.json");

--- a/packages/replayio/src/utils/launch-darkly/debug.ts
+++ b/packages/replayio/src/utils/launch-darkly/debug.ts
@@ -1,0 +1,3 @@
+import { createLog } from "../createLog";
+
+export const debug = createLog("launchdarkly");

--- a/packages/replayio/src/utils/launch-darkly/getFeatureFlagValue.ts
+++ b/packages/replayio/src/utils/launch-darkly/getFeatureFlagValue.ts
@@ -1,0 +1,17 @@
+import { debug } from "./debug";
+import { getLaunchDarklyClient } from "./getLaunchDarklyClient";
+
+export async function getFeatureFlagValue<Type>(flag: string, defaultValue: boolean) {
+  const client = getLaunchDarklyClient();
+  try {
+    await client.waitForInitialization();
+  } catch (error) {
+    debug("Failed to wait for LaunchDarkly initialization %j", error);
+
+    return defaultValue;
+  }
+
+  const value = await client.variation(flag, defaultValue);
+
+  return value as Type;
+}

--- a/packages/replayio/src/utils/launch-darkly/getLaunchDarklyClient.ts
+++ b/packages/replayio/src/utils/launch-darkly/getLaunchDarklyClient.ts
@@ -1,0 +1,32 @@
+import { LDClient, LDUser, initialize as initializeLDClient } from "launchdarkly-node-client-sdk";
+import { getReplayPath } from "../getReplayPath";
+
+let client: LDClient;
+
+export function getLaunchDarklyClient(): LDClient;
+export function getLaunchDarklyClient(initialize: true): LDClient;
+export function getLaunchDarklyClient(initialize: false): LDClient | undefined;
+
+export function getLaunchDarklyClient(initialize: boolean = true) {
+  if (client) {
+    return client;
+  } else if (initialize) {
+    client = initializeLDClient(
+      "60ca05fb43d6f10d234bb3cf",
+      {
+        anonymous: true,
+      } satisfies LDUser,
+      {
+        localStoragePath: getReplayPath("launchdarkly-user-cache"),
+        logger: {
+          debug() {},
+          error() {},
+          info() {},
+          warn() {},
+        },
+      }
+    );
+
+    return client;
+  }
+}

--- a/packages/replayio/src/utils/launch-darkly/identifyUserProfile.ts
+++ b/packages/replayio/src/utils/launch-darkly/identifyUserProfile.ts
@@ -1,0 +1,21 @@
+import { LDContext } from "launchdarkly-node-client-sdk";
+import { debug } from "./debug";
+import { getLaunchDarklyClient } from "./getLaunchDarklyClient";
+
+export async function identifyUserProfile(id: string) {
+  const client = getLaunchDarklyClient();
+  try {
+    await client.waitForInitialization();
+
+    debug("Identifying LaunchDarkly feature profile for user %s", id);
+
+    await client.identify({
+      kind: "user",
+      key: id,
+      anonymous: false,
+    } satisfies LDContext);
+  } catch (error) {
+    debug("Failed identify LaunchDarkly feature profiler %j", error);
+    return;
+  }
+}

--- a/packages/replayio/src/utils/launch-darkly/initLaunchDarklyFromAccessToken.ts
+++ b/packages/replayio/src/utils/launch-darkly/initLaunchDarklyFromAccessToken.ts
@@ -1,0 +1,92 @@
+import { readFromCache } from "../cache";
+import { queryGraphQL } from "../graphql/queryGraphQL";
+import { cachePath } from "./config";
+import { debug } from "./debug";
+import { identifyUserProfile } from "./identifyUserProfile";
+import { Cached } from "./types";
+import { updateLaunchDarklyCache } from "./updateLaunchDarklyCache";
+
+export async function initLaunchDarklyFromAccessToken(accessToken: string) {
+  debug("Initializing LaunchDarkly profile");
+
+  try {
+    const cached = readFromCache<Cached>(cachePath) ?? {};
+    let id = cached[accessToken];
+    if (!id) {
+      id = await fetchUserIdFromGraphQLOrThrow(accessToken);
+
+      updateLaunchDarklyCache(accessToken, id);
+    }
+
+    debug("Found cached user id %s", id);
+
+    if (id) {
+      await identifyUserProfile(id);
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function fetchUserIdFromGraphQLOrThrow(accessToken: string) {
+  debug("Fetching auth info from GraphQL");
+
+  const { data, errors } = await queryGraphQL(
+    "AuthInfo",
+    `
+      query AuthInfo {
+        viewer {
+          user {
+            id
+          }
+        }
+        auth {
+          workspaces {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+        `,
+    {
+      key: accessToken,
+    },
+    accessToken
+  );
+
+  if (errors) {
+    console.error(errors);
+
+    throw new Error("Failed to fetch auth info");
+  }
+
+  const response = data as {
+    viewer: {
+      user: {
+        id: string | null;
+      } | null;
+    };
+    auth: {
+      workspaces: {
+        edges: {
+          node: {
+            id: string;
+          };
+        }[];
+      };
+    };
+  };
+
+  const { viewer, auth } = response;
+
+  if (viewer?.user?.id) {
+    return viewer.user.id;
+  } else if (auth?.workspaces?.edges?.[0]?.node?.id) {
+    return auth.workspaces.edges[0].node.id;
+  }
+
+  throw new Error("Unrecognized type of an API key: Missing both user ID and workspace ID.");
+}

--- a/packages/replayio/src/utils/launch-darkly/types.ts
+++ b/packages/replayio/src/utils/launch-darkly/types.ts
@@ -1,0 +1,3 @@
+export type Cached = {
+  [accessToken: string]: string;
+};

--- a/packages/replayio/src/utils/launch-darkly/updateLaunchDarklyCache.ts
+++ b/packages/replayio/src/utils/launch-darkly/updateLaunchDarklyCache.ts
@@ -1,0 +1,18 @@
+import { readFromCache, writeToCache } from "../cache";
+import { cachePath } from "./config";
+import { Cached } from "./types";
+
+export function updateLaunchDarklyCache(accessToken: string, id: string | undefined) {
+  const cached = readFromCache<Cached>(cachePath) ?? {};
+  const newCached = {
+    ...cached,
+  };
+
+  if (id) {
+    newCached[accessToken] = id;
+  } else {
+    delete newCached[accessToken];
+  }
+
+  writeToCache<Cached>(cachePath, newCached);
+}

--- a/packages/replayio/src/utils/maskString.test.ts
+++ b/packages/replayio/src/utils/maskString.test.ts
@@ -1,0 +1,7 @@
+import { maskString } from "./maskString";
+
+describe("maskString", () => {
+  it("should filter alpha-numeric characters", () => {
+    expect(maskString("abc-ABC-123")).toBe("***-***-***");
+  });
+});

--- a/packages/replayio/src/utils/maskString.ts
+++ b/packages/replayio/src/utils/maskString.ts
@@ -1,0 +1,3 @@
+export function maskString(value: string): string {
+  return value.replace(/[a-zA-Z0-9]/g, "*");
+}

--- a/packages/replayio/src/utils/prompt/config.ts
+++ b/packages/replayio/src/utils/prompt/config.ts
@@ -1,0 +1,3 @@
+import { getReplayPath } from "../getReplayPath";
+
+export const promptHistoryPath = getReplayPath("profile", "promptHistory.json");

--- a/packages/replayio/src/utils/prompt/prompt.ts
+++ b/packages/replayio/src/utils/prompt/prompt.ts
@@ -1,0 +1,38 @@
+import { readFromCache, writeToCache } from "../cache";
+import { promptHistoryPath } from "./config";
+import { PromptHistory } from "./types";
+
+export async function prompt(id?: string): Promise<boolean> {
+  return new Promise(resolve => {
+    const stdin = process.stdin;
+    const wasRaw = stdin.isRaw;
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding("utf8");
+
+    function onData(data: string) {
+      stdin.off("data", onData);
+      stdin.setRawMode(wasRaw);
+      stdin.setEncoding();
+
+      if (id) {
+        const cache = readFromCache<PromptHistory>(promptHistoryPath) ?? {};
+        writeToCache<PromptHistory>(promptHistoryPath, {
+          ...cache,
+          [id]: Date.now(),
+        });
+      }
+
+      switch (data) {
+        case "\r":
+          resolve(true);
+          break;
+        default:
+          resolve(false);
+          break;
+      }
+    }
+
+    stdin.on("data", onData);
+  });
+}

--- a/packages/replayio/src/utils/prompt/shouldPrompt.ts
+++ b/packages/replayio/src/utils/prompt/shouldPrompt.ts
@@ -1,0 +1,15 @@
+import { readFromCache } from "../cache";
+import { promptHistoryPath } from "./config";
+import { PromptHistory } from "./types";
+
+const ONE_DAY = 1000 * 60 * 60 * 24;
+
+export function shouldPrompt(id: string, minimumIntervalMs: number = ONE_DAY) {
+  const cache = readFromCache<PromptHistory>(promptHistoryPath);
+  if (!cache) {
+    return true;
+  }
+
+  const lastPromptTime = cache[id];
+  return lastPromptTime == null || Date.now() - lastPromptTime >= minimumIntervalMs;
+}

--- a/packages/replayio/src/utils/prompt/types.ts
+++ b/packages/replayio/src/utils/prompt/types.ts
@@ -1,0 +1,3 @@
+export type PromptHistory = {
+  [id: string]: number;
+};

--- a/packages/replayio/src/utils/promptNpmUpdate.ts
+++ b/packages/replayio/src/utils/promptNpmUpdate.ts
@@ -1,0 +1,37 @@
+import chalk from "chalk";
+import { execSync } from "child_process";
+import { version as currentVersion, name } from "../../package.json";
+import { prompt } from "./prompt/prompt";
+import { shouldPrompt } from "./prompt/shouldPrompt";
+
+const PROMPT_ID = "npm-update";
+
+export async function promptNpmUpdate() {
+  if (!shouldPrompt(PROMPT_ID)) {
+    return;
+  }
+
+  try {
+    const text = execSync(`npm info ${name} --json`, {
+      encoding: "utf8",
+      stdio: "pipe",
+    }).trim();
+    const { version: latestVersion } = JSON.parse(text);
+    if (currentVersion !== latestVersion) {
+      console.log("");
+      console.log("A new version of replayio is available!");
+      console.log("  Installed version:", chalk.blueBright(currentVersion));
+      console.log("  New version:", chalk.blueBright(latestVersion));
+      console.log("");
+      console.log("To upgrade, run the following:");
+      console.log(chalk.yellowBright(`  npm install -g ${name}`));
+      console.log("");
+      console.log("Press any key to continue");
+      console.log("");
+
+      await prompt(PROMPT_ID);
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/packages/replayio/src/utils/recordings/canUpload.ts
+++ b/packages/replayio/src/utils/recordings/canUpload.ts
@@ -1,0 +1,9 @@
+import { LocalRecording } from "./types";
+
+export function canUpload(recording: LocalRecording) {
+  return (
+    recording.path &&
+    recording.uploadStatus === undefined &&
+    recording.recordingStatus === "finished"
+  );
+}

--- a/packages/replayio/src/utils/recordings/config.ts
+++ b/packages/replayio/src/utils/recordings/config.ts
@@ -1,0 +1,4 @@
+import { getReplayPath } from "../getReplayPath";
+
+export const logPath = getReplayPath("recordings.log");
+export const recordingsPath = getReplayPath();

--- a/packages/replayio/src/utils/recordings/debug.ts
+++ b/packages/replayio/src/utils/recordings/debug.ts
@@ -1,0 +1,3 @@
+import { createLog } from "../createLog";
+
+export const debug = createLog("recordings");

--- a/packages/replayio/src/utils/recordings/getRecordings.ts
+++ b/packages/replayio/src/utils/recordings/getRecordings.ts
@@ -1,0 +1,170 @@
+import assert from "assert";
+import { existsSync, readFileSync } from "fs-extra";
+import { basename } from "path";
+import { logPath } from "./config";
+import { debug } from "./debug";
+import { LocalRecording, LogEntry, RECORDING_LOG_KIND } from "./types";
+
+export function getRecordings(): LocalRecording[] {
+  const recordings: LocalRecording[] = [];
+  const idToRecording: Record<string, LocalRecording> = {};
+
+  if (existsSync(logPath)) {
+    debug("Reading recording log %s", logPath);
+
+    const log = readFileSync(logPath, "utf8");
+    const lines = log.split("\n");
+
+    debug("Found %s recording", lines.length);
+
+    const idToStartTimestamp: Record<string, number> = {};
+
+    lines.forEach(text => {
+      if (text) {
+        const entry = JSON.parse(text) as LogEntry;
+
+        debug(JSON.stringify(entry, null, 2));
+
+        switch (entry.kind) {
+          case RECORDING_LOG_KIND.addMetadata: {
+            const { id, metadata = {} } = entry;
+            const recording = idToRecording[id];
+            assert(recording, `Recording with ID "${id}" not found`);
+            if (entry.metadata?.uri) {
+              let host = metadata.uri;
+              if (host && typeof host === "string") {
+                try {
+                  const url = new URL(host);
+                  host = url.host;
+                } finally {
+                  recording.metadata.host = host;
+                }
+              }
+            } else if (Array.isArray(metadata.argv) && typeof metadata.argv[0] === "string") {
+              recording.metadata.host = basename(metadata.argv[0]);
+            }
+            break;
+          }
+          case RECORDING_LOG_KIND.crashData: {
+            const { data, id } = entry;
+
+            const recording = idToRecording[id];
+            assert(recording, `Recording with ID "${id}" not found`);
+            if (recording.crashData) {
+              recording.crashData.push(data);
+            } else {
+              recording.crashData = [data];
+            }
+            break;
+          }
+          case RECORDING_LOG_KIND.crashed: {
+            const { id } = entry;
+
+            const recording = idToRecording[id];
+            assert(recording, `Recording with ID "${id}" not found`);
+            recording.recordingStatus = "crashed";
+            break;
+          }
+          case RECORDING_LOG_KIND.crashUploaded: {
+            // No-op
+            break;
+          }
+          case RECORDING_LOG_KIND.createRecording: {
+            const recording: LocalRecording = {
+              buildId: entry.buildId as string,
+              crashData: undefined,
+              date: new Date(entry.timestamp),
+              driverVersion: entry.driverVersion as string,
+              duration: undefined,
+              id: entry.id,
+              metadata: {
+                host: undefined,
+                sourcemaps: undefined,
+              },
+              path: undefined,
+              recordingStatus: "in-progress",
+              uploadStatus: undefined,
+            };
+
+            idToRecording[entry.id] = recording;
+
+            // Newest to oldest
+            recordings.unshift(recording);
+            break;
+          }
+          case RECORDING_LOG_KIND.originalSourceAdded: {
+            // No-op
+            break;
+          }
+          case RECORDING_LOG_KIND.recordingUnusable: {
+            const { id } = entry;
+            const recording = idToRecording[id];
+
+            assert(recording, `Recording with ID "${id}" not found`);
+            recording.recordingStatus = "unusable";
+
+            const index = recordings.indexOf(recording);
+            recordings.splice(index, 1);
+            break;
+          }
+          case RECORDING_LOG_KIND.sourcemapAdded: {
+            const { path, recordingId } = entry;
+            assert(path, '"sourcemapAdded" entry must have a "path"');
+            assert(recordingId, '"sourcemapAdded" entry must have a "recordingId"');
+
+            const recording = idToRecording[recordingId];
+            assert(recording, `Recording with ID "${recordingId}" not found`);
+            if (recording.metadata.sourcemaps) {
+              recording.metadata.sourcemaps.push(path);
+            } else {
+              recording.metadata.sourcemaps = [path];
+            }
+            break;
+          }
+          case RECORDING_LOG_KIND.uploadFinished: {
+            const { id } = entry;
+
+            const recording = idToRecording[id];
+            assert(recording, `Recording with ID "${id}" not found`);
+            recording.uploadStatus = "finished";
+            break;
+          }
+          case RECORDING_LOG_KIND.uploadStarted: {
+            const { id } = entry;
+
+            const recording = idToRecording[id];
+            assert(recording, `Recording with ID "${id}" not found`);
+            recording.uploadStatus = "in-progress";
+            break;
+          }
+          case RECORDING_LOG_KIND.writeFinished: {
+            const { id, timestamp } = entry;
+
+            const recording = idToRecording[id];
+            assert(recording, `Recording with ID "${id}" not found`);
+            recording.recordingStatus = "finished";
+
+            const startTimestamp = idToStartTimestamp[id];
+            if (startTimestamp != undefined) {
+              recording.duration = timestamp - idToStartTimestamp[id];
+            }
+            break;
+          }
+          case RECORDING_LOG_KIND.writeStarted: {
+            const { id, path, timestamp } = entry;
+
+            const recording = idToRecording[id];
+            assert(recording, `Recording with ID "${id}" not found`);
+            recording.path = path;
+            idToStartTimestamp[id] = timestamp;
+            break;
+          }
+        }
+      }
+    });
+  } else {
+    debug("No recording log found at %s", logPath);
+  }
+
+  return recordings;
+}

--- a/packages/replayio/src/utils/recordings/printRecordings.ts
+++ b/packages/replayio/src/utils/recordings/printRecordings.ts
@@ -1,0 +1,55 @@
+import chalk from "chalk";
+import { formatDuration, formatRelativeDate } from "../date";
+import { printTable } from "../table";
+import { LocalRecording } from "./types";
+
+export function printRecordings(
+  recordings: LocalRecording[],
+  formattingOptions: {
+    showHeaderRow?: boolean;
+  } = {}
+) {
+  const { showHeaderRow = true } = formattingOptions;
+
+  let text = printTable(
+    recordings.map(recording => {
+      const columns = [];
+      columns.push(recording.id.substring(0, 8) + "…");
+      columns.push(chalk.blueBright.underline(recording.metadata.host ?? ""));
+      columns.push(chalk.dim(formatRelativeDate(recording.date)));
+      columns.push(chalk.dim(recording.duration ? formatDuration(recording.duration) : ""));
+
+      let status;
+      if (recording.uploadStatus) {
+        switch (recording.uploadStatus) {
+          case "in-progress":
+            status = "Uploading";
+            break;
+          case "finished":
+            status = "Uploaded";
+            break;
+        }
+      } else {
+        switch (recording.recordingStatus) {
+          case "crashed":
+            status = "Crashed";
+          case "in-progress":
+            status = "Recording";
+            break;
+          case "finished":
+            status = "Recorded";
+            break;
+          case "unusable":
+            status = "Unusable";
+            break;
+        }
+      }
+      columns.push(status);
+
+      return columns;
+    }),
+    showHeaderRow ? ["ID", "Host", "Date", "Duration", "Status"] : undefined
+  );
+
+  return text;
+}

--- a/packages/replayio/src/utils/recordings/processUploadedRecordings.ts
+++ b/packages/replayio/src/utils/recordings/processUploadedRecordings.ts
@@ -1,0 +1,6 @@
+import { LocalRecording } from "./types";
+
+export async function processUploadedRecordings(recordings: LocalRecording[]) {
+  // TODO [PRO-*] Process and wait
+  // TODO [PRO-*] Show spinners and progress
+}

--- a/packages/replayio/src/utils/recordings/removeFromDisk.ts
+++ b/packages/replayio/src/utils/recordings/removeFromDisk.ts
@@ -1,0 +1,61 @@
+import { readFileSync, readdirSync, removeSync, writeFileSync } from "fs-extra";
+import { join } from "path";
+import { logPath, recordingsPath } from "./config";
+import { debug } from "./debug";
+import { getRecordings } from "./getRecordings";
+import { LogEntry, RECORDING_LOG_KIND } from "./types";
+
+export function removeFromDisk(id?: string) {
+  if (id) {
+    debug("Removing recording %s", id);
+
+    const recordings = getRecordings();
+    const recording = recordings.find(recording => recording.id === id);
+    if (recording) {
+      const { metadata, path } = recording;
+
+      metadata.sourcemaps?.forEach(path => {
+        debug("Removing recording source-map file %s", path);
+
+        removeSync(path);
+      });
+
+      // Delete recording data file
+      if (path) {
+        debug("Removing recording data file %s", path);
+
+        removeSync(path);
+      }
+
+      // Remove entries from log
+      const log = readFileSync(logPath, "utf8");
+      const filteredLines = log.split("\n").filter(text => {
+        if (text) {
+          const entry = JSON.parse(text) as LogEntry;
+          switch (entry.kind) {
+            case RECORDING_LOG_KIND.sourcemapAdded: {
+              return entry.recordingId !== id;
+            }
+            default: {
+              return entry.id !== id;
+            }
+          }
+        }
+      });
+
+      writeFileSync(logPath, filteredLines.join("\n"), "utf8");
+    } else {
+      console.log("Recording not found");
+    }
+  } else {
+    debug("Removing all recordings");
+
+    const files = readdirSync(recordingsPath);
+    files.forEach(fileName => {
+      if (fileName.startsWith("recording-") || fileName.startsWith("sourcemap-")) {
+        removeSync(join(recordingsPath, fileName));
+      }
+    });
+    removeSync(logPath);
+  }
+}

--- a/packages/replayio/src/utils/recordings/selectRecordings.ts
+++ b/packages/replayio/src/utils/recordings/selectRecordings.ts
@@ -1,0 +1,65 @@
+import chalk from "chalk";
+// @ts-ignore TS types are busted; see github.com/enquirer/enquirer/issues/212
+import { MultiSelect } from "bvaughn-enquirer";
+import { canUpload } from "./canUpload";
+import { printRecordings } from "./printRecordings";
+import { LocalRecording } from "./types";
+
+export async function selectRecordings(
+  recordings: LocalRecording[],
+  options: {
+    maxRecordingsToDisplay?: number;
+    prompt: string;
+    selectionMessage: string;
+  }
+): Promise<LocalRecording[]> {
+  const { maxRecordingsToDisplay, prompt, selectionMessage } = options;
+
+  let isShowingAllRecordings = true;
+  if (maxRecordingsToDisplay != null && recordings.length > maxRecordingsToDisplay) {
+    isShowingAllRecordings = false;
+    recordings = recordings.slice(0, maxRecordingsToDisplay);
+  }
+
+  const printedLines = printRecordings(recordings, {
+    showHeaderRow: false,
+  }).split("\n");
+
+  const select = new MultiSelect(
+    {
+      choices: recordings.map((recording, index) => ({
+        disabled: !canUpload(recording),
+        message: printedLines[index],
+        value: recording.id,
+      })),
+      footer: isShowingAllRecordings
+        ? undefined
+        : chalk.dim(`\nViewing the most recent ${maxRecordingsToDisplay} recordings`),
+      hideAfterSubmit: true,
+      initial: recordings.map(recording => recording.id),
+      message: `${prompt}\n  ${chalk.dim(
+        "(↑/↓ to change selection, [space] to toggle, [a] to toggle all)"
+      )}\n`,
+      name: "numbers",
+      styles: {
+        // Selected row style
+        em: chalk.yellowBright,
+      },
+    },
+    (choices: any[]) => {
+      return choices.map(choice => choice.value);
+    }
+  );
+
+  const recordingIds = (await select.run()) as string[];
+
+  if (recordingIds.length > 0) {
+    const selectedRecordings = recordings.filter(recording => recordingIds.includes(recording.id));
+    console.log(selectionMessage);
+    console.log(printRecordings(selectedRecordings));
+
+    return selectedRecordings;
+  } else {
+    return [];
+  }
+}

--- a/packages/replayio/src/utils/recordings/types.ts
+++ b/packages/replayio/src/utils/recordings/types.ts
@@ -1,0 +1,46 @@
+export enum RECORDING_LOG_KIND {
+  addMetadata = "addMetadata",
+  crashData = "crashData",
+  crashed = "crashed",
+  crashUploaded = "crashUploaded",
+  createRecording = "createRecording",
+  originalSourceAdded = "originalSourceAdded",
+  recordingUnusable = "recordingUnusable",
+  sourcemapAdded = "sourcemapAdded",
+  uploadFinished = "uploadFinished",
+  uploadStarted = "uploadStarted",
+  writeFinished = "writeFinished",
+  writeStarted = "writeStarted",
+}
+
+// This data comes from the runtime
+export type LogEntry = {
+  buildId?: string;
+  data?: any;
+  driverVersion?: string;
+  id: string;
+  kind: RECORDING_LOG_KIND;
+  metadata?: {
+    argv?: string[];
+    uri?: string;
+  };
+  path?: string;
+  recordingId?: string;
+  timestamp: number;
+};
+
+export type LocalRecording = {
+  buildId: string;
+  crashData: any[] | undefined;
+  date: Date;
+  driverVersion: string;
+  duration: number | undefined;
+  id: string;
+  metadata: {
+    host: string | undefined;
+    sourcemaps: string[] | undefined;
+  };
+  path: string | undefined;
+  recordingStatus: "crashed" | "in-progress" | "finished" | "unusable";
+  uploadStatus: "in-progress" | "finished" | undefined;
+};

--- a/packages/replayio/src/utils/recordings/uploadRecordings.ts
+++ b/packages/replayio/src/utils/recordings/uploadRecordings.ts
@@ -1,0 +1,7 @@
+import { LocalRecording } from "./types";
+
+export async function uploadRecordings(recordings: LocalRecording[]) {
+  // TODO [PRO-*] Upload recording and metadata (duration)
+  // TODO [PRO-*] Show progress spinners/text
+  // TODO [PRO-*] Delete successfully uploaded recordings from disk
+}

--- a/packages/replayio/src/utils/spawnProcess.ts
+++ b/packages/replayio/src/utils/spawnProcess.ts
@@ -1,0 +1,33 @@
+import { spawn, SpawnOptions } from "child_process";
+
+export async function spawnProcess(
+  executablePath: string,
+  args: string[] = [],
+  options: SpawnOptions = {}
+) {
+  return new Promise<void>((resolve, reject) => {
+    const spawned = spawn(executablePath, args, {
+      stdio: "inherit",
+      ...options,
+      env: {
+        ...process.env,
+        ...options.env,
+      },
+    });
+
+    if (options?.detached) {
+      spawned.unref();
+    } else {
+      spawned.on("error", error => {
+        reject(error);
+      });
+      spawned.on("exit", (code, signal) => {
+        if (code || signal) {
+          reject(new Error(`Process failed (code: ${code}, signal: ${signal})`));
+        } else {
+          resolve();
+        }
+      });
+    }
+  });
+}

--- a/packages/replayio/src/utils/table.ts
+++ b/packages/replayio/src/utils/table.ts
@@ -1,0 +1,11 @@
+import chalk from "chalk";
+import { table } from "table";
+
+export function printTable(rows: unknown[][], headers?: string[]) {
+  const data = headers ? [headers.map(text => chalk.bold(text)), ...rows] : rows;
+
+  return table(data, {
+    drawHorizontalLine: () => false,
+    drawVerticalLine: () => false,
+  });
+}

--- a/packages/replayio/src/utils/wait.ts
+++ b/packages/replayio/src/utils/wait.ts
@@ -1,0 +1,3 @@
+export async function wait(ms: number) {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/replayio/src/utils/withResolvers.ts
+++ b/packages/replayio/src/utils/withResolvers.ts
@@ -1,0 +1,38 @@
+export function withResolvers<Type>() {
+  let reject: ((reason?: any) => void) | undefined = undefined;
+  let rejected = false;
+  let rejectedReason: any;
+
+  let resolve: ((value: Type | PromiseLike<Type>) => void) | undefined = undefined;
+  let resolved = false;
+  let resolvedValue: Type | PromiseLike<Type> | undefined = undefined;
+
+  return {
+    promise: new Promise<Type>((...args) => {
+      resolve = args[0];
+      reject = args[1];
+
+      if (rejected) {
+        reject(rejectedReason);
+      } else if (resolved) {
+        resolve(resolvedValue as Type);
+      }
+    }),
+    resolve: (value: Type | PromiseLike<Type>) => {
+      if (resolve) {
+        resolve(value);
+      } else {
+        resolved = true;
+        resolvedValue = value;
+      }
+    },
+    reject: (reason?: any) => {
+      if (reject) {
+        reject(reason);
+      } else {
+        rejected = true;
+        rejectedReason = reason;
+      }
+    },
+  };
+}

--- a/packages/replayio/tsconfig.json
+++ b/packages/replayio/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "@replay-cli/tsconfig/base.json",
+  "compilerOptions": {
+    "lib": ["ES2019"],
+    "outDir": "./dist",
+    "resolveJsonModule": true,
+    "rootDir": "./src",
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.test.ts"],
+  "references": [
+    {
+      "path": "../sourcemap-upload"
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,6 +677,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.21.0":
+  version: 7.24.1
+  resolution: "@babel/runtime@npm:7.24.1"
+  dependencies:
+    regenerator-runtime: "npm:^0.14.0"
+  checksum: 10c0/500c6a99ddd84f37c7bc5dbc84777af47b1372b20e879941670451d55484faf18a673c5ebee9ca2b0f36208a729417873b35b1b92e76f811620f6adf7b8cb0f1
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.16.7, @babel/template@npm:^7.22.15, @babel/template@npm:^7.24.0, @babel/template@npm:^7.3.3":
   version: 7.24.0
   resolution: "@babel/template@npm:7.24.0"
@@ -1672,6 +1681,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/fs-extra@npm:latest":
+  version: 11.0.4
+  resolution: "@types/fs-extra@npm:11.0.4"
+  dependencies:
+    "@types/jsonfile": "npm:*"
+    "@types/node": "npm:*"
+  checksum: 10c0/9e34f9b24ea464f3c0b18c3f8a82aefc36dc524cc720fc2b886e5465abc66486ff4e439ea3fb2c0acebf91f6d3f74e514f9983b1f02d4243706bdbb7511796ad
+  languageName: node
+  linkType: hard
+
 "@types/glob@npm:^7.1.3":
   version: 7.2.0
   resolution: "@types/glob@npm:7.2.0"
@@ -1688,6 +1707,16 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/235d2fc69741448e853333b7c3d1180a966dd2b8972c8cbcd6b2a0c6cd7f8d582ab2b8e58219dbc62cce8f1b40aa317ff78ea2201cdd8249da5025adebed6f0b
+  languageName: node
+  linkType: hard
+
+"@types/inquirer@npm:^9":
+  version: 9.0.7
+  resolution: "@types/inquirer@npm:9.0.7"
+  dependencies:
+    "@types/through": "npm:*"
+    rxjs: "npm:^7.2.0"
+  checksum: 10c0/b7138af41226c0457b99ff9b179da4a82078bc1674762e812d3cc3e3276936d7326b9fa6b98212b8eb055b2b6aaebe3c20359eebe176a6ca71061f4e08ce3a0f
   languageName: node
   linkType: hard
 
@@ -1730,6 +1759,31 @@ __metadata:
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
+  languageName: node
+  linkType: hard
+
+"@types/jsonfile@npm:*":
+  version: 6.1.4
+  resolution: "@types/jsonfile@npm:6.1.4"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/b12d068b021e4078f6ac4441353965769be87acf15326173e2aea9f3bf8ead41bd0ad29421df5bbeb0123ec3fc02eb0a734481d52903704a1454a1845896b9eb
+  languageName: node
+  linkType: hard
+
+"@types/lodash.padstart@npm:^4.6.9":
+  version: 4.6.9
+  resolution: "@types/lodash.padstart@npm:4.6.9"
+  dependencies:
+    "@types/lodash": "npm:*"
+  checksum: 10c0/7e0d69c2a762adc3d6e481940d29a3a4a9aec10d10636d46f7dab5897e79bb3fe75027e85437cec3f04162d44cbeaf91aaeef437c6694dd9726ec5051fe1c063
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*":
+  version: 4.17.0
+  resolution: "@types/lodash@npm:4.17.0"
+  checksum: 10c0/4c5b41c9a6c41e2c05d08499e96f7940bcf194dcfa84356235b630da920c2a5e05f193618cea76006719bec61c76617dff02defa9d29934f9f6a76a49291bd8f
   languageName: node
   linkType: hard
 
@@ -1808,10 +1862,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/table@npm:^6.3.2":
+  version: 6.3.2
+  resolution: "@types/table@npm:6.3.2"
+  dependencies:
+    table: "npm:*"
+  checksum: 10c0/30393083312b2022ffd6c03532b4f3ae41b2fdd2735daf666c3a0b64c42e59d8c663c7cf4aa6d176931302f4d8b92bb64e008c4de6e619d5c41c5bef2d34acd6
+  languageName: node
+  linkType: hard
+
 "@types/text-table@npm:^0.2.2":
   version: 0.2.5
   resolution: "@types/text-table@npm:0.2.5"
   checksum: 10c0/967054ba7509bf6ba4dda8adf81d048a7773b35295edb8670c045b6e27bda556a1917c8a29d4ea6b7d7e5b494785500779a002508c4415ef2e8b2a5351ca2066
+  languageName: node
+  linkType: hard
+
+"@types/through@npm:*":
+  version: 0.0.33
+  resolution: "@types/through@npm:0.0.33"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/6a8edd7f40cd7e197318e86310a40e568cddd380609dde59b30d5cc6c5f8276ddc698905eac4b3b429eb39f2e8ee326bc20dc6e95a2cdc41c4d3fc9a1ebd4929
   languageName: node
   linkType: hard
 
@@ -2257,6 +2329,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-escapes@npm:^6.2.0":
+  version: 6.2.1
+  resolution: "ansi-escapes@npm:6.2.1"
+  checksum: 10c0/a2c6f58b044be5f69662ee17073229b492daa2425a7fd99a665db6c22eab6e4ab42752807def7281c1c7acfed48f87f2362dda892f08c2c437f1b39c6b033103
+  languageName: node
+  linkType: hard
+
 "ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
@@ -2296,7 +2375,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^6.1.0":
+"ansi-styles@npm:^6.1.0, ansi-styles@npm:^6.2.1":
   version: 6.2.1
   resolution: "ansi-styles@npm:6.2.1"
   checksum: 10c0/5d1ec38c123984bcedd996eac680d548f31828bd679a66db2bdf11844634dde55fec3efa9c6bb1d89056a5e79c1ac540c4c784d592ea1d25028a92227d2f2d5c
@@ -2375,6 +2454,19 @@ __metadata:
   version: 1.0.0
   resolution: "assert-plus@npm:1.0.0"
   checksum: 10c0/b194b9d50c3a8f872ee85ab110784911e696a4d49f7ee6fc5fb63216dedbefd2c55999c70cb2eaeb4cf4a0e0338b44e9ace3627117b5bf0d42460e9132f21b91
+  languageName: node
+  linkType: hard
+
+"assert@npm:latest":
+  version: 2.1.0
+  resolution: "assert@npm:2.1.0"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    is-nan: "npm:^1.3.2"
+    object-is: "npm:^1.1.5"
+    object.assign: "npm:^4.1.4"
+    util: "npm:^0.12.5"
+  checksum: 10c0/7271a5da883c256a1fa690677bf1dd9d6aa882139f2bed1cd15da4f9e7459683e1da8e32a203d6cc6767e5e0f730c77a9532a87b896b4b0af0dd535f668775f0
   languageName: node
   linkType: hard
 
@@ -2550,6 +2642,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bl@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "bl@npm:4.1.0"
+  dependencies:
+    buffer: "npm:^5.5.0"
+    inherits: "npm:^2.0.4"
+    readable-stream: "npm:^3.4.0"
+  checksum: 10c0/02847e1d2cb089c9dc6958add42e3cdeaf07d13f575973963335ac0fdece563a50ac770ac4c8fa06492d2dd276f6cc3b7f08c7cd9c7a7ad0f8d388b2a28def5f
+  languageName: node
+  linkType: hard
+
 "blob-util@npm:^2.0.2":
   version: 2.0.2
   resolution: "blob-util@npm:2.0.2"
@@ -2638,7 +2741,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^5.6.0":
+"buffer@npm:^5.5.0, buffer@npm:^5.6.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
   dependencies:
@@ -2654,6 +2757,17 @@ __metadata:
   dependencies:
     semver: "npm:^7.0.0"
   checksum: 10c0/9390a51a9abbc0233dac79c66715f927508b9d0c62cb7a42448fe8c52def60c707e6e9eb2cc4c9b7aba11601899935bca4e4064ae5e19c04c7e1bb9309e69134
+  languageName: node
+  linkType: hard
+
+"bvaughn-enquirer@npm:2.4.2":
+  version: 2.4.2
+  resolution: "bvaughn-enquirer@npm:2.4.2"
+  dependencies:
+    ansi-colors: "npm:^4.1.1"
+    prettier: "npm:^3.2.4"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10c0/cac9ad4b78c94314ed45f59163aa422f74669a7d99be78963e668276a6f680c807b017b002da05e1efd61e9eec56affc7baa6ee817af9f65d0f1bc5f77f1995c
   languageName: node
   linkType: hard
 
@@ -2684,7 +2798,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind@npm:^1.0.2, call-bind@npm:^1.0.5, call-bind@npm:^1.0.6, call-bind@npm:^1.0.7":
+"call-bind@npm:^1.0.0, call-bind@npm:^1.0.2, call-bind@npm:^1.0.5, call-bind@npm:^1.0.6, call-bind@npm:^1.0.7":
   version: 1.0.7
   resolution: "call-bind@npm:1.0.7"
   dependencies:
@@ -2743,7 +2857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -2757,6 +2871,13 @@ __metadata:
   version: 1.0.2
   resolution: "char-regex@npm:1.0.2"
   checksum: 10c0/57a09a86371331e0be35d9083ba429e86c4f4648ecbe27455dbfb343037c16ee6fdc7f6b61f433a57cc5ded5561d71c56a150e018f40c2ffb7bc93a26dae341e
+  languageName: node
+  linkType: hard
+
+"chardet@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "chardet@npm:0.7.0"
+  checksum: 10c0/96e4731b9ec8050cbb56ab684e8c48d6c33f7826b755802d14e3ebfdc51c57afeece3ea39bc6b09acc359e4363525388b915e16640c1378053820f5e70d0f27d
   languageName: node
   linkType: hard
 
@@ -2811,6 +2932,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-cursor@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "cli-cursor@npm:4.0.0"
+  dependencies:
+    restore-cursor: "npm:^4.0.0"
+  checksum: 10c0/e776e8c3c6727300d0539b0d25160b2bb56aed1a63942753ba1826b012f337a6f4b7ace3548402e4f2f13b5e16bfd751be672c44b203205e7eca8be94afec42c
+  languageName: node
+  linkType: hard
+
+"cli-spinners@npm:^2.5.0, cli-spinners@npm:^2.9.2":
+  version: 2.9.2
+  resolution: "cli-spinners@npm:2.9.2"
+  checksum: 10c0/907a1c227ddf0d7a101e7ab8b300affc742ead4b4ebe920a5bf1bc6d45dce2958fcd195eb28fa25275062fe6fa9b109b93b63bc8033396ed3bcb50297008b3a3
+  languageName: node
+  linkType: hard
+
 "cli-table3@npm:~0.6.1":
   version: 0.6.3
   resolution: "cli-table3@npm:0.6.3"
@@ -2834,6 +2971,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-width@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "cli-width@npm:3.0.0"
+  checksum: 10c0/125a62810e59a2564268c80fdff56c23159a7690c003e34aeb2e68497dccff26911998ff49c33916fcfdf71e824322cc3953e3f7b48b27267c7a062c81348a9a
+  languageName: node
+  linkType: hard
+
 "cliui@npm:^8.0.1":
   version: 8.0.1
   resolution: "cliui@npm:8.0.1"
@@ -2842,6 +2986,13 @@ __metadata:
     strip-ansi: "npm:^6.0.1"
     wrap-ansi: "npm:^7.0.0"
   checksum: 10c0/4bda0f09c340cbb6dfdc1ed508b3ca080f12992c18d68c6be4d9cf51756033d5266e61ec57529e610dacbf4da1c634423b0c1b11037709cc6b09045cbd815df5
+  languageName: node
+  linkType: hard
+
+"clone@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "clone@npm:1.0.4"
+  checksum: 10c0/2176952b3649293473999a95d7bebfc9dc96410f6cbd3d2595cf12fd401f63a4bf41a7adbfd3ab2ff09ed60cb9870c58c6acdd18b87767366fabfc163700f13b
   languageName: node
   linkType: hard
 
@@ -3096,6 +3247,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"date-fns@npm:^2.28.0":
+  version: 2.30.0
+  resolution: "date-fns@npm:2.30.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.21.0"
+  checksum: 10c0/e4b521fbf22bc8c3db332bbfb7b094fd3e7627de0259a9d17c7551e2d2702608a7307a449206065916538e384f37b181565447ce2637ae09828427aed9cb5581
+  languageName: node
+  linkType: hard
+
 "dayjs@npm:^1.10.4":
   version: 1.11.10
   resolution: "dayjs@npm:1.11.10"
@@ -3154,6 +3314,15 @@ __metadata:
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
   checksum: 10c0/e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
+  languageName: node
+  linkType: hard
+
+"defaults@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "defaults@npm:1.0.4"
+  dependencies:
+    clone: "npm:^1.0.2"
+  checksum: 10c0/9cfbe498f5c8ed733775db62dfd585780387d93c17477949e1670bfcfb9346e0281ce8c4bf9f4ac1fc0f9b851113bd6dc9e41182ea1644ccd97de639fa13c35a
   languageName: node
   linkType: hard
 
@@ -3267,6 +3436,13 @@ __metadata:
   version: 0.10.2
   resolution: "emittery@npm:0.10.2"
   checksum: 10c0/2caeea7501a0cca9b0e9d8d0a84d7d059cd2319ab02016bb6f81ae8bc2f3353c6734ed50a5fe0e4e2b96ebcc1623c1344b6beec51a4feda34b121942dd50ba55
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^10.3.0":
+  version: 10.3.0
+  resolution: "emoji-regex@npm:10.3.0"
+  checksum: 10c0/b4838e8dcdceb44cf47f59abe352c25ff4fe7857acaf5fb51097c427f6f75b44d052eb907a7a3b86f86bc4eae3a93f5c2b7460abe79c407307e6212d65c91163
   languageName: node
   linkType: hard
 
@@ -3783,6 +3959,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"external-editor@npm:^3.0.3":
+  version: 3.1.0
+  resolution: "external-editor@npm:3.1.0"
+  dependencies:
+    chardet: "npm:^0.7.0"
+    iconv-lite: "npm:^0.4.24"
+    tmp: "npm:^0.0.33"
+  checksum: 10c0/c98f1ba3efdfa3c561db4447ff366a6adb5c1e2581462522c56a18bf90dfe4da382f9cd1feee3e330108c3595a854b218272539f311ba1b3298f841eb0fbf339
+  languageName: node
+  linkType: hard
+
 "extract-zip@npm:2.0.1":
   version: 2.0.1
   resolution: "extract-zip@npm:2.0.1"
@@ -3899,7 +4086,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"figures@npm:^3.2.0":
+"figures@npm:^3.0.0, figures@npm:^3.2.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
   dependencies:
@@ -4049,6 +4236,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:latest":
+  version: 11.2.0
+  resolution: "fs-extra@npm:11.2.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10c0/d77a9a9efe60532d2e790e938c81a02c1b24904ef7a3efb3990b835514465ba720e99a6ea56fd5e2db53b4695319b644d76d5a0e9988a2beef80aa7b1da63398
+  languageName: node
+  linkType: hard
+
 "fs-minipass@npm:^2.0.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
@@ -4137,6 +4335,13 @@ __metadata:
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
   checksum: 10c0/c6c7b60271931fa752aeb92f2b47e355eac1af3a2673f47c9589e8f8a41adc74d45551c1bc57b5e66a80609f10ffb72b6f575e4370d61cc3f7f3aaff01757cde
+  languageName: node
+  linkType: hard
+
+"get-east-asian-width@npm:^1.0.0":
+  version: 1.2.0
+  resolution: "get-east-asian-width@npm:1.2.0"
+  checksum: 10c0/914b1e217cf38436c24b4c60b4c45289e39a45bf9e65ef9fd343c2815a1a02b8a0215aeec8bf9c07c516089004b6e3826332481f40a09529fcadbf6e579f286b
   languageName: node
   linkType: hard
 
@@ -4445,6 +4650,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iconv-lite@npm:^0.4.24":
+  version: 0.4.24
+  resolution: "iconv-lite@npm:0.4.24"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3"
+  checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -4535,6 +4749,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"inquirer@npm:^8.0.0":
+  version: 8.2.6
+  resolution: "inquirer@npm:8.2.6"
+  dependencies:
+    ansi-escapes: "npm:^4.2.1"
+    chalk: "npm:^4.1.1"
+    cli-cursor: "npm:^3.1.0"
+    cli-width: "npm:^3.0.0"
+    external-editor: "npm:^3.0.3"
+    figures: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    mute-stream: "npm:0.0.8"
+    ora: "npm:^5.4.1"
+    run-async: "npm:^2.4.0"
+    rxjs: "npm:^7.5.5"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+    through: "npm:^2.3.6"
+    wrap-ansi: "npm:^6.0.1"
+  checksum: 10c0/eb5724de1778265323f3a68c80acfa899378cb43c24cdcb58661386500e5696b6b0b6c700e046b7aa767fe7b4823c6f04e6ddc268173e3f84116112529016296
+  languageName: node
+  linkType: hard
+
 "internal-slot@npm:^1.0.5, internal-slot@npm:^1.0.7":
   version: 1.0.7
   resolution: "internal-slot@npm:1.0.7"
@@ -4553,6 +4790,16 @@ __metadata:
     jsbn: "npm:1.1.0"
     sprintf-js: "npm:^1.1.3"
   checksum: 10c0/331cd07fafcb3b24100613e4b53e1a2b4feab11e671e655d46dc09ee233da5011284d09ca40c4ecbdfe1d0004f462958675c224a804259f2f78d2465a87824bc
+  languageName: node
+  linkType: hard
+
+"is-arguments@npm:^1.0.4":
+  version: 1.1.1
+  resolution: "is-arguments@npm:1.1.1"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    has-tostringtag: "npm:^1.0.0"
+  checksum: 10c0/5ff1f341ee4475350adfc14b2328b38962564b7c2076be2f5bac7bd9b61779efba99b9f844a7b82ba7654adccf8e8eb19d1bb0cc6d1c1a085e498f6793d4328f
   languageName: node
   linkType: hard
 
@@ -4660,10 +4907,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-fullwidth-code-point@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "is-fullwidth-code-point@npm:5.0.0"
+  dependencies:
+    get-east-asian-width: "npm:^1.0.0"
+  checksum: 10c0/cd591b27d43d76b05fa65ed03eddce57a16e1eca0b7797ff7255de97019bcaf0219acfc0c4f7af13319e13541f2a53c0ace476f442b13267b9a6a7568f2b65c8
+  languageName: node
+  linkType: hard
+
 "is-generator-fn@npm:^2.0.0":
   version: 2.1.0
   resolution: "is-generator-fn@npm:2.1.0"
   checksum: 10c0/2957cab387997a466cd0bf5c1b6047bd21ecb32bdcfd8996b15747aa01002c1c88731802f1b3d34ac99f4f6874b626418bd118658cf39380fe5fff32a3af9c4d
+  languageName: node
+  linkType: hard
+
+"is-generator-function@npm:^1.0.7":
+  version: 1.0.10
+  resolution: "is-generator-function@npm:1.0.10"
+  dependencies:
+    has-tostringtag: "npm:^1.0.0"
+  checksum: 10c0/df03514df01a6098945b5a0cfa1abff715807c8e72f57c49a0686ad54b3b74d394e2d8714e6f709a71eb00c9630d48e73ca1796c1ccc84ac95092c1fecc0d98b
   languageName: node
   linkType: hard
 
@@ -4686,10 +4951,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-interactive@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-interactive@npm:1.0.0"
+  checksum: 10c0/dd47904dbf286cd20aa58c5192161be1a67138485b9836d5a70433b21a45442e9611b8498b8ab1f839fc962c7620667a50535fdfb4a6bc7989b8858645c06b4d
+  languageName: node
+  linkType: hard
+
 "is-lambda@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-lambda@npm:1.0.1"
   checksum: 10c0/85fee098ae62ba6f1e24cf22678805473c7afd0fb3978a3aa260e354cb7bcb3a5806cf0a98403188465efedec41ab4348e8e4e79305d409601323855b3839d4d
+  languageName: node
+  linkType: hard
+
+"is-nan@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "is-nan@npm:1.3.2"
+  dependencies:
+    call-bind: "npm:^1.0.0"
+    define-properties: "npm:^1.1.3"
+  checksum: 10c0/8bfb286f85763f9c2e28ea32e9127702fe980ffd15fa5d63ade3be7786559e6e21355d3625dd364c769c033c5aedf0a2ed3d4025d336abf1b9241e3d9eddc5b0
   languageName: node
   linkType: hard
 
@@ -4767,7 +5049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-typed-array@npm:^1.1.13":
+"is-typed-array@npm:^1.1.13, is-typed-array@npm:^1.1.3":
   version: 1.1.13
   resolution: "is-typed-array@npm:1.1.13"
   dependencies:
@@ -5944,6 +6226,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.padstart@npm:^4.6.1":
+  version: 4.6.1
+  resolution: "lodash.padstart@npm:4.6.1"
+  checksum: 10c0/13c6c867d92a4dddd340484bc18ba89f08598c1afdd4d4eb9f0deb0d00842643cf134fab5262518407f6d3f0d2ab4fb3a8bcc7fcec02acbabfb1810de860485f
+  languageName: node
+  linkType: hard
+
 "lodash.truncate@npm:^4.4.2":
   version: 4.4.2
   resolution: "lodash.truncate@npm:4.4.2"
@@ -5958,7 +6247,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"log-symbols@npm:^4.0.0":
+"log-symbols@npm:^4.0.0, log-symbols@npm:^4.1.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
   dependencies:
@@ -5977,6 +6266,19 @@ __metadata:
     slice-ansi: "npm:^4.0.0"
     wrap-ansi: "npm:^6.2.0"
   checksum: 10c0/18b299e230432a156f2535660776406d15ba8bb7817dd3eaadd58004b363756d4ecaabcd658f9949f90b62ea7d3354423be3fdeb7a201ab951ec0e8d6139af86
+  languageName: node
+  linkType: hard
+
+"log-update@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "log-update@npm:6.0.0"
+  dependencies:
+    ansi-escapes: "npm:^6.2.0"
+    cli-cursor: "npm:^4.0.0"
+    slice-ansi: "npm:^7.0.0"
+    strip-ansi: "npm:^7.1.0"
+    wrap-ansi: "npm:^9.0.0"
+  checksum: 10c0/e0b3c3401ef49ce3eb17e2f83d644765e4f7988498fc1344eaa4f31ab30e510dcc469a7fb64dc01bd1c8d9237d917598fa677a9818705fb3774c10f6e9d4b27c
   languageName: node
   linkType: hard
 
@@ -6253,6 +6555,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mute-stream@npm:0.0.8":
+  version: 0.0.8
+  resolution: "mute-stream@npm:0.0.8"
+  checksum: 10c0/18d06d92e5d6d45e2b63c0e1b8f25376af71748ac36f53c059baa8b76ffac31c5ab225480494e7d35d30215ecdb18fed26ec23cafcd2f7733f2f14406bcd19e2
+  languageName: node
+  linkType: hard
+
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -6383,6 +6692,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-is@npm:^1.1.5":
+  version: 1.1.6
+  resolution: "object-is@npm:1.1.6"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+  checksum: 10c0/506af444c4dce7f8e31f34fc549e2fb8152d6b9c4a30c6e62852badd7f520b579c679af433e7a072f9d78eb7808d230dc12e1cf58da9154dfbf8813099ea0fe0
+  languageName: node
+  linkType: hard
+
 "object-keys@npm:^1.1.1":
   version: 1.1.1
   resolution: "object-keys@npm:1.1.1"
@@ -6390,7 +6709,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.assign@npm:^4.1.0, object.assign@npm:^4.1.5":
+"object.assign@npm:^4.1.0, object.assign@npm:^4.1.4, object.assign@npm:^4.1.5":
   version: 4.1.5
   resolution: "object.assign@npm:4.1.5"
   dependencies:
@@ -6445,12 +6764,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ora@npm:^5.4.1":
+  version: 5.4.1
+  resolution: "ora@npm:5.4.1"
+  dependencies:
+    bl: "npm:^4.1.0"
+    chalk: "npm:^4.1.0"
+    cli-cursor: "npm:^3.1.0"
+    cli-spinners: "npm:^2.5.0"
+    is-interactive: "npm:^1.0.0"
+    is-unicode-supported: "npm:^0.1.0"
+    log-symbols: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+    wcwidth: "npm:^1.0.1"
+  checksum: 10c0/10ff14aace236d0e2f044193362b22edce4784add08b779eccc8f8ef97195cae1248db8ec1ec5f5ff076f91acbe573f5f42a98c19b78dba8c54eefff983cae85
+  languageName: node
+  linkType: hard
+
 "original@npm:^1.0.2":
   version: 1.0.2
   resolution: "original@npm:1.0.2"
   dependencies:
     url-parse: "npm:^1.4.3"
   checksum: 10c0/af143d5be62b055ffb6fc2a0d08a650b822f48feca4ea21940c1f7a147727a317faedca254394ad0028ddaa4eecf7cf4376c370d746386cc35974e9122ebb14a
+  languageName: node
+  linkType: hard
+
+"os-tmpdir@npm:~1.0.2":
+  version: 1.0.2
+  resolution: "os-tmpdir@npm:1.0.2"
+  checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
   languageName: node
   linkType: hard
 
@@ -6531,6 +6874,13 @@ __metadata:
     json-parse-even-better-errors: "npm:^2.3.0"
     lines-and-columns: "npm:^1.1.6"
   checksum: 10c0/77947f2253005be7a12d858aedbafa09c9ae39eb4863adf330f7b416ca4f4a08132e453e08de2db46459256fb66afaac5ee758b44fe6541b7cdaf9d252e59585
+  languageName: node
+  linkType: hard
+
+"parse-ms@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "parse-ms@npm:2.1.0"
+  checksum: 10c0/9c5c0a95c6267c84085685556a6e102ee806c3147ec11cbb9b98e35998eb4a48a757bd6ea7bfd930062de65909a33d24985055b4394e70aa0b65ee40cef16911
   languageName: node
   linkType: hard
 
@@ -6745,6 +7095,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier@npm:^3.2.4":
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/ea327f37a7d46f2324a34ad35292af2ad4c4c3c3355da07313339d7e554320f66f65f91e856add8530157a733c6c4a897dc41b577056be5c24c40f739f5ee8c6
+  languageName: node
+  linkType: hard
+
 "pretty-bytes@npm:^5.6.0":
   version: 5.6.0
   resolution: "pretty-bytes@npm:5.6.0"
@@ -6772,6 +7131,15 @@ __metadata:
     ansi-styles: "npm:^5.0.0"
     react-is: "npm:^18.0.0"
   checksum: 10c0/596d8b459b6fdac7dcbd70d40169191e889939c17ffbcc73eebe2a9a6f82cdbb57faffe190274e0a507d9ecdf3affadf8a9b43442a625eecfbd2813b9319660f
+  languageName: node
+  linkType: hard
+
+"pretty-ms@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "pretty-ms@npm:7.0.1"
+  dependencies:
+    parse-ms: "npm:^2.1.0"
+  checksum: 10c0/069aec9d939e7903846b3db53b020bed92e3dc5909e0fef09ec8ab104a0b7f9a846605a1633c60af900d288582fb333f6f30469e59d6487a2330301fad35a89c
   languageName: node
   linkType: hard
 
@@ -6928,7 +7296,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:2 || 3":
+"readable-stream@npm:2 || 3, readable-stream@npm:^3.4.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -6936,6 +7304,13 @@ __metadata:
     string_decoder: "npm:^1.1.1"
     util-deprecate: "npm:^1.0.1"
   checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.14.0":
+  version: 0.14.1
+  resolution: "regenerator-runtime@npm:0.14.1"
+  checksum: 10c0/1b16eb2c4bceb1665c89de70dcb64126a22bc8eb958feef3cd68fe11ac6d2a4899b5cd1b80b0774c7c03591dc57d16631a7f69d2daa2ec98100e2f29f7ec4cc4
   languageName: node
   linkType: hard
 
@@ -6967,6 +7342,51 @@ __metadata:
     node-fetch: "npm:^3.3.1"
     prettier: "npm:^2.7.1"
     typescript: "npm:^5.4.2"
+  languageName: unknown
+  linkType: soft
+
+"replayio@workspace:packages/replayio":
+  version: 0.0.0-use.local
+  resolution: "replayio@workspace:packages/replayio"
+  dependencies:
+    "@replay-cli/tsconfig": "workspace:^"
+    "@replayio/sourcemap-upload": "workspace:^"
+    "@types/debug": "npm:^4.1.7"
+    "@types/fs-extra": "npm:latest"
+    "@types/inquirer": "npm:^9"
+    "@types/jest": "npm:^28.1.5"
+    "@types/lodash.padstart": "npm:^4.6.9"
+    "@types/node-fetch": "npm:^2.6.3"
+    "@types/semver": "npm:^7.5.6"
+    "@types/table": "npm:^6.3.2"
+    "@types/ws": "npm:^8.5.10"
+    assert: "npm:latest"
+    bvaughn-enquirer: "npm:2.4.2"
+    cli-spinners: "npm:^2.9.2"
+    commander: "npm:^12.0.0"
+    date-fns: "npm:^2.28.0"
+    debug: "npm:^4.3.4"
+    fs-extra: "npm:latest"
+    inquirer: "npm:^8.0.0"
+    is-uuid: "npm:^1.0.2"
+    jest: "npm:^28.1.3"
+    jsonata: "npm:^1.8.6"
+    launchdarkly-node-client-sdk: "npm:^3.1.0"
+    lodash.padstart: "npm:^4.6.1"
+    log-update: "npm:^6.0.0"
+    node-fetch: "npm:^2.6.8"
+    p-map: "npm:^4.0.0"
+    prettier: "npm:^2.7.1"
+    pretty-ms: "npm:^7.0.1"
+    query-registry: "npm:^2.6.0"
+    semver: "npm:^7.5.4"
+    superstruct: "npm:^0.15.4"
+    table: "npm:^6.8.2"
+    ts-jest: "npm:^28.0.6"
+    typescript: "npm:^5.4.2"
+    ws: "npm:^7.5.0"
+  bin:
+    replayio: ./replayio.js
   languageName: unknown
   linkType: soft
 
@@ -7073,6 +7493,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"restore-cursor@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "restore-cursor@npm:4.0.0"
+  dependencies:
+    onetime: "npm:^5.1.0"
+    signal-exit: "npm:^3.0.2"
+  checksum: 10c0/6f7da8c5e422ac26aa38354870b1afac09963572cf2879443540449068cb43476e9cbccf6f8de3e0171e0d6f7f533c2bc1a0a008003c9a525bbc098e89041318
+  languageName: node
+  linkType: hard
+
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -7105,6 +7535,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"run-async@npm:^2.4.0":
+  version: 2.4.1
+  resolution: "run-async@npm:2.4.1"
+  checksum: 10c0/35a68c8f1d9664f6c7c2e153877ca1d6e4f886e5ca067c25cdd895a6891ff3a1466ee07c63d6a9be306e9619ff7d509494e6d9c129516a36b9fd82263d579ee1
+  languageName: node
+  linkType: hard
+
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
@@ -7114,7 +7551,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.5.1":
+"rxjs@npm:^7.2.0, rxjs@npm:^7.5.1, rxjs@npm:^7.5.5":
   version: 7.8.1
   resolution: "rxjs@npm:7.8.1"
   dependencies:
@@ -7153,7 +7590,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:^2.0.2, safer-buffer@npm:^2.1.0, safer-buffer@npm:~2.1.0":
+"safer-buffer@npm:>= 2.1.2 < 3, safer-buffer@npm:>= 2.1.2 < 3.0.0, safer-buffer@npm:^2.0.2, safer-buffer@npm:^2.1.0, safer-buffer@npm:~2.1.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
   checksum: 10c0/7e3c8b2e88a1841c9671094bbaeebd94448111dd90a81a1f606f3f67708a6ec57763b3b47f06da09fc6054193e0e6709e77325415dc8422b04497a8070fa02d4
@@ -7308,6 +7745,16 @@ __metadata:
     astral-regex: "npm:^2.0.0"
     is-fullwidth-code-point: "npm:^3.0.0"
   checksum: 10c0/6c25678db1270d4793e0327620f1e0f9f5bea4630123f51e9e399191bc52c87d6e6de53ed33538609e5eacbd1fab769fae00f3705d08d029f02102a540648918
+  languageName: node
+  linkType: hard
+
+"slice-ansi@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "slice-ansi@npm:7.1.0"
+  dependencies:
+    ansi-styles: "npm:^6.2.1"
+    is-fullwidth-code-point: "npm:^5.0.0"
+  checksum: 10c0/631c971d4abf56cf880f034d43fcc44ff883624867bf11ecbd538c47343911d734a4656d7bc02362b40b89d765652a7f935595441e519b59e2ad3f4d5d6fe7ca
   languageName: node
   linkType: hard
 
@@ -7519,6 +7966,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-width@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "string-width@npm:7.1.0"
+  dependencies:
+    emoji-regex: "npm:^10.3.0"
+    get-east-asian-width: "npm:^1.0.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10c0/68a99fbc3bd3d8eb42886ff38dce819767dee55f606f74dfa4687a07dfd21262745d9683df0aa53bf81a5dd47c13da921a501925b974bec66a7ddd634fef0634
+  languageName: node
+  linkType: hard
+
 "string.prototype.matchall@npm:^4.0.5":
   version: 4.0.10
   resolution: "string.prototype.matchall@npm:4.0.10"
@@ -7587,7 +8045,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^7.0.1":
+"strip-ansi@npm:^7.0.1, strip-ansi@npm:^7.1.0":
   version: 7.1.0
   resolution: "strip-ansi@npm:7.1.0"
   dependencies:
@@ -7665,6 +8123,19 @@ __metadata:
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
   checksum: 10c0/6c4032340701a9950865f7ae8ef38578d8d7053f5e10518076e6554a9381fa91bd9c6850193695c141f32b21f979c985db07265a758867bac95de05f7d8aeb39
+  languageName: node
+  linkType: hard
+
+"table@npm:*, table@npm:^6.8.2":
+  version: 6.8.2
+  resolution: "table@npm:6.8.2"
+  dependencies:
+    ajv: "npm:^8.0.1"
+    lodash.truncate: "npm:^4.4.2"
+    slice-ansi: "npm:^4.0.0"
+    string-width: "npm:^4.2.3"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10c0/f8b348af38ee34e419d8ce7306ba00671ce6f20e861ccff22555f491ba264e8416086063ce278a8d81abfa8d23b736ec2cca7ac4029b5472f63daa4b4688b803
   languageName: node
   linkType: hard
 
@@ -7799,7 +8270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through@npm:2, through@npm:^2.3.8, through@npm:~2.3, through@npm:~2.3.1":
+"through@npm:2, through@npm:^2.3.6, through@npm:^2.3.8, through@npm:~2.3, through@npm:~2.3.1":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
@@ -7810,6 +8281,15 @@ __metadata:
   version: 8.0.2
   resolution: "tiny-lru@npm:8.0.2"
   checksum: 10c0/32dc73db748ae50bf43498f81150ed23922c924d7a3665ea240c7041abbbd5e8667c05328fd520ca923b4d10b89e69a4ba671365eaac221c6f7eb8b898530506
+  languageName: node
+  linkType: hard
+
+"tmp@npm:^0.0.33":
+  version: 0.0.33
+  resolution: "tmp@npm:0.0.33"
+  dependencies:
+    os-tmpdir: "npm:~1.0.2"
+  checksum: 10c0/69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
   languageName: node
   linkType: hard
 
@@ -8168,6 +8648,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"util@npm:^0.12.5":
+  version: 0.12.5
+  resolution: "util@npm:0.12.5"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    is-arguments: "npm:^1.0.4"
+    is-generator-function: "npm:^1.0.7"
+    is-typed-array: "npm:^1.1.3"
+    which-typed-array: "npm:^1.1.2"
+  checksum: 10c0/c27054de2cea2229a66c09522d0fa1415fb12d861d08523a8846bf2e4cbf0079d4c3f725f09dcb87493549bcbf05f5798dce1688b53c6c17201a45759e7253f3
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^8.0.0, uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
@@ -8242,6 +8735,15 @@ __metadata:
     glob-to-regexp: "npm:^0.4.1"
     graceful-fs: "npm:^4.1.2"
   checksum: 10c0/c694de0a61004e587a8a0fdc9cfec20ee692c52032d9ab2c2e99969a37fdab9e6e1bd3164ed506f9a13f7c83e65563d563e0d6b87358470cdb7309b83db78683
+  languageName: node
+  linkType: hard
+
+"wcwidth@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "wcwidth@npm:1.0.1"
+  dependencies:
+    defaults: "npm:^1.0.3"
+  checksum: 10c0/5b61ca583a95e2dd85d7078400190efd452e05751a64accb8c06ce4db65d7e0b0cde9917d705e826a2e05cc2548f61efde115ffa374c3e436d04be45c889e5b4
   languageName: node
   linkType: hard
 
@@ -8326,7 +8828,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-typed-array@npm:^1.1.14":
+"which-typed-array@npm:^1.1.14, which-typed-array@npm:^1.1.2":
   version: 1.1.15
   resolution: "which-typed-array@npm:1.1.15"
   dependencies:
@@ -8372,7 +8874,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^6.2.0":
+"wrap-ansi@npm:^6.0.1, wrap-ansi@npm:^6.2.0":
   version: 6.2.0
   resolution: "wrap-ansi@npm:6.2.0"
   dependencies:
@@ -8391,6 +8893,17 @@ __metadata:
     string-width: "npm:^5.0.1"
     strip-ansi: "npm:^7.0.1"
   checksum: 10c0/138ff58a41d2f877eae87e3282c0630fc2789012fc1af4d6bd626eeb9a2f9a65ca92005e6e69a75c7b85a68479fe7443c7dbe1eb8fbaa681a4491364b7c55c60
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "wrap-ansi@npm:9.0.0"
+  dependencies:
+    ansi-styles: "npm:^6.2.1"
+    string-width: "npm:^7.0.0"
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10c0/a139b818da9573677548dd463bd626a5a5286271211eb6e4e82f34a4f643191d74e6d4a9bb0a3c26ec90e6f904f679e0569674ac099ea12378a8b98e20706066
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Continued in #346

New Replay CLI (`replayio` package) with the following commands ¹
- [x] `list`: List all local recordings
  * `list` or `list --json`
- [x] `login`: Sign-in via system browser; only necessary if no API key env var is set
  - [x] Store access token _and_ refresh token (so we can regenerate expired access token)
- [x] `logout`: Sign-out; has no effect if API key env var is set
- [x] `record`: Launch Replay browser, record, and upload
  * `record` or `record <url>`
  - [x] Verify authentication (either API key or prompt for sign-in)
  - [x] Prompt user to update NPM package if a newer release is available
  - [x] Prompt user to update runtime if a newer release is available
  - [x] Launch Replay Chrome in record mode
  - [x] Prompt user to select which new recordings to upload ²
- [x] `remove`: Remove one or more recordings
  * `remove <id>` or `remove --all`
- [x] `update`: Update installed Replay runtime; (Chrome only for now)
- [ ] `upload`: Upload one or more recordings ³
  * `upload <id>` or `upload --all`
  - [ ] Process uploaded recordings ³
- [ ] `upload-source-maps`: Upload source-maps for a Workspace ³
- [x] `view`

---

### Example help output

![Screenshot 2024-04-03 at 10 01 36 AM](https://github.com/replayio/replay-cli/assets/29597/a49b6089-4e93-4cfb-a096-90286b28cbb7)

![Screenshot 2024-04-03 at 10 02 00 AM](https://github.com/replayio/replay-cli/assets/29597/cc9eecc3-987e-4ea9-af5b-7c8f55a1ca7b)

### Example `replay list` output

![Screenshot 2024-04-03 at 9 45 57 AM](https://github.com/replayio/replay-cli/assets/29597/c25a18db-93a8-4180-a018-116d98768b4b)

### Example `replay upload` output

![Screenshot 2024-04-03 at 10 03 54 AM](https://github.com/replayio/replay-cli/assets/29597/0e541089-c2fc-4807-865b-e6b11d92d99a)

### Example `replay record` flow

![Screenshot 2024-04-03 at 10 02 56 AM](https://github.com/replayio/replay-cli/assets/29597/154c85e4-1bf3-445a-85a2-8f91c8d4525e)

---

¹ A complete list of commands can be seen on the Notion project page
² Pending the outcome of TT-211, we may make this step more automated
³ This functionality will be implemented in a separate follow-up PR