### PR TITLE
Bump the compilation target in `@replayio/playwright`

### DIFF
--- a/packages/playwright/tsconfig.json
+++ b/packages/playwright/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@replay-cli/tsconfig/base.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "target": "ES2017"
   },
   "include": ["src/**/*.ts"],
   "references": [


### PR DESCRIPTION
Transforming async functions and destructuring patterns led to problems since Playwright extracts parameter names from the source text of the loaded functions. The error has been thrown here:
https://github.com/microsoft/playwright/blob/4d4308e7b3a8c870a5a44aba09dea5e0a0519435/packages/playwright/src/common/fixtures.ts#L252