### PR TITLE
CLI UX improvements

### DIFF
--- a/packages/replayio/src/commands/record.ts
+++ b/packages/replayio/src/commands/record.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from "uuid";
 import { launchBrowser } from "../utils/browser/launchBrowser";
 import { registerAuthenticatedCommand } from "../utils/commander";
 import { confirm } from "../utils/confirm";
@@ -19,7 +20,7 @@ async function record(url: string = "about:blank") {
 
   const recordingsBefore = await getRecordings();
 
-  await launchBrowser(url);
+  await launchBrowser(url, { processGroupId: uuid() });
 
   const recordingsAfter = await getRecordings();
   const recordingsNew = recordingsAfter.filter(
@@ -46,7 +47,8 @@ async function record(url: string = "about:blank") {
       console.log(""); // Spacing for readability
     } else {
       selectedRecordings = await selectRecordings(recordingsNew, {
-        defaultSelected: recording => recording.metadata.processType === "root",
+        defaultSelected: recording =>
+          recording.metadata.processType === undefined || recording.metadata.processType === "root",
         prompt: "New recordings found. Which would you like to upload?",
         selectionMessage: "The following recording(s) will be uploaded:",
       });

--- a/packages/replayio/src/commands/record.ts
+++ b/packages/replayio/src/commands/record.ts
@@ -9,6 +9,7 @@ import { printRecordings } from "../utils/recordings/printRecordings";
 import { selectRecordings } from "../utils/recordings/selectRecordings";
 import { LocalRecording } from "../utils/recordings/types";
 import { uploadRecordings } from "../utils/recordings/upload/uploadRecordings";
+import { findMostRecentPrimaryRecording } from "../utils/recordings/findMostRecentPrimaryRecording";
 
 registerAuthenticatedCommand("record")
   .argument("[url]", `URL to open (default: "about:blank")`)
@@ -46,9 +47,10 @@ async function record(url: string = "about:blank") {
 
       console.log(""); // Spacing for readability
     } else {
+      const defaultRecording = findMostRecentPrimaryRecording(recordingsNew);
+
       selectedRecordings = await selectRecordings(recordingsNew, {
-        defaultSelected: recording =>
-          recording.metadata.processType === undefined || recording.metadata.processType === "root",
+        defaultSelected: recording => recording === defaultRecording,
         prompt: "New recordings found. Which would you like to upload?",
         selectionMessage: "The following recording(s) will be uploaded:",
       });

--- a/packages/replayio/src/commands/upload.ts
+++ b/packages/replayio/src/commands/upload.ts
@@ -32,7 +32,8 @@ async function upload(
     selectedRecordings = recordings;
   } else {
     selectedRecordings = await selectRecordings(recordings, {
-      defaultSelected: recording => recording.metadata.processType === "root",
+      defaultSelected: recording =>
+        recording.metadata.processType === undefined || recording.metadata.processType === "root",
       disabledSelector: recording => !canUpload(recording),
       noSelectableRecordingsMessage:
         "The recording(s) below cannot be uploaded.\n" +

--- a/packages/replayio/src/commands/upload.ts
+++ b/packages/replayio/src/commands/upload.ts
@@ -1,6 +1,7 @@
 import { registerAuthenticatedCommand } from "../utils/commander";
 import { exitProcess } from "../utils/exitProcess";
 import { canUpload } from "../utils/recordings/canUpload";
+import { findMostRecentPrimaryRecording } from "../utils/recordings/findMostRecentPrimaryRecording";
 import { findRecordingsWithShortIds } from "../utils/recordings/findRecordingsWithShortIds";
 import { getRecordings } from "../utils/recordings/getRecordings";
 import { printRecordings } from "../utils/recordings/printRecordings";
@@ -31,9 +32,10 @@ async function upload(
   } else if (all) {
     selectedRecordings = recordings;
   } else {
+    const defaultRecording = findMostRecentPrimaryRecording(recordings);
+
     selectedRecordings = await selectRecordings(recordings, {
-      defaultSelected: recording =>
-        recording.metadata.processType === undefined || recording.metadata.processType === "root",
+      defaultSelected: recording => recording === defaultRecording,
       disabledSelector: recording => !canUpload(recording),
       noSelectableRecordingsMessage:
         "The recording(s) below cannot be uploaded.\n" +

--- a/packages/replayio/src/utils/browser/launchBrowser.ts
+++ b/packages/replayio/src/utils/browser/launchBrowser.ts
@@ -12,9 +12,11 @@ export async function launchBrowser(
   url: string,
   options: {
     directory?: string;
-  } = {}
+    processGroupId: string;
+  }
 ) {
   const { path: executablePath, runtime } = runtimeMetadata;
+  const { directory, processGroupId } = options;
 
   const profileDir = join(runtimePath, "profiles", runtime);
   ensureDirSync(profileDir);
@@ -29,7 +31,8 @@ export async function launchBrowser(
   const processOptions = {
     env: {
       RECORD_ALL_CONTENT: "1",
-      RECORD_REPLAY_DIRECTORY: options.directory,
+      RECORD_REPLAY_DIRECTORY: directory,
+      RECORD_REPLAY_METADATA: JSON.stringify({ processGroupId }),
     },
     stdio: undefined,
   };

--- a/packages/replayio/src/utils/installation/promptForUpdate.ts
+++ b/packages/replayio/src/utils/installation/promptForUpdate.ts
@@ -14,7 +14,7 @@ import { MetadataJSON } from "./types";
 const PROMPT_ID = "runtime-update";
 
 export async function promptForUpdate() {
-  const { path: executablePath, runtime } = runtimeMetadata;
+  const { path: executablePath } = runtimeMetadata;
   const runtimeExecutablePath = join(runtimePath, ...executablePath);
   let isRuntimeInstalled = existsSync(runtimeExecutablePath);
 

--- a/packages/replayio/src/utils/recordings/findMostRecentPrimaryRecording.ts
+++ b/packages/replayio/src/utils/recordings/findMostRecentPrimaryRecording.ts
@@ -1,0 +1,12 @@
+import { LocalRecording } from "./types";
+
+export function findMostRecentPrimaryRecording(
+  recordings: LocalRecording[]
+): LocalRecording | undefined {
+  const cloned = [...recordings];
+  cloned.sort((a, b) => b.date.getTime() - a.date.getTime());
+  return cloned.find(
+    recording =>
+      recording.metadata.processType === undefined || recording.metadata.processType === "root"
+  );
+}

--- a/packages/replayio/src/utils/recordings/formatRecording.ts
+++ b/packages/replayio/src/utils/recordings/formatRecording.ts
@@ -1,14 +1,19 @@
 import { formatDuration, formatRelativeDate } from "../date";
 import { parseBuildId } from "../installation/parseBuildId";
-import { dim, link } from "../theme";
+import { dim, link, transparent } from "../theme";
 import { LocalRecording } from "./types";
 
 const MAX_TITLE_LENGTH = 35;
 
 export function formatRecording(recording: LocalRecording) {
-  const id = recording.id.substring(0, 8) + "…";
+  const { buildId, metadata, recordingStatus, uploadStatus } = recording;
 
-  const { runtime } = parseBuildId(recording.buildId);
+  const { runtime } = parseBuildId(buildId);
+
+  const category =
+    metadata.processType === undefined || metadata.processType === "root" ? "primary" : "secondary";
+
+  let id = recording.id.substring(0, 8) + "…";
 
   let title;
   switch (runtime) {
@@ -17,11 +22,11 @@ export function formatRecording(recording: LocalRecording) {
       break;
     }
     default: {
-      if (recording.metadata.host) {
-        if (recording.metadata.host.length > MAX_TITLE_LENGTH) {
-          title = link(recording.metadata.host.substring(0, MAX_TITLE_LENGTH).trimEnd() + "…");
+      if (metadata.host) {
+        if (metadata.host.length > MAX_TITLE_LENGTH) {
+          title = link(metadata.host.substring(0, MAX_TITLE_LENGTH).trimEnd() + "…");
         } else {
-          title = link(recording.metadata.host);
+          title = link(metadata.host);
         }
       } else {
         title = "(untitled)";
@@ -30,15 +35,13 @@ export function formatRecording(recording: LocalRecording) {
     }
   }
 
-  const date = dim(formatRelativeDate(recording.date));
-  const duration = dim(recording.duration ? formatDuration(recording.duration) : "");
-  const processType = dim(
-    recording.metadata.processType ? `(${recording.metadata.processType})` : ""
-  );
+  let date = dim(formatRelativeDate(recording.date));
+  let duration = dim(recording.duration ? formatDuration(recording.duration) : "");
+  let processType = dim(metadata.processType ? metadata.processType : "");
 
   let status;
-  if (recording.uploadStatus) {
-    switch (recording.uploadStatus) {
+  if (uploadStatus) {
+    switch (uploadStatus) {
       case "uploaded":
         status = "Uploaded";
         break;
@@ -47,7 +50,7 @@ export function formatRecording(recording: LocalRecording) {
         break;
     }
   } else {
-    switch (recording.recordingStatus) {
+    switch (recordingStatus) {
       case "crashed":
         status = "Crashed";
       case "finished":
@@ -59,6 +62,16 @@ export function formatRecording(recording: LocalRecording) {
       case "unusable":
         status = "Unusable";
         break;
+    }
+  }
+
+  switch (category) {
+    case "primary": {
+      break;
+    }
+    case "secondary": {
+      id = `${dim("↘")} ${id}`;
+      break;
     }
   }
 

--- a/packages/replayio/src/utils/recordings/printViewRecordingLinks.ts
+++ b/packages/replayio/src/utils/recordings/printViewRecordingLinks.ts
@@ -5,22 +5,36 @@ import { formatRecording } from "./formatRecording";
 import { LocalRecording } from "./types";
 
 export function printViewRecordingLinks(recordings: LocalRecording[]) {
-  if (recordings.length > 0) {
-    console.log("View recording(s) at:");
-
-    for (const recording of recordings) {
-      const { processType, title } = formatRecording(recording);
-
+  switch (recordings.length) {
+    case 0: {
+      break;
+    }
+    case 1: {
+      const recording = recordings[0];
       const url = `${replayAppHost}/recording/${recording.id}`;
 
-      const formatted = processType ? `${title} ${processType}` : title;
+      console.log("View recording at:");
+      console.log(link(url));
+      break;
+    }
+    default: {
+      console.log("View recording(s) at:");
 
-      let text = `${formatted}: ${link(url)}`;
-      if (strip(text).length > process.stdout.columns) {
-        text = `${formatted}:\n${link(url)}`;
+      for (const recording of recordings) {
+        const { processType, title } = formatRecording(recording);
+
+        const url = `${replayAppHost}/recording/${recording.id}`;
+
+        const formatted = processType ? `${title} ${processType}` : title;
+
+        let text = `${formatted}: ${link(url)}`;
+        if (strip(text).length > process.stdout.columns) {
+          text = `${formatted}:\n${link(url)}`;
+        }
+
+        console.log(text);
       }
-
-      console.log(text);
+      break;
     }
   }
 }

--- a/packages/replayio/src/utils/recordings/types.ts
+++ b/packages/replayio/src/utils/recordings/types.ts
@@ -29,6 +29,7 @@ export type LogEntry = {
   metadata?: {
     argv?: string[];
     process?: ProcessType;
+    processGroupId?: string;
     uri?: string;
     [key: string]: unknown;
   };
@@ -47,6 +48,7 @@ export type LocalRecording = {
   id: string;
   metadata: {
     host: string | undefined;
+    processGroupId: string | undefined;
     processType: ProcessType | undefined;
     sourcemaps: string[] | undefined;
     uri: string | undefined;


### PR DESCRIPTION
- [x] Optimize single recording case: No need to show the title _and_ the URL; just show the URL.
- [x] Group related recordings and sort with root up top

https://github.com/replayio/replay-cli/assets/29597/5e37d9ed-afd9-4781-bd66-b80f71cf2284

- [x] `upload` command should only select the most recent "root" recording by default

![Screenshot 2024-04-09 at 10 18 34 AM](https://github.com/replayio/replay-cli/assets/29597/b0a43ff6-a75a-4257-8201-27c6f708a985)
