### PR TITLE
Upload source maps when uploading a fresh recording

### DIFF
--- a/packages/replayio/src/utils/protocol/api/addOriginalSource.ts
+++ b/packages/replayio/src/utils/protocol/api/addOriginalSource.ts
@@ -1,0 +1,14 @@
+import { addOriginalSourceParameters, addOriginalSourceResult } from "@replayio/protocol";
+import ProtocolClient from "../ProtocolClient";
+
+export async function addOriginalSource(
+  client: ProtocolClient,
+  params: addOriginalSourceParameters
+) {
+  await client.waitUntilAuthenticated();
+
+  return await client.sendCommand<addOriginalSourceParameters, addOriginalSourceResult>({
+    method: "Record.addOriginalSource",
+    params,
+  });
+}

--- a/packages/replayio/src/utils/protocol/api/addOriginalSource.ts
+++ b/packages/replayio/src/utils/protocol/api/addOriginalSource.ts
@@ -8,7 +8,7 @@ export async function addOriginalSource(
   await client.waitUntilAuthenticated();
 
   return await client.sendCommand<addOriginalSourceParameters, addOriginalSourceResult>({
-    method: "Record.addOriginalSource",
+    method: "Recording.addOriginalSource",
     params,
   });
 }

--- a/packages/replayio/src/utils/protocol/api/addSourceMap.ts
+++ b/packages/replayio/src/utils/protocol/api/addSourceMap.ts
@@ -1,0 +1,11 @@
+import { addSourceMapParameters, addSourceMapResult } from "@replayio/protocol";
+import ProtocolClient from "../ProtocolClient";
+
+export async function addSourceMap(client: ProtocolClient, params: addSourceMapParameters) {
+  await client.waitUntilAuthenticated();
+
+  return await client.sendCommand<addSourceMapParameters, addSourceMapResult>({
+    method: "Recording.addSourceMap",
+    params,
+  });
+}

--- a/packages/replayio/src/utils/protocol/api/checkIfResourceExists.ts
+++ b/packages/replayio/src/utils/protocol/api/checkIfResourceExists.ts
@@ -1,0 +1,11 @@
+import { existsParameters, existsResult } from "@replayio/protocol";
+import ProtocolClient from "../ProtocolClient";
+
+export async function checkIfResourceExists(client: ProtocolClient, params: existsParameters) {
+  await client.waitUntilAuthenticated();
+
+  return await client.sendCommand<existsParameters, existsResult>({
+    method: "Resource.exists",
+    params,
+  });
+}

--- a/packages/replayio/src/utils/protocol/api/createResource.ts
+++ b/packages/replayio/src/utils/protocol/api/createResource.ts
@@ -1,0 +1,11 @@
+import { createParameters, createResult } from "@replayio/protocol";
+import ProtocolClient from "../ProtocolClient";
+
+export async function createResource(client: ProtocolClient, params: createParameters) {
+  await client.waitUntilAuthenticated();
+
+  return await client.sendCommand<createParameters, createResult>({
+    method: "Resource.create",
+    params,
+  });
+}

--- a/packages/replayio/src/utils/protocol/api/getResourceToken.ts
+++ b/packages/replayio/src/utils/protocol/api/getResourceToken.ts
@@ -1,0 +1,11 @@
+import { tokenParameters, tokenResult } from "@replayio/protocol";
+import ProtocolClient from "../ProtocolClient";
+
+export async function getResourceToken(client: ProtocolClient, params: tokenParameters) {
+  await client.waitUntilAuthenticated();
+
+  return await client.sendCommand<tokenParameters, tokenResult>({
+    method: "Resource.token",
+    params,
+  });
+}

--- a/packages/replayio/src/utils/recordings/types.ts
+++ b/packages/replayio/src/utils/recordings/types.ts
@@ -37,6 +37,27 @@ export type LogEntry = {
   recordingId?: string;
   server?: string;
   timestamp: number;
+  baseURL?: string;
+  targetContentHash?: string;
+  targetURLHash?: string;
+  targetMapURLHash?: string;
+  parentId?: string;
+  parentOffset?: number;
+};
+
+export type OriginalSource = {
+  path: string;
+  parentOffset: number;
+};
+
+export type SourceMap = {
+  id: string;
+  path: string;
+  baseURL: string;
+  targetContentHash?: string;
+  targetURLHash?: string;
+  targetMapURLHash: string;
+  originalSources: OriginalSource[];
 };
 
 export type LocalRecording = {
@@ -50,7 +71,7 @@ export type LocalRecording = {
     host: string | undefined;
     processGroupId: string | undefined;
     processType: ProcessType | undefined;
-    sourcemaps: string[] | undefined;
+    sourcemaps: SourceMap[];
     uri: string | undefined;
     [key: string]: unknown;
   };

--- a/packages/replayio/src/utils/recordings/types.ts
+++ b/packages/replayio/src/utils/recordings/types.ts
@@ -21,6 +21,7 @@ export type UnstructuredMetadata = Record<string, unknown>;
 // This data primarily comes from the runtime
 // The CLI adds some entries as well, based on upload status
 export type LogEntry = {
+  baseURL?: string;
   buildId?: string;
   data?: any;
   driverVersion?: string;
@@ -33,16 +34,15 @@ export type LogEntry = {
     uri?: string;
     [key: string]: unknown;
   };
+  parentId?: string;
+  parentOffset?: number;
   path?: string;
   recordingId?: string;
   server?: string;
-  timestamp: number;
-  baseURL?: string;
   targetContentHash?: string;
-  targetURLHash?: string;
   targetMapURLHash?: string;
-  parentId?: string;
-  parentOffset?: number;
+  targetURLHash?: string;
+  timestamp: number;
 };
 
 export type OriginalSource = {
@@ -51,13 +51,13 @@ export type OriginalSource = {
 };
 
 export type SourceMap = {
-  id: string;
-  path: string;
   baseURL: string;
-  targetContentHash?: string;
-  targetURLHash?: string;
-  targetMapURLHash: string;
+  id: string;
   originalSources: OriginalSource[];
+  path: string;
+  targetContentHash?: string;
+  targetMapURLHash: string;
+  targetURLHash?: string;
 };
 
 export type LocalRecording = {

--- a/packages/replayio/src/utils/recordings/upload/uploadRecording.ts
+++ b/packages/replayio/src/utils/recordings/upload/uploadRecording.ts
@@ -18,6 +18,7 @@ import { debugLogPath, multiPartChunkSize, multiPartMinSizeThreshold } from "../
 import { debug } from "../debug";
 import { LocalRecording, RECORDING_LOG_KIND } from "../types";
 import { updateRecordingLog } from "../updateRecordingLog";
+import { uploadSourceMaps } from "./uploadSourceMaps";
 import { validateRecordingMetadata } from "./validateRecordingMetadata";
 
 export async function uploadRecording(
@@ -117,7 +118,7 @@ export async function uploadRecording(
 
   debug("Uploaded %d bytes for recording %s", size, recording.id);
 
-  // TODO [PRO-103] Upload source-maps
+  await uploadSourceMaps(client, recording);
 
   updateRecordingLog(recording, {
     kind: RECORDING_LOG_KIND.uploadFinished,

--- a/packages/replayio/src/utils/recordings/upload/uploadRecording.ts
+++ b/packages/replayio/src/utils/recordings/upload/uploadRecording.ts
@@ -118,7 +118,10 @@ export async function uploadRecording(
 
   debug("Uploaded %d bytes for recording %s", size, recording.id);
 
-  await uploadSourceMaps(client, recording);
+  if (recording.metadata.sourcemaps.length) {
+    await uploadSourceMaps(client, recording);
+    debug("Uploaded sourcemaps for recording %s", recording.id);
+  }
 
   updateRecordingLog(recording, {
     kind: RECORDING_LOG_KIND.uploadFinished,


### PR DESCRIPTION
Not a lot has changed here UX-wise - beyond the added functionality (which is transparent to the user).

I thought briefly if this needs any extra work to surface to the user what's happening and all but I think it would be too technical and noisy. For what the user cares it's just part of the upload.

Note that `replayio upload-source-maps` will be implemented in the follow-up PR.