### PR TITLE
0.0.2 release

### DIFF
--- a/packages/replayio/package.json
+++ b/packages/replayio/package.json
@@ -18,10 +18,13 @@
   "bugs": {
     "url": "https://github.com/replayio/replay-cli/issues"
   },
+  "files": [
+    "dist",
+    "replayio.js"
+  ],
   "homepage": "https://github.com/replayio/replay-cli/blob/main/packages/replay/README.md",
   "dependencies": {
     "@replayio/protocol": "^0.71.0",
-    "@replayio/sourcemap-upload": "workspace:^",
     "@types/semver": "^7.5.6",
     "assert": "latest",
     "bvaughn-enquirer": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7283,7 +7283,6 @@ __metadata:
   dependencies:
     "@replay-cli/tsconfig": "workspace:^"
     "@replayio/protocol": "npm:^0.71.0"
-    "@replayio/sourcemap-upload": "workspace:^"
     "@types/debug": "npm:^4.1.7"
     "@types/fs-extra": "npm:latest"
     "@types/inquirer": "npm:^9"


### PR DESCRIPTION
- [x] Added missing `files` attributes
- [x] Temporarily remove (unused) `@replayio/sourcemap-upload` dependency (see https://github.com/replayio/replay-cli/pull/331/files#r1558168535)