### PR TITLE
CLI UX feedback

### DIFF
--- a/packages/replayio/src/commands/upload.ts
+++ b/packages/replayio/src/commands/upload.ts
@@ -31,6 +31,8 @@ async function upload(
     selectedRecordings = findRecordingsWithShortIds(recordings, shortIds);
   } else if (all) {
     selectedRecordings = recordings;
+  } else if (recordings.length === 0) {
+    console.log("No recordings found.");
   } else {
     const defaultRecording = findMostRecentPrimaryRecording(recordings);
 

--- a/packages/replayio/src/utils/recordings/findMostRecentPrimaryRecording.ts
+++ b/packages/replayio/src/utils/recordings/findMostRecentPrimaryRecording.ts
@@ -7,6 +7,7 @@ export function findMostRecentPrimaryRecording(
   cloned.sort((a, b) => b.date.getTime() - a.date.getTime());
   return cloned.find(
     recording =>
-      recording.metadata.processType === undefined || recording.metadata.processType === "root"
+      recording.uploadStatus === undefined &&
+      (recording.metadata.processType === undefined || recording.metadata.processType === "root")
   );
 }

--- a/packages/replayio/src/utils/recordings/selectRecordings.ts
+++ b/packages/replayio/src/utils/recordings/selectRecordings.ts
@@ -1,6 +1,6 @@
 // @ts-ignore TS types are busted; see github.com/enquirer/enquirer/issues/212
 import { MultiSelect } from "bvaughn-enquirer";
-import { dim, highlight, transparent } from "../theme";
+import { dim, select, transparent } from "../theme";
 import { printRecordings } from "./printRecordings";
 import { LocalRecording } from "./types";
 
@@ -42,7 +42,7 @@ export async function selectRecordings(
     return [];
   }
 
-  const select = new MultiSelect(
+  const multiSelect = new MultiSelect(
     {
       choices: recordings.map((recording, index) => {
         const disabled = disabledSelector(recording);
@@ -51,6 +51,10 @@ export async function selectRecordings(
         return {
           disabled,
           hint: "",
+          indicator: {
+            off: "☐",
+            on: "✔",
+          },
           message: disabled ? transparent(message) : message,
           value: recording.id,
         };
@@ -61,12 +65,13 @@ export async function selectRecordings(
       hideAfterSubmit: true,
       initial: recordings.filter(defaultSelected).map(recording => recording.id),
       message: `${prompt}\n  ${dim(
-        "(↑/↓ to change selection, [space] to toggle, [a] to toggle all)"
+        "(↑/↓ to change selection, Space to toggle, a/A to toggle all, Enter to confirm)"
       )}\n`,
       name: "numbers",
+      pointer: "→ ",
       styles: {
         // Selected row style
-        em: highlight,
+        em: select,
       },
     },
     (choices: any[]) => {
@@ -74,7 +79,7 @@ export async function selectRecordings(
     }
   );
 
-  const recordingIds = (await select.run()) as string[];
+  const recordingIds = (await multiSelect.run()) as string[];
 
   if (recordingIds.length > 0) {
     const selectedRecordings = recordings.filter(recording => recordingIds.includes(recording.id));

--- a/packages/replayio/src/utils/theme.ts
+++ b/packages/replayio/src/utils/theme.ts
@@ -5,6 +5,7 @@ export const emphasize = chalk.bold;
 export const highlight = chalk.yellowBright;
 export const highlightAlternate = chalk.blueBright;
 export const link = chalk.blueBright;
+export const select = chalk.bold;
 export const statusPending = chalk.yellowBright;
 export const statusFailed = chalk.redBright;
 export const statusSuccess = chalk.greenBright;


### PR DESCRIPTION
- [x] Update default selection for the `upload` prompt to not recommend a recording that can't be uploaded (due to its status).

- [x] [PRO-133](https://linear.app/replay/issue/PRO-133): Add explicit "Enter to confirm" text to upload selection prompt.
![Screenshot 2024-04-10 at 9 31 35 AM](https://github.com/replayio/replay-cli/assets/29597/80f92169-63fd-4779-8009-10b1a54b8ac0)

- [x] [PRO-132](https://linear.app/replay/issue/PRO-132): Use font weight and a "→" prefix for the current row (rather than color) and replace the green/gray "✔" with "☐" for unselected and "✔" for selected.
![Screenshot 2024-04-10 at 9 31 41 AM](https://github.com/replayio/replay-cli/assets/29597/eee35cd1-2f9a-4dd8-9386-847f4f919339)
