### PR TITLE
Handle protocol authentication errors in a better way

### DIFF
--- a/packages/replayio/src/utils/createDeferred.ts
+++ b/packages/replayio/src/utils/createDeferred.ts
@@ -6,8 +6,8 @@ export type StatusPending = typeof STATUS_PENDING;
 export type StatusRejected = typeof STATUS_REJECTED;
 export type StatusResolved = typeof STATUS_RESOLVED;
 
-export interface Deferred<Type, Data = void> {
-  data: Data | undefined;
+export interface Deferred<Type, Data = undefined> {
+  data: Data;
   debugLabel: string | undefined;
   promise: Promise<Type>;
   rejection: Error | undefined;
@@ -21,10 +21,15 @@ export interface Deferred<Type, Data = void> {
 
 export type Status = StatusPending | StatusRejected | StatusResolved;
 
-export function createDeferred<Type, Data = void>(
+export function createDeferred<Type, Data>(data: Data, debugLabel?: string): Deferred<Type, Data>;
+export function createDeferred<Type, Data = undefined>(
   data?: Data,
   debugLabel?: string
-): Deferred<Type, Data> {
+): Deferred<Type, Data | undefined>;
+export function createDeferred<Type, Data>(
+  data?: Data,
+  debugLabel?: string
+): Deferred<Type, Data | undefined> {
   let rejection: Error | undefined = undefined;
   let resolution: Type | undefined = undefined;
   let status: StatusPending | StatusRejected | StatusResolved = STATUS_PENDING;
@@ -46,7 +51,7 @@ export function createDeferred<Type, Data = void>(
     }
   }
 
-  const deferred: Deferred<Type, Data> = {
+  const deferred: Deferred<Type, Data | undefined> = {
     data,
     debugLabel,
 

--- a/packages/replayio/src/utils/graphql/GraphQLError.ts
+++ b/packages/replayio/src/utils/graphql/GraphQLError.ts
@@ -1,9 +1,8 @@
 export class GraphQLError extends Error {
-  code: string;
+  errors: unknown[];
 
-  constructor(code: string, message: string) {
+  constructor(message: string, errors: unknown[]) {
     super(message);
-
-    this.code = code;
+    this.errors = errors;
   }
 }

--- a/packages/replayio/src/utils/launch-darkly/initLaunchDarklyFromAccessToken.ts
+++ b/packages/replayio/src/utils/launch-darkly/initLaunchDarklyFromAccessToken.ts
@@ -1,4 +1,5 @@
 import { readFromCache } from "../cache";
+import { GraphQLError } from "../graphql/GraphQLError";
 import { queryGraphQL } from "../graphql/queryGraphQL";
 import { cachePath } from "./config";
 import { debug } from "./debug";
@@ -24,7 +25,7 @@ export async function initLaunchDarklyFromAccessToken(accessToken: string) {
       await identifyUserProfile(id);
     }
   } catch (error) {
-    console.error(error);
+    debug("Failed to initialize LaunchDarkly profile: %o", error);
   }
 }
 
@@ -58,9 +59,7 @@ async function fetchUserIdFromGraphQLOrThrow(accessToken: string) {
   );
 
   if (errors) {
-    console.error(errors);
-
-    throw new Error("Failed to fetch auth info");
+    throw new GraphQLError("Failed to fetch auth info", errors);
   }
 
   const response = data as {

--- a/packages/replayio/src/utils/protocol/ProtocolError.ts
+++ b/packages/replayio/src/utils/protocol/ProtocolError.ts
@@ -6,6 +6,8 @@ type ProtocolErrorBase = {
   data: ErrorData;
 };
 
+export const AUTHENTICATION_REQUIRED_ERROR_CODE = 49;
+
 export class ProtocolError extends Error {
   readonly protocolCode: number;
   readonly protocolMessage: string;

--- a/packages/replayio/src/utils/recordings/printDeferredRecordingActions.ts
+++ b/packages/replayio/src/utils/recordings/printDeferredRecordingActions.ts
@@ -21,9 +21,11 @@ export async function printDeferredRecordingActions(
   {
     renderTitle,
     renderExtraColumns,
+    renderFailedSummary,
   }: {
     renderTitle: (options: { done: boolean }) => string;
     renderExtraColumns: (recording: LocalRecording) => string[];
+    renderFailedSummary: (failedRecordings: LocalRecording[]) => string;
   }
 ) {
   let dotIndex = 0;
@@ -60,6 +62,7 @@ export async function printDeferredRecordingActions(
 
   const failedActions = deferredActions.filter(deferred => deferred.status !== STATUS_RESOLVED);
   if (failedActions.length > 0) {
-    console.log(statusFailed(`${failedActions.length} recording(s) did not upload successfully\n`));
+    const failedSummary = renderFailedSummary(failedActions.map(action => action.data));
+    console.log(statusFailed(`${failedSummary}`) + "\n");
   }
 }

--- a/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
+++ b/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
@@ -45,7 +45,7 @@ export async function uploadRecordings(
         const name = process.env.REPLAY_API_KEY ? "REPLAY_API_KEY" : "RECORD_REPLAY_API_KEY";
         message += ` Please check your ${highlight(name)}.`;
       } else {
-        message += " Please try to `replay login` again.";
+        message += ` Please try to ${highlight("replay login")} again.`;
       }
       console.error(message);
       await exitProcess(1);

--- a/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
+++ b/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
@@ -73,17 +73,22 @@ export async function uploadRecordings(
         switch (recording.processingStatus) {
           case "processing":
             status = "(processing…)";
+            break;
           case "processed":
             status = "(uploaded+processed)";
+            break;
         }
       } else {
         switch (recording.uploadStatus) {
           case "failed":
             status = "(failed)";
+            break;
           case "uploading":
             status = "(uploading…)";
+            break;
           case "uploaded":
             status = "(uploaded)";
+            break;
         }
       }
       return [status ? dim(status) : ""];

--- a/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
+++ b/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
@@ -2,7 +2,7 @@ import { exitProcess } from "../../exitProcess";
 import { getFeatureFlagValue } from "../../launch-darkly/getFeatureFlagValue";
 import ProtocolClient from "../../protocol/ProtocolClient";
 import { AUTHENTICATION_REQUIRED_ERROR_CODE, ProtocolError } from "../../protocol/ProtocolError";
-import { highlight, statusFailed } from "../../theme";
+import { dim, highlight, statusFailed } from "../../theme";
 import { canUpload } from "../canUpload";
 import { createSettledDeferred } from "../createSettledDeferred";
 import { debug } from "../debug";
@@ -65,7 +65,21 @@ export async function uploadRecordings(
     }
   });
 
-  printDeferredRecordingActions(deferredActions);
+  printDeferredRecordingActions(deferredActions, {
+    renderTitle: ({ done }) => (done ? "Uploaded recordings" : `Uploading recordings...`),
+    renderExtraColumns: recording => {
+      let status: string | undefined;
+      switch (recording.uploadStatus) {
+        case "failed":
+          status = "(failed)";
+        case "uploading":
+          status = "(uploading…)";
+        case "uploaded":
+          status = "(uploaded)";
+      }
+      return [status ? dim(status) : ""];
+    },
+  });
 
   await Promise.all(deferredActions.map(deferred => deferred.promise));
 

--- a/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
+++ b/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
@@ -79,6 +79,8 @@ export async function uploadRecordings(
       }
       return [status ? dim(status) : ""];
     },
+    renderFailedSummary: failedRecordings =>
+      `${failedRecordings.length} recording(s) did not upload successfully`,
   });
 
   await Promise.all(deferredActions.map(deferred => deferred.promise));


### PR DESCRIPTION
I had some old token cached in one of my terminal sessions. I couldn't upload anything and accidentally my first run was with `DEBUG` on. That got me investigating why we are not printing anything to the console about failed recordings. it turned out that we print it but some of the logs were not logged because `printDeferredRecordingActions` suppressed parts of the logs in `DEBUG`. So I changed it to print the table only at the beginning and at the end - that should help to avoid confusing situations for us while debugging while it still wont interfere with the updatable CLI output.

While using this wrong token I also noticed some gnarly error logs related to the failed authentication in the launchdarkly files. While the problem was real - that path shouldn't fail fast most of the time and shouldn't introduce unfriendly logs like this. So I replaced that with some `debug` calls.

The big issue that is being fixed though is handling the authentication errors from the protocol when uploading recordings. The deferred authentication promise was always resolved with a boolean so all of the `await client.waitUntilAuthenticated()` calls were kind of useless. I'm not rejecting that deferred so we can actually catch it early and avoid going into the loop responsible for uploading recordings.