### PR TITLE
Disable process recordings

### DIFF
--- a/packages/replayio/src/commands/record.ts
+++ b/packages/replayio/src/commands/record.ts
@@ -57,7 +57,7 @@ async function record(url: string = "about:blank") {
     }
 
     if (selectedRecordings.length > 0) {
-      await uploadRecordings(selectedRecordings, { processAfterUpload: true });
+      await uploadRecordings(selectedRecordings, { processAfterUpload: false });
     }
   } else {
     console.log("No new recordings were created");

--- a/packages/replayio/src/commands/upload.ts
+++ b/packages/replayio/src/commands/upload.ts
@@ -48,7 +48,7 @@ async function upload(
   }
 
   if (selectedRecordings.length > 0) {
-    await uploadRecordings(selectedRecordings, { processAfterUpload: true });
+    await uploadRecordings(selectedRecordings, { processAfterUpload: false });
   }
 
   await exitProcess(0);

--- a/packages/replayio/src/index.ts
+++ b/packages/replayio/src/index.ts
@@ -19,7 +19,7 @@ finalizeCommander();
 // avoid ERR_UNHANDLED_REJECTION from being printed to the console
 process.on("uncaughtException", async error => {
   if (error.name !== "UnhandledPromiseRejection") {
-    console.error("uncaughtException:", error);
+    console.error(error);
   }
 
   await exitProcess(1);

--- a/packages/replayio/src/utils/recordings/getRecordings.ts
+++ b/packages/replayio/src/utils/recordings/getRecordings.ts
@@ -92,6 +92,7 @@ export function getRecordings(): LocalRecording[] {
                 uri: undefined,
               },
               path: undefined,
+              processingStatus: undefined,
               recordingStatus: "recording",
               uploadStatus: undefined,
             };
@@ -123,6 +124,30 @@ export function getRecordings(): LocalRecording[] {
               path,
               parentOffset,
             });
+            break;
+          }
+          case RECORDING_LOG_KIND.processingFailed: {
+            const { id } = entry;
+
+            const recording = idToRecording[id];
+            assert(recording, `Recording with ID "${id}" not found`);
+            recording.processingStatus = "failed";
+            break;
+          }
+          case RECORDING_LOG_KIND.processingFinished: {
+            const { id } = entry;
+
+            const recording = idToRecording[id];
+            assert(recording, `Recording with ID "${id}" not found`);
+            recording.processingStatus = "processed";
+            break;
+          }
+          case RECORDING_LOG_KIND.processingStarted: {
+            const { id } = entry;
+
+            const recording = idToRecording[id];
+            assert(recording, `Recording with ID "${id}" not found`);
+            recording.processingStatus = "processing";
             break;
           }
           case RECORDING_LOG_KIND.recordingUnusable: {

--- a/packages/replayio/src/utils/recordings/types.ts
+++ b/packages/replayio/src/utils/recordings/types.ts
@@ -5,6 +5,9 @@ export enum RECORDING_LOG_KIND {
   crashUploaded = "crashUploaded",
   createRecording = "createRecording",
   originalSourceAdded = "originalSourceAdded",
+  processingFailed = "processingFailed",
+  processingFinished = "processingFinished",
+  processingStarted = "processingStarted",
   recordingUnusable = "recordingUnusable",
   sourcemapAdded = "sourcemapAdded",
   uploadFailed = "uploadFailed",
@@ -77,6 +80,7 @@ export type LocalRecording = {
     [key: string]: unknown;
   };
   path: string | undefined;
+  processingStatus: "failed" | "processed" | "processing" | undefined;
   recordingStatus: "crashed" | "finished" | "recording" | "unusable";
   uploadStatus: "failed" | "uploading" | "uploaded" | undefined;
 };

--- a/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
+++ b/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
@@ -48,6 +48,13 @@ export async function uploadRecordings(
     "Uploading recordings...",
     "recording(s) did not upload successfully",
     recording => {
+      switch (recording.processingStatus) {
+        case "processing":
+          return "(processing…)";
+        case "processed":
+          return "(uploaded+processed)";
+      }
+
       switch (recording.uploadStatus) {
         case "failed":
           return "(failed)";


### PR DESCRIPTION
This feature is apparently too controversial (see [PRO-140](https://linear.app/replay/issue/PRO-140)) so I've just turned it off for now.

I did re-add the blocking behavior though, because we may want to re-add processing support in the future.