### PR TITLE
Improve package upgrade prompt

### DIFF
--- a/packages/replayio/src/utils/initialization/getLatestPackageVersion.ts
+++ b/packages/replayio/src/utils/initialization/getLatestPackageVersion.ts
@@ -1,0 +1,31 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+import { PackageManager } from "./types";
+
+const execAsync = promisify(exec);
+
+export async function getLatestPackageVersion(command: PackageManager, packageName: string) {
+  try {
+    switch (command) {
+      case "npm":
+      case "pnpm": {
+        const { stdout: text } = await execAsync(`${command} info ${packageName} --json`, {
+          encoding: "utf8",
+        });
+        const json = JSON.parse(text.trim());
+
+        return json.version;
+      }
+      case "yarn": {
+        const { stdout: text } = await execAsync(`yarn npm info ${packageName} --json`, {
+          encoding: "utf8",
+        });
+        const json = JSON.parse(text.trim());
+
+        return json["dist-tags"]?.latest;
+      }
+    }
+  } catch (error) {
+    // Ignore
+  }
+}

--- a/packages/replayio/src/utils/initialization/getPackageManagerCommand.ts
+++ b/packages/replayio/src/utils/initialization/getPackageManagerCommand.ts
@@ -1,0 +1,22 @@
+import { basename, sep } from "path";
+import { isPackageManagerInstalled } from "./isPackageManagerInstalled";
+import { PackageManager } from "./types";
+
+export function getPackageManagerCommand(): PackageManager | undefined {
+  // If this is a global install, it's possible we can detect the package manager that way
+  const path = basename(__filename);
+  if (path.includes("pnpm" + sep)) {
+    return "pnpm";
+  } else if (path.includes("yarn" + sep)) {
+    return "yarn";
+  }
+
+  // Otherwise let's see which package manager(s) are installed
+  if (isPackageManagerInstalled("pnpm")) {
+    return "pnpm";
+  } else if (isPackageManagerInstalled("yarn")) {
+    return "yarn";
+  } else if (isPackageManagerInstalled("npm")) {
+    return "npm";
+  }
+}

--- a/packages/replayio/src/utils/initialization/isPackageManagerInstalled.ts
+++ b/packages/replayio/src/utils/initialization/isPackageManagerInstalled.ts
@@ -1,0 +1,12 @@
+import { execSync } from "child_process";
+import { PackageManager } from "./types";
+
+export function isPackageManagerInstalled(name: PackageManager): boolean {
+  try {
+    const output = execSync(`${name} --version`);
+    const text = output.toString().trim();
+    return /^\d+.\d+.\d+$/.test(text);
+  } catch (error) {
+    return false;
+  }
+}

--- a/packages/replayio/src/utils/initialization/promptForNpmUpdate.ts
+++ b/packages/replayio/src/utils/initialization/promptForNpmUpdate.ts
@@ -1,7 +1,8 @@
-import { name } from "../../../package.json";
+import { name as packageName } from "../../../package.json";
 import { prompt } from "../prompt/prompt";
 import { updateCachedPromptData } from "../prompt/updateCachedPromptData";
 import { highlight } from "../theme";
+import { getPackageManagerCommand } from "./getPackageManagerCommand";
 import { UpdateCheckResult } from "./types";
 
 const PROMPT_ID = "npm-update";
@@ -9,21 +10,41 @@ const PROMPT_ID = "npm-update";
 export async function promptForNpmUpdate(updateCheck: UpdateCheckResult<string>) {
   const { fromVersion, toVersion } = updateCheck;
 
-  console.log("");
-  console.log("A new version of replayio is available!");
-  console.log("  Installed version:", highlight(fromVersion));
-  console.log("  New version:", highlight(toVersion));
-  console.log("");
-  console.log("To upgrade, run the following:");
-  console.log(highlight(`  npm install -g ${name}`));
-  console.log("");
-  console.log("Press any key to continue");
-  console.log("");
+  const command = getPackageManagerCommand();
+  if (command) {
+    let baseCommand;
+    switch (command) {
+      case "npm": {
+        baseCommand = "npm install --global";
+        break;
+      }
+      case "pnpm": {
+        baseCommand = "pnpm install --global";
+        break;
+      }
+      case "yarn": {
+        // Only supported by Yarn 1.0
+        baseCommand = "yarn global";
+        break;
+      }
+    }
 
-  await prompt();
+    console.log("");
+    console.log("A new version of replayio is available!");
+    console.log("  Installed version:", highlight(fromVersion));
+    console.log("  New version:", highlight(toVersion));
+    console.log("");
+    console.log("To upgrade, run the following:");
+    console.log(highlight(`  ${baseCommand} ${packageName}`));
+    console.log("");
+    console.log("Press any key to continue");
+    console.log("");
 
-  updateCachedPromptData({
-    id: PROMPT_ID,
-    metadata: toVersion,
-  });
+    await prompt();
+
+    updateCachedPromptData({
+      id: PROMPT_ID,
+      metadata: toVersion,
+    });
+  }
 }

--- a/packages/replayio/src/utils/initialization/types.ts
+++ b/packages/replayio/src/utils/initialization/types.ts
@@ -10,3 +10,6 @@ export type UpdateCheckResult<Version> = {
 };
 
 export type UpdateCheck<Version> = UpdateCheckFailed | UpdateCheckResult<Version>;
+
+// Bun doesn't provide a way to query info about a package so we'll ignore it
+export type PackageManager = "npm" | "pnpm" | "yarn";


### PR DESCRIPTION
TBH I'm not sure if even this is worth doing. I think everyone who uses a package manager other than NPM knows how to convert the standard "npm install" message to their own package-manager-of-choice.