### PR TITLE
Add `replayio info` command

### DIFF
--- a/packages/replayio/src/commands/info.ts
+++ b/packages/replayio/src/commands/info.ts
@@ -1,0 +1,29 @@
+import { name as packageName, version as packageVersion } from "../../package.json";
+import { registerCommand } from "../utils/commander/registerCommand";
+import { exitProcess } from "../utils/exitProcess";
+import { getCurrentRuntimeMetadata } from "../utils/initialization/getCurrentRuntimeMetadata";
+import { parseBuildId } from "../utils/installation/parseBuildId";
+import { dim, highlight } from "../utils/theme";
+
+registerCommand("info", { requireAuthentication: false })
+  .description("Display info for installed Replay dependencies")
+  .action(info);
+
+async function info() {
+  console.log(`Currently using ${highlight(`${packageName}@${packageVersion}`)}`);
+
+  const metadata = getCurrentRuntimeMetadata("chromium");
+  if (metadata) {
+    const { buildId, nativeVersion } = metadata;
+
+    const { releaseDate } = parseBuildId(buildId);
+
+    console.log("\nReplay Chromium");
+    console.log(`• Release date: ${highlight(releaseDate.toLocaleDateString())}`);
+    if (nativeVersion) {
+      console.log(`• Native version: ${highlight(nativeVersion)}`);
+    }
+  }
+
+  await exitProcess(0);
+}

--- a/packages/replayio/src/commands/info.ts
+++ b/packages/replayio/src/commands/info.ts
@@ -14,14 +14,14 @@ async function info() {
 
   const metadata = getCurrentRuntimeMetadata("chromium");
   if (metadata) {
-    const { buildId, nativeVersion } = metadata;
+    const { buildId, forkedVersion } = metadata;
 
     const { releaseDate } = parseBuildId(buildId);
 
     console.log("\nReplay Chromium");
     console.log(`• Release date: ${highlight(releaseDate.toLocaleDateString())}`);
-    if (nativeVersion) {
-      console.log(`• Native version: ${highlight(nativeVersion)}`);
+    if (forkedVersion) {
+      console.log(`• Forked version: ${highlight(forkedVersion)}`);
     }
   }
 

--- a/packages/replayio/src/index.ts
+++ b/packages/replayio/src/index.ts
@@ -2,6 +2,7 @@ import { finalizeCommander } from "./utils/commander/finalizeCommander";
 import { exitProcess } from "./utils/exitProcess";
 
 // Commands self-register with "commander"
+import "./commands/info";
 import "./commands/list";
 import "./commands/login";
 import "./commands/logout";

--- a/packages/replayio/src/utils/commander/finalizeCommander.ts
+++ b/packages/replayio/src/utils/commander/finalizeCommander.ts
@@ -9,6 +9,8 @@ export function finalizeCommander() {
         const helpText = help.formatHelp(command, helper);
         return formatOutput(helpText);
       },
+      sortOptions: true,
+      sortSubcommands: true,
     });
     program.configureOutput({
       writeErr: (text: string) => process.stderr.write(formatOutput(text)),

--- a/packages/replayio/src/utils/initialization/checkForRuntimeUpdate.ts
+++ b/packages/replayio/src/utils/initialization/checkForRuntimeUpdate.ts
@@ -1,11 +1,11 @@
 import { existsSync } from "fs-extra";
 import { join } from "path";
-import { metadataPath, runtimeMetadata, runtimePath } from "../installation/config";
+import { runtimeMetadata, runtimePath } from "../installation/config";
 import { getLatestRelease } from "../installation/getLatestReleases";
-import { MetadataJSON, Release } from "../installation/types";
-import { readFromCache } from "../cache";
+import { Release } from "../installation/types";
 import { shouldPrompt } from "../prompt/shouldPrompt";
 import { debug } from "./debug";
+import { getCurrentRuntimeMetadata } from "./getCurrentRuntimeMetadata";
 import { UpdateCheck } from "./types";
 
 const PROMPT_ID = "runtime-update";
@@ -47,8 +47,7 @@ export async function checkForRuntimeUpdate(): Promise<UpdateCheck<Version>> {
     };
   }
 
-  const metadata = readFromCache<MetadataJSON>(metadataPath);
-  const currentBuildId = metadata?.chromium?.buildId;
+  const { buildId: currentBuildId } = getCurrentRuntimeMetadata("chromium") ?? {};
   if (currentBuildId) {
     debug("Current build id: %s", currentBuildId);
   } else {

--- a/packages/replayio/src/utils/initialization/getCurrentRuntimeMetadata.ts
+++ b/packages/replayio/src/utils/initialization/getCurrentRuntimeMetadata.ts
@@ -1,0 +1,8 @@
+import { readFromCache } from "../cache";
+import { metadataPath } from "../installation/config";
+import { MetadataJSON, Runtime } from "../installation/types";
+
+export function getCurrentRuntimeMetadata(runtime: Runtime) {
+  const metadata = readFromCache<MetadataJSON>(metadataPath);
+  return metadata?.[runtime];
+}

--- a/packages/replayio/src/utils/installation/installLatestRelease.ts
+++ b/packages/replayio/src/utils/installation/installLatestRelease.ts
@@ -44,6 +44,7 @@ export async function installLatestRelease() {
 
   const latestRelease = await getLatestRelease();
   const latestBuildId = latestRelease.buildId;
+  const latestVersion = latestRelease.version;
 
   // Write version metadata to disk so we can compare against the latest release and prompt to update
   debug("Saving release metadata to %s", metadataPath);
@@ -51,7 +52,9 @@ export async function installLatestRelease() {
     chromium: {
       buildId: latestBuildId,
       installDate: new Date().toISOString(),
+      nativeVersion: latestVersion,
     },
+    node: undefined,
   });
 }
 

--- a/packages/replayio/src/utils/installation/installLatestRelease.ts
+++ b/packages/replayio/src/utils/installation/installLatestRelease.ts
@@ -54,7 +54,6 @@ export async function installLatestRelease() {
       installDate: new Date().toISOString(),
       nativeVersion: latestVersion,
     },
-    node: undefined,
   });
 }
 

--- a/packages/replayio/src/utils/installation/installLatestRelease.ts
+++ b/packages/replayio/src/utils/installation/installLatestRelease.ts
@@ -4,7 +4,7 @@ import { get } from "https";
 import { join } from "path";
 import { writeToCache } from "../cache";
 import { getReplayPath } from "../getReplayPath";
-import { dim } from "../theme";
+import { dim, highlight, link } from "../theme";
 import { metadataPath, runtimeMetadata } from "./config";
 import { debug } from "./debug";
 import { getLatestRelease } from "./getLatestReleases";
@@ -51,8 +51,8 @@ export async function installLatestRelease() {
   writeToCache<MetadataJSON>(metadataPath, {
     chromium: {
       buildId: latestBuildId,
+      forkedVersion: latestVersion,
       installDate: new Date().toISOString(),
-      nativeVersion: latestVersion,
     },
   });
 }
@@ -66,7 +66,7 @@ async function downloadReplayFile() {
 
   for (let i = 0; i < 5; i++) {
     console.log(
-      `Downloading ${runtimeMetadata.runtime} from replay.io${
+      `Downloading ${highlight(runtimeMetadata.runtime)} from ${link("replay.io")}${
         i ? ` ${dim(`(retry ${i} of 4)`)}` : ""
       }`
     );

--- a/packages/replayio/src/utils/installation/types.ts
+++ b/packages/replayio/src/utils/installation/types.ts
@@ -16,12 +16,14 @@ export type Release = {
   version: string | null;
 };
 
-export type MetadataJSON = Record<
-  Runtime,
-  | {
-      buildId: string;
-      installDate: string;
-      nativeVersion: string | null;
-    }
-  | undefined
+export type MetadataJSON = Partial<
+  Record<
+    Runtime,
+    | {
+        buildId: string;
+        installDate: string;
+        nativeVersion: string | null;
+      }
+    | undefined
+  >
 >;

--- a/packages/replayio/src/utils/installation/types.ts
+++ b/packages/replayio/src/utils/installation/types.ts
@@ -16,9 +16,12 @@ export type Release = {
   version: string | null;
 };
 
-export type MetadataJSON = {
-  chromium: {
-    buildId: string;
-    installDate: string;
-  };
-};
+export type MetadataJSON = Record<
+  Runtime,
+  | {
+      buildId: string;
+      installDate: string;
+      nativeVersion: string | null;
+    }
+  | undefined
+>;

--- a/packages/replayio/src/utils/installation/types.ts
+++ b/packages/replayio/src/utils/installation/types.ts
@@ -16,14 +16,10 @@ export type Release = {
   version: string | null;
 };
 
-export type MetadataJSON = Partial<
-  Record<
-    Runtime,
-    | {
-        buildId: string;
-        installDate: string;
-        nativeVersion: string | null;
-      }
-    | undefined
-  >
->;
+export type MetadataJSON = {
+  [Key in Runtime]?: {
+    buildId: string;
+    forkedVersion: string | null;
+    installDate: string;
+  };
+};


### PR DESCRIPTION
I think this will be helpful when debugging potential stale NPM cache issues (e.g. with `npx`) and may also be useful when reporting bugs with either Replay CLI or browser. Example output:

![Screenshot 2024-04-12 at 12 55 57 PM](https://github.com/replayio/replay-cli/assets/29597/ded5c0ca-05ec-420b-bb0c-a49a2c26bc61)
