### PR TITLE
Log information about failed crash uploads

### DIFF
--- a/packages/replayio/src/commands/record.ts
+++ b/packages/replayio/src/commands/record.ts
@@ -57,7 +57,7 @@ async function record(url: string = "about:blank") {
         pending: "Uploading crash data...",
         success: () => {
           if (uploadableCrashes.some(recording => recording.uploadStatus === "failed")) {
-            return "Some of the crash data couldn't be uploaded";
+            return "Crash data could only be partially uploaded";
           }
           return "Crash data uploaded successfully";
         },

--- a/packages/replayio/src/utils/exitProcess.ts
+++ b/packages/replayio/src/utils/exitProcess.ts
@@ -1,6 +1,6 @@
 import { close } from "./launch-darkly/close";
 
-export async function exitProcess(code?: number) {
+export async function exitProcess(code?: number): Promise<never> {
   await close();
 
   process.exit(code);

--- a/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
+++ b/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
@@ -50,7 +50,6 @@ export async function uploadRecordings(
       }
       console.error(message);
       await exitProcess(1);
-      return;
     }
     throw error;
   }
@@ -115,4 +114,5 @@ export async function uploadRecordings(
   }
 
   client.close();
+  return deferredActions.map(action => action.data);
 }


### PR DESCRIPTION
Follow up to the discussion [here](https://github.com/replayio/replay-cli/pull/384#discussion_r1565421735)

The situation can be mocked with this temp patch:
<details>
<summary>git diff</summary>

```diff
diff --git a/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts b/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
index 04e14c9..7256a48 100644
--- a/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
+++ b/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
@@ -57,7 +57,17 @@ export async function uploadRecordings(

   const deferredActions = recordings.map(recording => {
     if (recording.recordingStatus === "crashed") {
-      return createSettledDeferred<LocalRecording>(recording, uploadCrashedData(client, recording));
+      // return createSettledDeferred<LocalRecording>(recording, uploadCrashedData(client, recording));
+      return createSettledDeferred<LocalRecording>(
+        recording,
+        new Promise((_, reject) => {
+          setTimeout(() => {
+            recording.uploadStatus = "failed";
+            reject(new Error("Couldnt upload it"));
+          }, 1000);
+        })
+      );
     } else {
       return createSettledDeferred<LocalRecording>(
         recording,
```
</details>

Currently, if the crash upload fails we still see this output:
```
> node ./packages/replayio/replayio.js record https://app.replay.io/team/me/recordings
Recording (press any key to stop recording)

It looks like something went wrong with this recording. Please hold while we upload crash data.
✔ Crash data uploaded successfully
```

With this PR we replace that with information that some of the crash upload data couldn't be uploaded