### PR TITLE
Decouple `postinstall` execution from the package manager

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -17,9 +17,7 @@
     "*.d.ts"
   ],
   "scripts": {
-    "if:exists": "node -e \"require('fs').existsSync(process.argv[1]) ? require('child_process').spawnSync(process.argv[2], process.argv.slice(3), {shell: true, stdio: 'inherit'}) : 0\"",
-    "if:dist": "yarn run if:exists -- dist",
-    "postinstall": "yarn run if:dist -- node ./bin.js first-run",
+    "postinstall": "\"$npm_node_execpath\" ./postinstall.js",
     "prepare": "npm run build",
     "build": "rm -rf dist/ tsconfig.tsbuildinfo && tsc",
     "test": "echo \"Error: no test specified\"",

--- a/packages/cypress/postinstall.js
+++ b/packages/cypress/postinstall.js
@@ -1,0 +1,11 @@
+const { existsSync } = require("fs");
+if (existsSync("dist")) {
+  require("child_process").spawnSync(
+    `"${process.env.npm_node_execpath}"`,
+    ["./bin.js", "first-run"],
+    {
+      shell: true,
+      stdio: "inherit",
+    }
+  );
+}

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -17,9 +17,7 @@
     "*.d.ts"
   ],
   "scripts": {
-    "if:exists": "node -e \"require('fs').existsSync(process.argv[1]) ? require('child_process').spawnSync(process.argv[2], process.argv.slice(3), {shell: true, stdio: 'inherit'}) : 0\"",
-    "if:dist": "yarn run if:exists -- dist",
-    "postinstall": "yarn run if:dist -- node ./bin.js first-run",
+    "postinstall": "\"$npm_node_execpath\" ./postinstall.js",
     "prepare": "yarn run build",
     "build": "rm -rf dist/ tsconfig.tsbuildinfo && tsc",
     "test": "echo \"Error: no test specified\"",

--- a/packages/playwright/postinstall.js
+++ b/packages/playwright/postinstall.js
@@ -1,0 +1,11 @@
+const { existsSync } = require("fs");
+if (existsSync("dist")) {
+  require("child_process").spawnSync(
+    `"${process.env.npm_node_execpath}"`,
+    ["./bin.js", "first-run"],
+    {
+      shell: true,
+      stdio: "inherit",
+    }
+  );
+}

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -12,9 +12,7 @@
     "*.d.ts"
   ],
   "scripts": {
-    "if:exists": "node -e \"require('fs').existsSync(process.argv[1]) ? require('child_process').spawnSync(process.argv[2], process.argv.slice(3), {shell: true, stdio: 'inherit'}) : 0\"",
-    "if:dist": "yarn run if:exists -- dist",
-    "postinstall": "yarn run if:dist -- node ./bin.js first-run",
+    "postinstall": "\"$npm_node_execpath\" ./postinstall.js",
     "prepare": "yarn run build",
     "build": "rm -rf dist/ tsconfig.tsbuildinfo && tsc",
     "test": "echo \"Error: no test specified\"",

--- a/packages/puppeteer/postinstall.js
+++ b/packages/puppeteer/postinstall.js
@@ -1,0 +1,11 @@
+const { existsSync } = require("fs");
+if (existsSync("dist")) {
+  require("child_process").spawnSync(
+    `"${process.env.npm_node_execpath}"`,
+    ["./bin.js", "first-run"],
+    {
+      shell: true,
+      stdio: "inherit",
+    }
+  );
+}


### PR DESCRIPTION
I tested this with npm, yarn, pnpm and bun. Bun won't run postinstall scripts in our package but it sets `process.env.npm_node_execpath` correctly~ (from what I can tell it sets it to node and not bun unless you pass some extra options).

This isn't a particularly popular thing to reach for `$` variables within `package.json`... but it's standard and supported. Nevertheless, I feel a little bit weird proposing this 😅 