### PR TITLE
Make the returned value of `createReplayReporterConfig` a tuple

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -59,7 +59,11 @@ export const devices = {
 };
 
 export function createReplayReporterConfig(config: ReplayPlaywrightConfig) {
-  return ["@replayio/playwright/reporter", config];
+  // intentionally produce a mutable array here with the help of satisfies
+  // this has to be kept for a foreseeable future to keep compat with older Playwright versions
+  // even after the fix for this gets released: https://github.com/microsoft/playwright/pull/30387
+  return ["@replayio/playwright/reporter", config] as const satisfies unknown[];
 }
 
 export { getMetadataFilePath };
+export type { ReplayPlaywrightConfig };


### PR DESCRIPTION
Playwright expects those to be mutable (non-readonly) tuples. I had to test this before in a JS file or something where the type errors didn't show up