### PR TITLE
Remove authentication requirement from the `update` command

### DIFF
--- a/packages/replayio/src/commands/update.ts
+++ b/packages/replayio/src/commands/update.ts
@@ -2,9 +2,7 @@ import { registerCommand } from "../utils/commander/registerCommand";
 import { exitProcess } from "../utils/exitProcess";
 import { installLatestRelease } from "../utils/installation/installLatestRelease";
 
-registerCommand("update", { requireAuthentication: true })
-  .description("Update your installed Replay browser")
-  .action(update);
+registerCommand("update").description("Update your installed Replay browser").action(update);
 
 async function update() {
   try {


### PR DESCRIPTION
Authentication requirement makes it harder to use on the CI. We don't really need this as nothing in this command doesn't truly depend on the authenticated user.