### PR TITLE
Disable animated log for CI environments

### DIFF
--- a/packages/replayio/src/config.ts
+++ b/packages/replayio/src/config.ts
@@ -1,5 +1,9 @@
 export const replayApiServer = process.env.REPLAY_API_SERVER || "https://api.replay.io";
-export const isDebugging = !!process.env.DEBUG;
 export const replayAppHost = process.env.REPLAY_APP_SERVER || "https://app.replay.io";
 export const replayWsServer =
   process.env.RECORD_REPLAY_SERVER || process.env.REPLAY_SERVER || "wss://dispatch.replay.io";
+
+const isCI = !!process.env.CI;
+const isDebugging = !!process.env.DEBUG;
+
+export const disableAnimatedLog = isCI || isDebugging;

--- a/packages/replayio/src/utils/async/logPromise.ts
+++ b/packages/replayio/src/utils/async/logPromise.ts
@@ -1,5 +1,5 @@
 import { dots } from "cli-spinners";
-import { isDebugging } from "../../config";
+import { disableAnimatedLog } from "../../config";
 import { logUpdate } from "../logUpdate";
 import { statusFailed, statusPending, statusSuccess } from "../theme";
 import { STATUS_PENDING, STATUS_REJECTED, STATUS_RESOLVED, createDeferred } from "./createDeferred";
@@ -26,7 +26,7 @@ export async function logPromise<PromiseType>(
     let prefix: string;
     switch (deferred.status) {
       case STATUS_PENDING:
-        if (!isDebugging && delayBeforeLoggingMs > 0 && Date.now() < logAfter) {
+        if (!disableAnimatedLog && delayBeforeLoggingMs > 0 && Date.now() < logAfter) {
           return;
         }
 
@@ -58,7 +58,7 @@ export async function logPromise<PromiseType>(
 
   print();
 
-  const interval = !isDebugging ? setInterval(print, dots.interval) : undefined;
+  const interval = disableAnimatedLog ? undefined : setInterval(print, dots.interval);
 
   try {
     deferred.resolve(await promise);

--- a/packages/replayio/src/utils/logUpdate.ts
+++ b/packages/replayio/src/utils/logUpdate.ts
@@ -1,5 +1,5 @@
 import logUpdateExternal, { LogUpdate } from "log-update";
-import { isDebugging } from "../config";
+import { disableAnimatedLog } from "../config";
 
 function logUpdateDebugging(...text: string[]) {
   console.log(...text);
@@ -8,4 +8,4 @@ logUpdateDebugging.clear = (() => {}) satisfies LogUpdate["clear"];
 logUpdateDebugging.done = (() => {}) satisfies LogUpdate["done"];
 
 // log-update interferes with verbose DEBUG output
-export const logUpdate = isDebugging ? (logUpdateDebugging as LogUpdate) : logUpdateExternal;
+export const logUpdate = disableAnimatedLog ? (logUpdateDebugging as LogUpdate) : logUpdateExternal;

--- a/packages/replayio/src/utils/recordings/printDeferredRecordingActions.ts
+++ b/packages/replayio/src/utils/recordings/printDeferredRecordingActions.ts
@@ -1,5 +1,5 @@
 import { dots } from "cli-spinners";
-import { isDebugging } from "../../config";
+import { disableAnimatedLog } from "../../config";
 import { Deferred, STATUS_RESOLVED } from "../async/createDeferred";
 import { logUpdate } from "../logUpdate";
 import { printTable } from "../table";
@@ -26,7 +26,7 @@ export async function printDeferredRecordingActions(
     const title = renderTitle({ done });
     const table = printTable({
       rows: deferredActions.map(deferred => {
-        let status = !isDebugging ? statusPending(dot) : "";
+        let status = disableAnimatedLog ? "" : statusPending(dot);
         if (deferred.resolution === true) {
           status = statusSuccess("✔");
         } else if (deferred.resolution === false) {
@@ -43,7 +43,7 @@ export async function printDeferredRecordingActions(
 
   print();
 
-  const interval = !isDebugging ? setInterval(print, dots.interval) : undefined;
+  const interval = disableAnimatedLog ? undefined : setInterval(print, dots.interval);
 
   await Promise.all(deferredActions.map(deferred => deferred.promise));
 


### PR DESCRIPTION
Looking through [CI logs](https://github.com/replayio/dashboard/actions/runs/8707526986/job/23884003205?pr=19) and realized the animated log is pretty noisy:
![Screenshot 2024-04-16 at 11 07 14 AM](https://github.com/replayio/replay-cli/assets/29597/92147923-71b8-49cd-8d25-3759231851d7)
