### PR TITLE
Add guard not to print an empty recordings table

### DIFF
--- a/packages/replayio/src/commands/record.ts
+++ b/packages/replayio/src/commands/record.ts
@@ -30,7 +30,9 @@ async function record(url: string = "about:blank") {
   recordingsAfter.filter(recording => {
     if (!prevRecordings.some(({ id }) => id === recording.id)) {
       if (recording.recordingStatus === "crashed") {
-        nextCrashedRecordings.push(recording);
+        if (canUpload(recording)) {
+          nextCrashedRecordings.push(recording);
+        }
       } else {
         nextRecordings.push(recording);
       }
@@ -45,8 +47,6 @@ async function record(url: string = "about:blank") {
       "It looks like something went wrong with this recording. Please hold while we upload crash data."
     );
 
-    const uploadableCrashes = nextCrashedRecordings.filter(canUpload);
-
     const promise = uploadRecordings(nextCrashedRecordings, {
       processingBehavior: "do-not-process",
       silent: true,
@@ -56,7 +56,7 @@ async function record(url: string = "about:blank") {
       messages: {
         pending: "Uploading crash data...",
         success: () => {
-          if (uploadableCrashes.some(recording => recording.uploadStatus === "failed")) {
+          if (nextCrashedRecordings.some(recording => recording.uploadStatus === "failed")) {
             return "Crash data could only be partially uploaded";
           }
           return "Crash data uploaded successfully";

--- a/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
+++ b/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
@@ -33,6 +33,10 @@ export async function uploadRecordings(
     return true;
   });
 
+  if (recordings.length === 0) {
+    return;
+  }
+
   const multiPartUpload = await getFeatureFlagValue<boolean>("cli-multipart-upload", false);
   const client = new ProtocolClient();
   try {


### PR DESCRIPTION
I think #387 introduced a potential error edge case reported in PRO-222:
> Error: Table must define at least one row.

Since we check `nextCrashedRecordings.length` but then pass `uploadableCrashes` (which _could_ be empty)