### PR TITLE
Recordings list improvements

### DIFF
--- a/packages/replayio/src/utils/date.ts
+++ b/packages/replayio/src/utils/date.ts
@@ -1,6 +1,7 @@
 import differenceInCalendarDays from "date-fns/differenceInCalendarDays";
 import differenceInMinutes from "date-fns/differenceInMinutes";
 import differenceInMonths from "date-fns/differenceInMonths";
+import differenceInSeconds from "date-fns/differenceInSeconds";
 import differenceInWeeks from "date-fns/differenceInWeeks";
 import differenceInYears from "date-fns/differenceInYears";
 import prettyMilliseconds from "pretty-ms";
@@ -10,6 +11,7 @@ export function formatDuration(ms: number) {
 }
 
 export function formatRelativeDate(date: Date): string {
+  const seconds = differenceInSeconds(Date.now(), date);
   const minutes = differenceInMinutes(Date.now(), date);
   const days = differenceInCalendarDays(Date.now(), date);
   const weeks = differenceInWeeks(Date.now(), date);
@@ -28,6 +30,8 @@ export function formatRelativeDate(date: Date): string {
     return `${Math.floor(minutes / 60)}h ago`;
   } else if (minutes > 0) {
     return `${minutes}m ago`;
+  } else if (seconds > 0) {
+    return `${seconds}s ago`;
   }
 
   return "Now";

--- a/packages/replayio/src/utils/recordings/formatRecording.ts
+++ b/packages/replayio/src/utils/recordings/formatRecording.ts
@@ -1,9 +1,9 @@
 import { formatDuration, formatRelativeDate } from "../date";
 import { parseBuildId } from "../installation/parseBuildId";
-import { dim, link, transparent } from "../theme";
+import { dim, link } from "../theme";
 import { LocalRecording } from "./types";
 
-const MAX_TITLE_LENGTH = 35;
+const MAX_TITLE_LENGTH = 50;
 
 function truncateRecordingTitle(title: string) {
   title = title.trimEnd();
@@ -33,7 +33,7 @@ export function formatRecording(recording: LocalRecording) {
     }
     default: {
       if (metadata.host) {
-        title = link(metadata.host);
+        title = link(truncateRecordingTitle(metadata.host));
       } else {
         title = "(untitled)";
       }


### PR DESCRIPTION
- [x] Update relative date/time formatter to show "x seconds ago" rather than "now" for recent recordings
- [x] Also trim long host names (this change was lost as part of #354)

![Screenshot 2024-04-18 at 7 24 32 AM](https://github.com/replayio/replay-cli/assets/29597/aa6cc65d-7711-4992-9250-1fed0e7b98aa)
