### PR TITLE
Add internal --verbose flag for browser debugging

### DIFF
--- a/packages/replayio/src/commands/record.ts
+++ b/packages/replayio/src/commands/record.ts
@@ -1,3 +1,4 @@
+import debug from "debug";
 import { writeFileSync } from "fs-extra";
 import { v4 as uuid } from "uuid";
 import { ProcessError } from "../utils/ProcessError";
@@ -19,13 +20,21 @@ import { dim } from "../utils/theme";
 registerCommand("record", { checkForRuntimeUpdate: true, requireAuthentication: true })
   .argument("[url]", `URL to open (default: "about:blank")`)
   .description("Launch the replay browser in recording mode")
-  .action(record);
+  .action(record)
+  .allowUnknownOption();
 
 async function record(url: string = "about:blank") {
+  // This flag is intentionally not listed in the command options
+  // but if specified, it will both enable "debug" logging and Replay Browser's "verbose" mode
+  const verbose = process.argv.includes("--verbose");
+  if (verbose) {
+    debug.enable("replayio:browser");
+  }
+
   const prevRecordings = await getRecordings();
 
   try {
-    await launchBrowser(url, { processGroupId: uuid() });
+    await launchBrowser(url, { processGroupId: uuid(), verbose });
   } catch (error) {
     if (error instanceof ProcessError) {
       console.log("\nSomething went wrong while recording. Try again.");

--- a/packages/replayio/src/utils/browser/launchBrowser.ts
+++ b/packages/replayio/src/utils/browser/launchBrowser.ts
@@ -12,9 +12,10 @@ export async function launchBrowser(
   url: string,
   options: {
     processGroupId: string;
+    verbose?: boolean;
   }
 ) {
-  const { processGroupId } = options;
+  const { processGroupId, verbose } = options;
 
   const profileDir = join(runtimePath, "profiles", runtimeMetadata.runtime);
   ensureDirSync(profileDir);
@@ -31,6 +32,7 @@ export async function launchBrowser(
       RECORD_ALL_CONTENT: "1",
       RECORD_REPLAY_DIRECTORY: getReplayPath(),
       RECORD_REPLAY_METADATA: JSON.stringify({ processGroupId }),
+      RECORD_REPLAY_VERBOSE: verbose ? "1" : undefined,
     },
     stdio: undefined,
   };


### PR DESCRIPTION
Default behavior (silent):
![Screenshot 2024-04-18 at 8 01 57 AM](https://github.com/replayio/replay-cli/assets/29597/0b228d17-8f0b-49d6-b08f-83a6e1a7e527)

Debug flag only:
![Screenshot 2024-04-18 at 8 02 13 AM](https://github.com/replayio/replay-cli/assets/29597/926251a8-2158-4e00-b975-a20a839135eb)

Verbose debug mode:
![Screenshot 2024-04-18 at 8 01 38 AM](https://github.com/replayio/replay-cli/assets/29597/39e5f4dc-ef59-4a84-90cd-2409b97eb473)
