### PR TITLE
Report a better uploading errors to the user

### DIFF
--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -591,6 +591,9 @@ class ReplayReporter<TRecordingMetadata extends UnstructuredMetadata = Unstructu
     try {
       const result = await uploadRecording(recording.id, {
         apiKey: this.apiKey,
+        // Per TT-941, we want to throw on any error so it can be caught below
+        // and reported back to the user rather than just returning null
+        strict: true,
       });
 
       if (result === null) {

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -589,19 +589,12 @@ class ReplayReporter<TRecordingMetadata extends UnstructuredMetadata = Unstructu
     debug("Starting upload of %s", recording.id);
 
     try {
-      const result = await uploadRecording(recording.id, {
+      await uploadRecording(recording.id, {
         apiKey: this.apiKey,
         // Per TT-941, we want to throw on any error so it can be caught below
         // and reported back to the user rather than just returning null
         strict: true,
       });
-
-      if (result === null) {
-        return {
-          type: "upload",
-          error: new Error("Upload failed"),
-        };
-      }
 
       debug("Successfully uploaded %s", recording.id);
 


### PR DESCRIPTION
Passing `strict` to `uploadRecording` will cause it to throw on any error rather than returning `null` (which is a legacy behavior that should eventually change in a future breaking release). This allows us to show more detailed errors to the user like when they are being rate-limited.