### PR TITLE
`update` command should always check for NPM update

### DIFF
--- a/packages/replayio/src/commands/update.ts
+++ b/packages/replayio/src/commands/update.ts
@@ -1,12 +1,42 @@
 import { registerCommand } from "../utils/commander/registerCommand";
 import { exitProcess } from "../utils/exitProcess";
+import { checkForNpmUpdate } from "../utils/initialization/checkForNpmUpdate";
+import { checkForRuntimeUpdate } from "../utils/initialization/checkForRuntimeUpdate";
+import { promptForNpmUpdate } from "../utils/initialization/promptForNpmUpdate";
 import { installLatestRelease } from "../utils/installation/installLatestRelease";
+import { statusSuccess } from "../utils/theme";
 
-registerCommand("update").description("Update your installed Replay browser").action(update);
+registerCommand("update", {
+  checkForRuntimeUpdate: false,
+  checkForNpmUpdate: false,
+})
+  .description("Update Replay")
+  .action(update);
 
 async function update() {
   try {
-    await installLatestRelease();
+    const [runtimeUpdateCheck, npmUpdateCheck] = await Promise.all([
+      checkForRuntimeUpdate(),
+      checkForNpmUpdate(),
+    ]);
+
+    if (runtimeUpdateCheck.hasUpdate && npmUpdateCheck.hasUpdate) {
+      await installLatestRelease();
+      await promptForNpmUpdate(npmUpdateCheck, false);
+    } else if (npmUpdateCheck.hasUpdate) {
+      console.log(statusSuccess("✔"), "You have the latest version of the Replay Browser");
+
+      await promptForNpmUpdate(npmUpdateCheck, false);
+    } else if (runtimeUpdateCheck.hasUpdate) {
+      console.log(statusSuccess("✔"), "You have the latest version of replayio");
+
+      await installLatestRelease();
+    } else {
+      console.log(
+        statusSuccess("✔"),
+        "You have the latest version of replayio and the Replay Browser"
+      );
+    }
 
     await exitProcess(0);
   } catch (error) {

--- a/packages/replayio/src/utils/commander/registerCommand.ts
+++ b/packages/replayio/src/utils/commander/registerCommand.ts
@@ -4,13 +4,18 @@ import { initialize } from "../initialization/initialize";
 export function registerCommand(
   commandName: string,
   config: {
+    checkForNpmUpdate?: boolean;
     checkForRuntimeUpdate?: boolean;
     requireAuthentication?: boolean;
   } = {}
 ) {
-  const { checkForRuntimeUpdate = false, requireAuthentication = false } = config;
+  const {
+    checkForNpmUpdate = true,
+    checkForRuntimeUpdate = false,
+    requireAuthentication = false,
+  } = config;
 
   return program.command(commandName).hook("preAction", async () => {
-    await initialize({ checkForRuntimeUpdate, requireAuthentication });
+    await initialize({ checkForNpmUpdate, checkForRuntimeUpdate, requireAuthentication });
   });
 }

--- a/packages/replayio/src/utils/initialization/initialize.ts
+++ b/packages/replayio/src/utils/initialization/initialize.ts
@@ -9,9 +9,11 @@ import { promptForNpmUpdate } from "./promptForNpmUpdate";
 import { promptForRuntimeUpdate } from "./promptForRuntimeUpdate";
 
 export async function initialize({
+  checkForNpmUpdate: shouldCheckForNpmUpdate,
   checkForRuntimeUpdate: shouldCheckForRuntimeUpdate,
   requireAuthentication,
 }: {
+  checkForNpmUpdate: boolean;
   checkForRuntimeUpdate: boolean;
   requireAuthentication: boolean;
 }) {
@@ -22,7 +24,7 @@ export async function initialize({
     shouldCheckForRuntimeUpdate
       ? raceWithTimeout(checkForRuntimeUpdate(), 5_000)
       : Promise.resolve(),
-    raceWithTimeout(checkForNpmUpdate(), 5_000),
+    shouldCheckForNpmUpdate ? raceWithTimeout(checkForNpmUpdate(), 5_000) : Promise.resolve(),
   ]);
 
   logPromise(promises, {

--- a/packages/replayio/src/utils/initialization/promptForNpmUpdate.ts
+++ b/packages/replayio/src/utils/initialization/promptForNpmUpdate.ts
@@ -6,7 +6,10 @@ import { UpdateCheckResult } from "./types";
 
 const PROMPT_ID = "npm-update";
 
-export async function promptForNpmUpdate(updateCheck: UpdateCheckResult<string>) {
+export async function promptForNpmUpdate(
+  updateCheck: UpdateCheckResult<string>,
+  promptBeforeContinuing: boolean = true
+) {
   const { fromVersion, toVersion } = updateCheck;
 
   console.log("");
@@ -18,11 +21,13 @@ export async function promptForNpmUpdate(updateCheck: UpdateCheckResult<string>)
   console.log(highlight(`  npm install --global ${packageName}@${toVersion}`));
   console.log("");
 
-  if (process.stdin.isTTY) {
-    console.log("Press any key to continue");
-    console.log("");
+  if (promptBeforeContinuing) {
+    if (process.stdin.isTTY) {
+      console.log("Press any key to continue");
+      console.log("");
 
-    await prompt();
+      await prompt();
+    }
   }
 
   updateCachedPromptData({


### PR DESCRIPTION
- [x] Also check for an update to the `replayio` NPM package
- [x] Ignore the update prompt frequency check when the user is explicitly asking for an udpate

| NPM update? | Runtime update? | UI |
| :--- | :--- | :--- |
| ✘ | ✘ | ![Screenshot 2024-04-22 at 7 52 21 AM](https://github.com/replayio/replay-cli/assets/29597/06bccb78-adfe-472f-9956-e60b12181b2b) |
| ✘ | ✔ | ![Screenshot 2024-04-22 at 7 52 13 AM](https://github.com/replayio/replay-cli/assets/29597/fbb37816-0f59-4a3c-badd-ea9e7ed89f4d) |
| ✔ | ✘ | ![Screenshot 2024-04-22 at 7 49 52 AM](https://github.com/replayio/replay-cli/assets/29597/ed700937-1ee6-468f-ac8d-2cc8dfa8033e) |
| ✔ | ✔ | ![Screenshot 2024-04-22 at 7 51 47 AM](https://github.com/replayio/replay-cli/assets/29597/0c07c4dc-c2a6-4b63-8c06-ace053ea98b7) |