### PR TITLE
Avoid initializing LaunchDarkly outside of the CLI context

### DIFF
--- a/packages/replay/src/auth.ts
+++ b/packages/replay/src/auth.ts
@@ -394,5 +394,5 @@ export async function initLDContextFromApiKey(options: Options = {}) {
     await writeAuthInfoCache(apiKey, targetId, options);
   }
 
-  await getLaunchDarkly().identify({ type: "user", id: targetId });
+  await getLaunchDarkly().initialize().identify({ type: "user", id: targetId });
 }


### PR DESCRIPTION
The problem with LaunchDarkly is that it setups a timer loop. Outside of the CLI context (like when importing and using upload utils) we don't have a good place to stop this client. 

Doing it per-util or something would be super error-prone as it's quite easy to forget that it has to be handled. So I decided to just avoid creating that client outside of the CLI context - all calls to bare utils will just use the default values.