### PR TITLE
Add REPLAY_API_KEY fallback for RECORD_REPLAY_API_KEY

### DIFF
--- a/.github/workflows/create-react-app-typescript-ci.yml
+++ b/.github/workflows/create-react-app-typescript-ci.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: ./.github/actions/playwright
         with:
           project: "replay-chromium"
-          api-key: ${{ secrets.RECORD_REPLAY_API_KEY }}
+          api-key: ${{ secrets.REPLAY_API_KEY || secrets.RECORD_REPLAY_API_KEY }}
           working-directory: examples/create-react-app-typescript

--- a/examples/create-react-app-typescript/README.md
+++ b/examples/create-react-app-typescript/README.md
@@ -30,7 +30,7 @@ You can now upload that replay by copying it's id and passing that as an argumen
 npx @replayio/replay upload 1146850316
 ```
 
-\*Don't forget to set your `RECORD_REPLAY_API_KEY`, which can be created from the settings panel of `app.replay.io`.
+\*Don't forget to set your `REPLAY_API_KEY`, which can be created from the settings panel of `app.replay.io`.
 
 If all goes well you should see something like the following output:
 

--- a/packages/replay/README.md
+++ b/packages/replay/README.md
@@ -18,7 +18,7 @@ When using the Replay plugins to record automated tests or the Replay version of
 npx @replayio/replay <command>
 ```
 
-Possible commands are given below. These may be used with the `--directory <dir>` option to override the default recording directory, or `--server <address>` to override the default server address. When uploading, an API key is required, which can be passed via `--api-key <key>` or by setting the `RECORD_REPLAY_API_KEY` environment variable.
+Possible commands are given below. These may be used with the `--directory <dir>` option to override the default recording directory, or `--server <address>` to override the default server address. When uploading, an API key is required, which can be passed via `--api-key <key>` or by setting the `REPLAY_API_KEY` environment variable.
 
 ### launch
 
@@ -111,7 +111,7 @@ The CLI command `replay upload-sourcemaps [opts] <paths...>` has the following o
   require uploaded names to have an overall group name associated with them.
   This could for instance be a version number, or commit hash.
 - `--api-key`: The API key to use when connecting to Replay's servers.
-  Defaults to `process.env.RECORD_REPLAY_API_KEY`.
+  Defaults to `process.env.REPLAY_API_KEY`.
 - `--root`: Set the directory that relative paths should be computed with respect to. The relative path
   of sourcemaps is included in the uploaded entry, and will be visible in the uploaded-asset UI, so this
   can be used to strip off unimportant directories in the build path. Defaults to `process.cwd()`.

--- a/packages/replay/src/client.ts
+++ b/packages/replay/src/client.ts
@@ -63,11 +63,11 @@ class ProtocolClient {
   }
 
   async setAccessToken(accessToken?: string) {
-    accessToken = accessToken || process.env.RECORD_REPLAY_API_KEY;
+    accessToken = accessToken || process.env.REPLAY_API_KEY || process.env.RECORD_REPLAY_API_KEY;
 
     if (!accessToken) {
       throw new Error(
-        "Access token must be passed or set via the RECORD_REPLAY_API_KEY environment variable."
+        "Access token must be passed or set via the REPLAY_API_KEY environment variable."
       );
     }
 

--- a/packages/replayio/README.md
+++ b/packages/replayio/README.md
@@ -22,7 +22,7 @@ For help on a specific command, use the `help` command:
 replayio help list
 ```
 
-This CLI will automatically prompt you to log into your Replay account (or to register one). You can use an `RECORD_REPLAY_API_KEY` environment variable for authentication instead if you prefer.
+This CLI will automatically prompt you to log into your Replay account (or to register one). You can use an `REPLAY_API_KEY` environment variable for authentication instead if you prefer.
 
 The CLI will also prompt you to download the Replay runtime if you have not already done so.
 

--- a/packages/sourcemap-upload/README.md
+++ b/packages/sourcemap-upload/README.md
@@ -46,7 +46,7 @@ interface Options {
 
   /**
    * The API key to use when connecting to Replay's servers.
-   * Defaults to `process.env.RECORD_REPLAY_API_KEY`.
+   * Defaults to `process.env.REPLAY_API_KEY`.
    */
   key?: string;
 

--- a/packages/sourcemap-upload/src/index.ts
+++ b/packages/sourcemap-upload/src/index.ts
@@ -80,10 +80,14 @@ export async function uploadSourceMaps(opts: UploadOptions): Promise<void> {
     "'root' must be a string or undefined"
   );
 
-  const apiKey = opts.key || process.env.RECORD_REPLAY_API_KEY || null;
+  const apiKey =
+    opts.key ||
+    process.env.REPLAY_API_KEY ||
+    process.env.RECORD_REPLAY_API_KEY ||
+    null;
   assert(
     apiKey,
-    "'key' must contain a key, or the RECORD_REPLAY_API_KEY must be set."
+    "'key' must contain a key, or the REPLAY_API_KEY must be set."
   );
 
   assert(


### PR DESCRIPTION
We weren't doing this everywhere, just most places.

I also updated a few docs to reference `REPLAY_API_KEY` instead of the legacy `RECORD_REPLAY_API_KEY` variable.