### PR TITLE
[wip] Add honeycomb event

### DIFF
--- a/packages/replayio/src/commands/record.ts
+++ b/packages/replayio/src/commands/record.ts
@@ -16,6 +16,7 @@ import { selectRecordings } from "../utils/recordings/selectRecordings";
 import { LocalRecording } from "../utils/recordings/types";
 import { uploadRecordings } from "../utils/recordings/upload/uploadRecordings";
 import { dim } from "../utils/theme";
+import { sendEvent } from "../utils/telemetry";
 
 registerCommand("record", { checkForRuntimeUpdate: true, requireAuthentication: true })
   .argument("[url]", `URL to open (default: "about:blank")`)
@@ -46,6 +47,10 @@ async function record(url: string = "about:blank") {
         const errorLogPath = getReplayPath("recorder-crash.log");
 
         writeFileSync(errorLogPath, stderr, "utf8");
+
+        sendEvent("cli-recorder-crash", {
+          message: stderr,
+        });
 
         console.log(dim(`More information can be found in ${errorLogPath}`));
       }

--- a/packages/replayio/src/utils/telemetry.ts
+++ b/packages/replayio/src/utils/telemetry.ts
@@ -1,0 +1,47 @@
+import assert from "assert";
+
+let defaultTags = {};
+export function setDefaultTags(tags: Object) {
+  defaultTags = tags;
+}
+
+export async function sendEvent(event: string, tags: Object = {}): Promise<void> {
+  const eventTags = { ...defaultTags, ...tags };
+
+  if (process.env.NODE_ENV !== "development" || process.env.REPLAY_TELEMETRY) {
+    try {
+      const response = await fetch("https://telemetry.replay.io/", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          event,
+          ...eventTags,
+        }),
+      });
+
+      if (!response.ok) {
+        console.error(`Telemetry request returned unexpected status: ${response.status}`);
+      }
+    } catch (error) {
+      console.error("Telemetry request failed:", error);
+    }
+  }
+}
+
+export function assertWithTelemetry(
+  assertion: unknown,
+  message: string,
+  type: string,
+  tags: Object = {}
+): asserts assertion {
+  if (!assertion) {
+    sendEvent(type, {
+      message,
+      ...tags,
+    });
+  }
+
+  return assert(assertion, message);
+}


### PR DESCRIPTION
This adds a `sendEvent` method for tracking errors in honeycomb. This is lifted from [recordData](https://github.com/search?type=code&q=org%3Areplayio+recordData+repo%3Areplayio%2Fdevtools) in DevTools.

Marking it as a WIP because i haven't tested it.