### PR TITLE
Disable animated log output for non-TTY instances

### DIFF
--- a/packages/replayio/src/config.ts
+++ b/packages/replayio/src/config.ts
@@ -5,5 +5,6 @@ export const replayWsServer =
 
 const isCI = !!process.env.CI;
 const isDebugging = !!process.env.DEBUG;
+const isTTY = process.stdout.isTTY;
 
-export const disableAnimatedLog = isCI || isDebugging;
+export const disableAnimatedLog = isCI || isDebugging || !isTTY;


### PR DESCRIPTION
Maybe this is a good idea to always do?