### PR TITLE
fix: no errors should occur when pressing a button to halt recording

### DIFF
--- a/packages/replayio/src/utils/spawnProcess.ts
+++ b/packages/replayio/src/utils/spawnProcess.ts
@@ -54,6 +54,11 @@ export function spawnProcess(
 
     spawned.on("exit", (code, signal) => {
       if (code || signal) {
+        // Don't fail on manual closing
+        if (signal === "SIGTERM") {
+          deferred.resolveIfPending();
+          return;
+        }
         const message = `Process failed (${code ? `code: ${code}` : `signal: ${signal}`})`;
 
         deferred.rejectIfPending(new ProcessError(message, stderr));


### PR DESCRIPTION
When using the keyboard in the CLI to halt the Replay browser, I was getting the following error:

![image](https://github.com/replayio/replay-cli/assets/9100169/24ef3568-69bd-49fe-91f6-89b6a3d4fdc3)

Without a relevant stacktrace/error log file.

This is because `process.kill` (triggered by the `prompt`) would send a `signal: "SIGTERM"`, which would be seen by this code as a failure.

This code edgecases `SIGTERM` to sidestep this problem.