### PR TITLE
fix: don't throw errors when minor errors occur in Chromium

### DIFF
--- a/packages/replayio/src/utils/browser/launchBrowser.ts
+++ b/packages/replayio/src/utils/browser/launchBrowser.ts
@@ -28,6 +28,8 @@ export async function launchBrowser(
     "--no-first-run",
     "--no-default-browser-check",
     `--user-data-dir=${profileDir}`,
+    // Ignore errors like USB read descriptors on devices with faulty USB
+    "--log-level=3"
   ];
   const processOptions = {
     env: {


### PR DESCRIPTION
While working on a machine with slightly faulty USB (**really hard to figure out exactly what's wrong**) I noticed that I couldn't submit a replay because of the following errors:

```
[15872:31260:0505/003743.712:ERROR:device_event_log_impl.cc(215)] [00:37:43.712] Bluetooth: bluetooth_adapter_winrt.cc:1074 Getting Default Adapter failed.
[15872:31260:0505/003743.718:ERROR:device_event_log_impl.cc(215)] [00:37:43.718] USB: usb_service_win.cc:104 SetupDiGetDeviceProperty({{A45C254E-DF1C-4EFD-8020-67D146A850E0}, 6}) failed: Element not found. (0x490)
[15872:31260:0505/003743.721:ERROR:device_event_log_impl.cc(215)] [00:37:43.721] USB: usb_device_handle_win.cc:1045 Failed to read descriptor from node connection: A device attached to the system is not functioning. (0x1F)
[15872:31260:0505/003743.729:ERROR:device_event_log_impl.cc(215)] [00:37:43.729] USB: usb_device_handle_win.cc:1045 Failed to read descriptor from node connection: A device attached to the system is not functioning. (0x1F)
```

But these don't appear to be major errors that we should be listening to as a heuristic to block a recording.

This PR follows:

https://peter.sh/experiments/chromium-command-line-switches/

And switches the `--log-level` of Chromium to 3 for `FATAL` errors, rather than **all** errors. This should allow more replays to be sent through and crashes to still be reported properly.