### PR TITLE
Show reason for unusable recording

### DIFF
--- a/.changeset/tough-cycles-heal.md
+++ b/.changeset/tough-cycles-heal.md
@@ -1,0 +1,6 @@
+---
+"@replayio/replay": patch
+"replayio": patch
+---
+
+Show the reason for recordings failures if it is known (e.g. a stack overflow)

--- a/packages/replayio/src/commands/record.ts
+++ b/packages/replayio/src/commands/record.ts
@@ -111,12 +111,10 @@ async function record(url: string = "about:blank") {
   } else if (unusableRecordings.length > 0) {
     // If there were unusable recordings we should provide explicit messaging about them
     const reason = unusableRecordings.findLast(
-      recording => recording.recordingStatus === "unusable" && recording.unusableReason
+      recording => recording.unusableReason
     )?.unusableReason;
-    if (reason) {
-      console.log("An error occurred while recording:\n" + statusFailed(reason));
-      console.log(""); // Spacing for readability
-    }
+    console.log("An error occurred while recording:\n" + statusFailed(reason ?? "Internal"));
+    console.log(""); // Spacing for readability
   }
 
   trackEvent("record.results", {

--- a/packages/replayio/src/commands/record.ts
+++ b/packages/replayio/src/commands/record.ts
@@ -11,7 +11,6 @@ import { exitProcess } from "../utils/exitProcess";
 import { killProcess } from "../utils/killProcess";
 import { trackEvent } from "../utils/mixpanel/trackEvent";
 import { canUpload } from "../utils/recordings/canUpload";
-import { getRecordingUnusableReason } from "../utils/recordings/getRecordingUnusableReason";
 import { getRecordings } from "../utils/recordings/getRecordings";
 import { printRecordings } from "../utils/recordings/printRecordings";
 import { selectRecordings } from "../utils/recordings/selectRecordings";
@@ -111,7 +110,9 @@ async function record(url: string = "about:blank") {
     console.log(""); // Spacing for readability
   } else if (unusableRecordings.length > 0) {
     // If there were unusable recordings we should provide explicit messaging about them
-    const reason = getRecordingUnusableReason(processGroupId);
+    const reason = unusableRecordings.findLast(
+      recording => recording.recordingStatus === "unusable" && recording.unusableReason
+    )?.unusableReason;
     if (reason) {
       console.log("An error occurred while recording:\n" + statusFailed(reason));
       console.log(""); // Spacing for readability

--- a/packages/replayio/src/commands/upload.ts
+++ b/packages/replayio/src/commands/upload.ts
@@ -41,7 +41,6 @@ async function upload(
 
     selectedRecordings = await selectRecordings(recordings, {
       defaultSelected: recording => recording.metadata.processType === "root",
-      disabledSelector: recording => !canUpload(recording),
       noSelectableRecordingsMessage:
         "The recording(s) below cannot be uploaded.\n" +
         printRecordings(recordings, { showHeaderRow: false }),

--- a/packages/replayio/src/utils/recordings/getRecordingUnusableReason.ts
+++ b/packages/replayio/src/utils/recordings/getRecordingUnusableReason.ts
@@ -1,0 +1,8 @@
+import { getRecordings } from "./getRecordings";
+
+export function getRecordingUnusableReason(processGroupIdFilter?: string) {
+  // Look for the most recent unusable recording; that is most likely to be related
+  return getRecordings(processGroupIdFilter).findLast(
+    recording => recording.recordingStatus === "unusable" && recording.unusableReason
+  )?.unusableReason;
+}

--- a/packages/replayio/src/utils/recordings/getRecordingUnusableReason.ts
+++ b/packages/replayio/src/utils/recordings/getRecordingUnusableReason.ts
@@ -1,8 +1,0 @@
-import { getRecordings } from "./getRecordings";
-
-export function getRecordingUnusableReason(processGroupIdFilter?: string) {
-  // Look for the most recent unusable recording; that is most likely to be related
-  return getRecordings(processGroupIdFilter).findLast(
-    recording => recording.recordingStatus === "unusable" && recording.unusableReason
-  )?.unusableReason;
-}

--- a/packages/replayio/src/utils/recordings/getRecordings.test.ts
+++ b/packages/replayio/src/utils/recordings/getRecordings.test.ts
@@ -1,0 +1,134 @@
+import type { getRecordings as getRecordingsStatic } from "./getRecordings";
+
+describe("getRecordings", () => {
+  let getRecordings: typeof getRecordingsStatic;
+  let mockExistsSync: jest.MockInstance<boolean, []>;
+  let mockReadFileSync: jest.MockInstance<string, [string]>;
+
+  beforeEach(() => {
+    jest.mock("fs-extra");
+
+    mockExistsSync = require("fs-extra").existsSync;
+    mockExistsSync.mockReturnValue(true);
+
+    mockReadFileSync = require("fs-extra").readFileSync;
+    mockReadFileSync.mockReturnValue("");
+
+    getRecordings = require("./getRecordings").getRecordings;
+  });
+
+  it("should parse an empty log", () => {
+    const recordings = getRecordings();
+    expect(recordings).toHaveLength(0);
+  });
+
+  it("should parse a log with finished recordings", () => {
+    mockReadFileSync.mockReturnValue(`
+      {"id":"fake","kind":"createRecording"}
+      {"id":"fake","kind":"addMetadata","metadata":{"processGroupId":"fake"}}
+      {"id":"fake","kind":"addMetadata","metadata":{"process":"root"}}
+      {"id":"fake","kind":"addMetadata","metadata":{"uri":"https://www.fake.com/"}}
+      {"id":"fake","kind":"writeStarted","path":"~/.replay/recording-fake.dat"}
+      {"id":"fake","kind":"writeFinished"}
+    `);
+
+    const recordings = getRecordings();
+    expect(recordings).toHaveLength(1);
+    expect(recordings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          metadata: expect.objectContaining({ processType: "root" }),
+          processingStatus: undefined,
+          recordingStatus: "finished",
+        }),
+      ])
+    );
+  });
+
+  it("should parse a log with in-progress recordings", () => {
+    mockReadFileSync.mockReturnValue(`
+      {"id":"fake","kind":"createRecording"}
+      {"id":"fake","kind":"addMetadata","metadata":{"processGroupId":"fake"}}
+      {"id":"fake","kind":"addMetadata","metadata":{"process":"root"}}
+      {"id":"fake","kind":"addMetadata","metadata":{"uri":"https://www.fake.com/"}}
+      {"id":"fake","kind":"writeStarted","path":"~/.replay/recording-fake.dat"}
+    `);
+
+    const recordings = getRecordings();
+    expect(recordings).toHaveLength(1);
+    expect(recordings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          recordingStatus: "recording",
+        }),
+      ])
+    );
+  });
+
+  it("should parse a log with crashed recordings", () => {
+    mockReadFileSync.mockReturnValue(`
+      {"id":"fake","kind":"createRecording"}
+      {"id":"fake","kind":"addMetadata","metadata":{"processGroupId":"fake"}}
+      {"id":"fake","kind":"addMetadata","metadata":{"process":"root"}}
+      {"id":"fake","kind":"addMetadata","metadata":{"uri":"https://www.fake.com/"}}
+      {"id":"fake","kind":"writeStarted","path":"~/.replay/recording-fake.dat"}
+      {"id":"fake","kind":"crashed"}
+    `);
+
+    const recordings = getRecordings();
+    expect(recordings).toHaveLength(1);
+    expect(recordings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          recordingStatus: "crashed",
+        }),
+      ])
+    );
+  });
+
+  it("should parse a log with unusable recordings", () => {
+    mockReadFileSync.mockReturnValue(`
+      {"id":"fake","kind":"createRecording"}
+      {"id":"fake","kind":"addMetadata","metadata":{"processGroupId":"fake"}}
+      {"id":"fake","kind":"addMetadata","metadata":{"process":"root"}}
+      {"id":"fake","kind":"addMetadata","metadata":{"uri":"https://www.fake.com/"}}
+      {"id":"fake","kind":"writeStarted","path":"~/.replay/recording-fake.dat"}
+      {"id":"fake","kind":"recordingUnusable","reason":"Recording invalidated: Stack overflow"}
+      {"id":"fake","kind":"writeFinished"}
+    `);
+
+    const recordings = getRecordings();
+    expect(recordings).toHaveLength(1);
+    expect(recordings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          recordingStatus: "unusable",
+          unusableReason: "Recording invalidated: Stack overflow",
+        }),
+      ])
+    );
+  });
+
+  it("should parse a log with out-of-order entries", () => {
+    mockReadFileSync.mockReturnValue(`
+      {"id":"fake","kind":"addMetadata","metadata":{"processGroupId":"fake"}}
+      {"id":"fake","kind":"addMetadata","metadata":{"process":"root"}}
+      {"id":"fake","kind":"addMetadata","metadata":{"uri":"https://www.fake.com/"}}
+      {"id":"fake","kind":"createRecording"}
+      {"id":"fake","kind":"writeStarted","path":"~/.replay/recording-fake.dat"}
+      {"id":"fake","kind":"writeFinished"}
+    `);
+
+    const recordings = getRecordings();
+    expect(recordings).toHaveLength(1);
+    expect(recordings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          metadata: expect.objectContaining({ processType: "root" }),
+          processingStatus: undefined,
+          recordingStatus: "finished",
+        }),
+      ])
+    );
+  });
+});

--- a/packages/replayio/src/utils/recordings/getRecordings.ts
+++ b/packages/replayio/src/utils/recordings/getRecordings.ts
@@ -264,7 +264,7 @@ export function getRecordings(processGroupIdFilter?: string): LocalRecording[] {
     }
   }
 
-  debug("Found %s recordings:\n%o\n%o", recordings.length, JSON.stringify(recordings, null, 2));
+  debug("Found %s recordings:\n%O", recordings.length, recordings);
 
   return (
     recordings

--- a/packages/replayio/src/utils/recordings/getRecordings.ts
+++ b/packages/replayio/src/utils/recordings/getRecordings.ts
@@ -6,34 +6,12 @@ import { debug } from "./debug";
 import { readRecordingLog } from "./readRecordingLog";
 import { LocalRecording, RECORDING_LOG_KIND } from "./types";
 
-const RECORDING_LOG_KINDS = [
-  RECORDING_LOG_KIND.createRecording,
-  RECORDING_LOG_KIND.addMetadata,
-  RECORDING_LOG_KIND.writeStarted,
-  RECORDING_LOG_KIND.sourcemapAdded,
-  RECORDING_LOG_KIND.originalSourceAdded,
-  RECORDING_LOG_KIND.writeFinished,
-  RECORDING_LOG_KIND.uploadStarted,
-  RECORDING_LOG_KIND.uploadFinished,
-  RECORDING_LOG_KIND.uploadFailed,
-  RECORDING_LOG_KIND.recordingUnusable,
-  RECORDING_LOG_KIND.crashed,
-  RECORDING_LOG_KIND.crashData,
-  RECORDING_LOG_KIND.crashUploaded,
-  RECORDING_LOG_KIND.processingStarted,
-  RECORDING_LOG_KIND.processingFinished,
-  RECORDING_LOG_KIND.processingFailed,
-];
-
 export function getRecordings(processGroupIdFilter?: string): LocalRecording[] {
   const recordings: LocalRecording[] = [];
   const idToRecording: Record<string, LocalRecording> = {};
 
   if (existsSync(recordingLogPath)) {
     const entries = readRecordingLog();
-    entries.sort(
-      (a, b) => RECORDING_LOG_KINDS.indexOf(a.kind) - RECORDING_LOG_KINDS.indexOf(b.kind)
-    );
 
     debug("Reading recording log %s\n%s", recordingLogPath, JSON.stringify(entries));
 

--- a/packages/replayio/src/utils/recordings/readRecordingLog.ts
+++ b/packages/replayio/src/utils/recordings/readRecordingLog.ts
@@ -1,7 +1,26 @@
 import { readFileSync } from "fs-extra";
 import { recordingLogPath } from "./config";
 import { debug } from "./debug";
-import { LogEntry } from "./types";
+import { LogEntry, RECORDING_LOG_KIND } from "./types";
+
+const RECORDING_LOG_KINDS = [
+  RECORDING_LOG_KIND.createRecording,
+  RECORDING_LOG_KIND.addMetadata,
+  RECORDING_LOG_KIND.writeStarted,
+  RECORDING_LOG_KIND.sourcemapAdded,
+  RECORDING_LOG_KIND.originalSourceAdded,
+  RECORDING_LOG_KIND.writeFinished,
+  RECORDING_LOG_KIND.uploadStarted,
+  RECORDING_LOG_KIND.uploadFinished,
+  RECORDING_LOG_KIND.uploadFailed,
+  RECORDING_LOG_KIND.recordingUnusable,
+  RECORDING_LOG_KIND.crashed,
+  RECORDING_LOG_KIND.crashData,
+  RECORDING_LOG_KIND.crashUploaded,
+  RECORDING_LOG_KIND.processingStarted,
+  RECORDING_LOG_KIND.processingFinished,
+  RECORDING_LOG_KIND.processingFailed,
+];
 
 export function readRecordingLog() {
   const rawText = readFileSync(recordingLogPath, "utf8");
@@ -34,5 +53,6 @@ export function readRecordingLog() {
         });
       }
     })
-    .filter((v): v is LogEntry => !!v);
+    .filter((value): value is LogEntry => !!value)
+    .sort((a, b) => RECORDING_LOG_KINDS.indexOf(a.kind) - RECORDING_LOG_KINDS.indexOf(b.kind));
 }

--- a/packages/replayio/src/utils/recordings/selectRecordings.ts
+++ b/packages/replayio/src/utils/recordings/selectRecordings.ts
@@ -1,6 +1,7 @@
 // @ts-ignore TS types are busted; see github.com/enquirer/enquirer/issues/212
 import { MultiSelect } from "bvaughn-enquirer";
 import { dim, select, transparent } from "../theme";
+import { canUpload } from "./canUpload";
 import { printRecordings } from "./printRecordings";
 import { LocalRecording } from "./types";
 
@@ -8,7 +9,6 @@ export async function selectRecordings(
   recordings: LocalRecording[],
   options: {
     defaultSelected?: (recording: LocalRecording) => boolean;
-    disabledSelector?: (recording: LocalRecording) => boolean;
     maxRecordingsToDisplay?: number;
     noSelectableRecordingsMessage?: string;
     prompt: string;
@@ -16,13 +16,24 @@ export async function selectRecordings(
   }
 ): Promise<LocalRecording[]> {
   const {
-    defaultSelected = () => true,
-    disabledSelector = () => false,
+    defaultSelected: defaultSelectedProp,
     maxRecordingsToDisplay = 25,
     noSelectableRecordingsMessage,
     prompt,
     selectionMessage,
   } = options;
+
+  const defaultSelected = (recording: LocalRecording) => {
+    if (!canUpload(recording)) {
+      return false;
+    } else if (defaultSelectedProp) {
+      return defaultSelectedProp(recording);
+    } else {
+      return true;
+    }
+  };
+
+  const disabledSelector = (recording: LocalRecording) => !canUpload(recording);
 
   let isShowingAllRecordings = true;
   if (maxRecordingsToDisplay != null && recordings.length > maxRecordingsToDisplay) {

--- a/packages/replayio/src/utils/recordings/types.ts
+++ b/packages/replayio/src/utils/recordings/types.ts
@@ -41,6 +41,7 @@ export type LogEntry = {
   parentId?: string;
   parentOffset?: number;
   path?: string;
+  reason?: string;
   recordingId?: string;
   server?: string;
   targetContentHash?: string;
@@ -84,5 +85,6 @@ export type LocalRecording = {
   path: string | undefined;
   processingStatus: "failed" | "processed" | "processing" | undefined;
   recordingStatus: "crashed" | "finished" | "recording" | "unusable";
+  unusableReason: string | undefined;
   uploadStatus: "failed" | "uploading" | "uploaded" | undefined;
 };


### PR DESCRIPTION
Resolves PRO-533

When a recording is marked as _unusable_, the CLI should report that to the user.

| Scenario | Screenshot |
| :--- | :--- |
| 1 unusable recording | ![Screenshot 2024-06-05 at 3 48 29 PM](https://github.com/replayio/replay-cli/assets/29597/20dd1831-1c8c-4464-a571-40b34a8b203f) |
| 1 unusable recording and 1 usable recording | ![Screenshot 2024-06-05 at 3 48 37 PM](https://github.com/replayio/replay-cli/assets/29597/4730548c-e400-4188-8b5a-ab86c3439be6) |
| 1 usable recording | ![Screenshot 2024-06-05 at 3 48 45 PM](https://github.com/replayio/replay-cli/assets/29597/d853dc83-7964-42a2-aebb-5e49adc41242) |
| multiple usable recordings | ![Screenshot 2024-06-05 at 4 02 48 PM](https://github.com/replayio/replay-cli/assets/29597/8c375519-67d4-43a0-91e7-e421f9d441f4) |
| no new recordings | ![Screenshot 2024-06-05 at 4 04 46 PM](https://github.com/replayio/replay-cli/assets/29597/023c721c-6810-4f56-8f22-35b9018faaae) |