### PR TITLE
Fixed process crash on `setMetadata` failures

### DIFF
--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -249,7 +249,7 @@ async function multipartUploadRecording(
       size,
       requestPartChunkSize
     );
-  setMetadata(client, recordingId, metadata, strict, verbose);
+  await setMetadata(client, recordingId, metadata, strict, verbose);
   addRecordingEvent(dir, "uploadStarted", recording.id, {
     server,
     recordingId,
@@ -280,7 +280,7 @@ async function directUploadRecording(
     recording.buildId!,
     size
   );
-  setMetadata(client, recordingId, metadata, strict, verbose);
+  await setMetadata(client, recordingId, metadata, strict, verbose);
   addRecordingEvent(dir, "uploadStarted", recording.id, {
     server,
     recordingId,


### PR DESCRIPTION
Our test reporters run uploads with `strict: true`. This makes `handleUploadingError` throw when an error happens. Without `await` here those promises were floating (aka orphaned) and they were crashing the whole process (when they could be propagated to proper `catch` blocks.

With the fix the reporters won't crash with errors but will proceed to upload the rest of the recordings and list the ones that were uploaded successfully + list the failures.
