### PR TITLE
Take release architecture in to account when getting latest release

### DIFF
--- a/packages/replayio/src/utils/installation/config.ts
+++ b/packages/replayio/src/utils/installation/config.ts
@@ -1,7 +1,8 @@
 import { getReplayPath } from "../getReplayPath";
-import { Platform, Runtime } from "./types";
+import { Architecture, Platform, Runtime } from "./types";
 
 type Metadata = {
+  architecture: Architecture;
   destinationName: string;
   downloadFileName: string;
   path: string[];
@@ -12,9 +13,12 @@ type Metadata = {
 
 export let runtimeMetadata: Metadata;
 
+const architecture: Architecture = process.arch.startsWith("arm") ? "arm" : "x86_64";
+
 switch (process.platform) {
   case "darwin":
     runtimeMetadata = {
+      architecture,
       destinationName: "Replay-Chromium.app",
       downloadFileName:
         process.env.RECORD_REPLAY_CHROMIUM_DOWNLOAD_FILE ||
@@ -29,6 +33,7 @@ switch (process.platform) {
     break;
   case "linux":
     runtimeMetadata = {
+      architecture,
       destinationName: "chrome-linux",
       downloadFileName:
         process.env.RECORD_REPLAY_CHROMIUM_DOWNLOAD_FILE || "linux-replay-chromium.tar.xz",
@@ -40,6 +45,7 @@ switch (process.platform) {
     break;
   case "win32":
     runtimeMetadata = {
+      architecture,
       destinationName: "replay-chromium",
       downloadFileName:
         process.env.RECORD_REPLAY_CHROMIUM_DOWNLOAD_FILE || "windows-replay-chromium.zip",

--- a/packages/replayio/src/utils/installation/getLatestReleases.test.ts
+++ b/packages/replayio/src/utils/installation/getLatestReleases.test.ts
@@ -99,4 +99,40 @@ describe("getLatestRelease", () => {
 
     expect(mockedFetch).toHaveBeenCalledWith(expectedUrl);
   });
+
+  it("should handle a mix of null and unknown architectures", async () => {
+    const now = Date.now();
+    const nowString = now.toString();
+    const unknownRelease: Release = {
+      architecture: "unknown",
+      buildFile: "mocked-build-file",
+      buildId: "mocked-build-id",
+      platform: "linux",
+      releaseFile: "mocked-release-file",
+      runtime: "chromium",
+      time: (now - 500).toString(),
+      version: "mocked-version",
+    };
+    const oldRelease: Release = {
+      architecture: null,
+      buildFile: "mocked-build-file",
+      buildId: "mocked-build-id",
+      platform: "linux",
+      releaseFile: "mocked-release-file",
+      runtime: "chromium",
+      time: (now - 1000).toString(),
+      version: "mocked-version",
+    };
+    mockedFetch.mockResolvedValueOnce({
+      json: async () => [unknownRelease, oldRelease],
+    } as any);
+
+    await expect(getLatestRelease()).resolves.toEqual(unknownRelease);
+
+    mockedFetch.mockResolvedValueOnce({
+      json: async () => [oldRelease, unknownRelease],
+    } as any);
+
+    await expect(getLatestRelease()).resolves.toEqual(oldRelease);
+  });
 });

--- a/packages/replayio/src/utils/installation/getLatestReleases.test.ts
+++ b/packages/replayio/src/utils/installation/getLatestReleases.test.ts
@@ -1,0 +1,57 @@
+import fetch from "node-fetch";
+import { mocked } from "jest-mock";
+import { getLatestRelease } from "./getLatestReleases";
+import { replayAppHost } from "../../config";
+import { Release } from "./types";
+
+jest.mock("node-fetch");
+const mockedFetch = mocked(fetch, true);
+
+jest.mock("./config", () => ({
+  runtimeMetadata: {
+    platform: "linux",
+    runtime: "chromium",
+  },
+}));
+
+describe("getLatestRelease", () => {
+  beforeEach(() => {
+    mockedFetch.mockClear();
+  });
+
+  it("should throw an error if a recent release cannot be found", async () => {
+    const expectedUrl = `${replayAppHost}/api/releases`;
+    mockedFetch.mockResolvedValueOnce({ json: async () => [] } as any);
+
+    await expect(getLatestRelease()).rejects.toThrowError("No release found for linux:chromium");
+
+    expect(mockedFetch).toHaveBeenCalledWith(expectedUrl);
+  });
+
+  it("should return the latest release", async () => {
+    const expectedUrl = `${replayAppHost}/api/releases`;
+    const release: Release = {
+      platform: "linux",
+      runtime: "chromium",
+      releaseFile: "mocked-release-file",
+      buildFile: "mocked-build-file",
+      buildId: "mocked-build-id",
+      version: "mocked-version",
+      time: Date.now().toString(),
+    };
+    const oldRelease: Release = {
+      platform: "linux",
+      runtime: "chromium",
+      releaseFile: "mocked-release-file",
+      buildFile: "mocked-build-file",
+      buildId: "mocked-build-id",
+      version: "mocked-version",
+      time: (Date.now() - 1000).toString(),
+    };
+    mockedFetch.mockResolvedValueOnce({ json: async () => [release, oldRelease] } as any);
+
+    await expect(getLatestRelease()).resolves.toEqual(release);
+
+    expect(mockedFetch).toHaveBeenCalledWith(expectedUrl);
+  });
+});

--- a/packages/replayio/src/utils/installation/getLatestReleases.test.ts
+++ b/packages/replayio/src/utils/installation/getLatestReleases.test.ts
@@ -9,9 +9,9 @@ const mockedFetch = mocked(fetch, true);
 
 jest.mock("./config", () => ({
   runtimeMetadata: {
+    architecture: "x86_64",
     platform: "linux",
     runtime: "chromium",
-    architecture: "x86_64",
   },
 }));
 
@@ -32,24 +32,24 @@ describe("getLatestRelease", () => {
   it("should return the latest release and handle null architectures", async () => {
     const expectedUrl = `${replayAppHost}/api/releases`;
     const release: Release = {
-      platform: "linux",
       architecture: null,
-      runtime: "chromium",
-      releaseFile: "mocked-release-file",
       buildFile: "mocked-build-file",
       buildId: "mocked-build-id",
-      version: "mocked-version",
+      platform: "linux",
+      releaseFile: "mocked-release-file",
+      runtime: "chromium",
       time: Date.now().toString(),
+      version: "mocked-version",
     };
     const oldRelease: Release = {
-      platform: "linux",
       architecture: null,
-      runtime: "chromium",
-      releaseFile: "mocked-release-file",
       buildFile: "mocked-build-file",
       buildId: "mocked-build-id",
-      version: "mocked-version",
+      platform: "linux",
+      releaseFile: "mocked-release-file",
+      runtime: "chromium",
       time: (Date.now() - 1000).toString(),
+      version: "mocked-version",
     };
     mockedFetch.mockResolvedValueOnce({ json: async () => [release, oldRelease] } as any);
 
@@ -62,34 +62,34 @@ describe("getLatestRelease", () => {
     const expectedUrl = `${replayAppHost}/api/releases`;
     const now = Date.now().toString();
     const x86Release: Release = {
-      platform: "linux",
       architecture: "x86_64",
-      runtime: "chromium",
-      releaseFile: "mocked-release-file",
       buildFile: "mocked-build-file",
       buildId: "mocked-build-id",
-      version: "mocked-version",
+      platform: "linux",
+      releaseFile: "mocked-release-file",
+      runtime: "chromium",
       time: now,
+      version: "mocked-version",
     };
     const armRelease: Release = {
-      platform: "linux",
       architecture: "arm",
-      runtime: "chromium",
-      releaseFile: "mocked-release-file",
       buildFile: "mocked-build-file",
       buildId: "mocked-build-id",
-      version: "mocked-version",
+      platform: "linux",
+      releaseFile: "mocked-release-file",
+      runtime: "chromium",
       time: now,
+      version: "mocked-version",
     };
     const oldRelease: Release = {
-      platform: "linux",
       architecture: "x86_64",
-      runtime: "chromium",
-      releaseFile: "mocked-release-file",
       buildFile: "mocked-build-file",
       buildId: "mocked-build-id",
-      version: "mocked-version",
+      platform: "linux",
+      releaseFile: "mocked-release-file",
+      runtime: "chromium",
       time: (Date.now() - 1000).toString(),
+      version: "mocked-version",
     };
     mockedFetch.mockResolvedValueOnce({
       json: async () => [armRelease, x86Release, oldRelease],

--- a/packages/replayio/src/utils/installation/getLatestReleases.test.ts
+++ b/packages/replayio/src/utils/installation/getLatestReleases.test.ts
@@ -29,10 +29,10 @@ describe("getLatestRelease", () => {
     expect(mockedFetch).toHaveBeenCalledWith(expectedUrl);
   });
 
-  it("should return the latest release and handle null architectures", async () => {
+  it("should return the latest release and handle unknown architectures", async () => {
     const expectedUrl = `${replayAppHost}/api/releases`;
     const release: Release = {
-      architecture: null,
+      architecture: "unknown",
       buildFile: "mocked-build-file",
       buildId: "mocked-build-id",
       platform: "linux",
@@ -42,7 +42,7 @@ describe("getLatestRelease", () => {
       version: "mocked-version",
     };
     const oldRelease: Release = {
-      architecture: null,
+      architecture: "unknown",
       buildFile: "mocked-build-file",
       buildId: "mocked-build-id",
       platform: "linux",
@@ -98,41 +98,5 @@ describe("getLatestRelease", () => {
     await expect(getLatestRelease()).resolves.toEqual(x86Release);
 
     expect(mockedFetch).toHaveBeenCalledWith(expectedUrl);
-  });
-
-  it("should handle a mix of null and unknown architectures", async () => {
-    const now = Date.now();
-    const nowString = now.toString();
-    const unknownRelease: Release = {
-      architecture: "unknown",
-      buildFile: "mocked-build-file",
-      buildId: "mocked-build-id",
-      platform: "linux",
-      releaseFile: "mocked-release-file",
-      runtime: "chromium",
-      time: (now - 500).toString(),
-      version: "mocked-version",
-    };
-    const oldRelease: Release = {
-      architecture: null,
-      buildFile: "mocked-build-file",
-      buildId: "mocked-build-id",
-      platform: "linux",
-      releaseFile: "mocked-release-file",
-      runtime: "chromium",
-      time: (now - 1000).toString(),
-      version: "mocked-version",
-    };
-    mockedFetch.mockResolvedValueOnce({
-      json: async () => [unknownRelease, oldRelease],
-    } as any);
-
-    await expect(getLatestRelease()).resolves.toEqual(unknownRelease);
-
-    mockedFetch.mockResolvedValueOnce({
-      json: async () => [oldRelease, unknownRelease],
-    } as any);
-
-    await expect(getLatestRelease()).resolves.toEqual(oldRelease);
   });
 });

--- a/packages/replayio/src/utils/installation/getLatestReleases.ts
+++ b/packages/replayio/src/utils/installation/getLatestReleases.ts
@@ -20,9 +20,7 @@ export async function getLatestRelease() {
   );
 
   debug("Latest release", latestRelease);
-  if (!latestRelease) {
-    throw new Error(`No release found for ${platform}:${runtime}`);
-  }
+  assert(latestRelease, `No release found for ${platform}:${runtime}`);
 
   debug("Latest release on", new Date(latestRelease.time).toLocaleDateString());
 

--- a/packages/replayio/src/utils/installation/getLatestReleases.ts
+++ b/packages/replayio/src/utils/installation/getLatestReleases.ts
@@ -22,7 +22,10 @@ export async function getLatestRelease() {
     }
   });
 
-  assert(latestRelease, `No release found for ${platform}:${runtime}`);
+  debug("Latest release", latestRelease);
+  if (!latestRelease) {
+    throw new Error(`No release found for ${platform}:${runtime}`);
+  }
 
   debug("Latest release on", new Date(latestRelease.time).toLocaleDateString());
 

--- a/packages/replayio/src/utils/installation/getLatestReleases.ts
+++ b/packages/replayio/src/utils/installation/getLatestReleases.ts
@@ -5,7 +5,7 @@ import { runtimeMetadata } from "./config";
 import { debug } from "./debug";
 import { Release } from "./types";
 
-const { platform, runtime, architecture } = runtimeMetadata;
+const { architecture, platform, runtime } = runtimeMetadata;
 
 export async function getLatestRelease() {
   debug("Fetching release metadata");

--- a/packages/replayio/src/utils/installation/getLatestReleases.ts
+++ b/packages/replayio/src/utils/installation/getLatestReleases.ts
@@ -5,22 +5,19 @@ import { runtimeMetadata } from "./config";
 import { debug } from "./debug";
 import { Release } from "./types";
 
-const { platform, runtime } = runtimeMetadata;
+const { platform, runtime, architecture } = runtimeMetadata;
 
 export async function getLatestRelease() {
   debug("Fetching release metadata");
 
   const response = await fetch(`${replayAppHost}/api/releases`);
   const json = (await response.json()) as Release[];
-  const latestRelease = json.find(release => {
-    if (release.platform === platform && release.runtime === runtime) {
-      if (platform === "macOS") {
-        return process.arch.startsWith("arm") === release.releaseFile.includes("arm");
-      } else {
-        return true;
-      }
-    }
-  });
+  const latestRelease = json.find(
+    release =>
+      release.platform === platform &&
+      release.runtime === runtime &&
+      (release.architecture === architecture || release.architecture === null)
+  );
 
   debug("Latest release", latestRelease);
   if (!latestRelease) {

--- a/packages/replayio/src/utils/installation/getLatestReleases.ts
+++ b/packages/replayio/src/utils/installation/getLatestReleases.ts
@@ -17,7 +17,9 @@ export async function getLatestRelease() {
       release.platform === platform &&
       release.runtime === runtime &&
       // TODO(dmiller): remove this null check once we have done a release with the architecture field
-      (release.architecture === architecture || release.architecture === null)
+      (release.architecture === architecture ||
+        release.architecture === "unknown" ||
+        release.architecture === null)
   );
 
   debug("Latest release", latestRelease);

--- a/packages/replayio/src/utils/installation/getLatestReleases.ts
+++ b/packages/replayio/src/utils/installation/getLatestReleases.ts
@@ -16,6 +16,7 @@ export async function getLatestRelease() {
     release =>
       release.platform === platform &&
       release.runtime === runtime &&
+      // TODO(dmiller): remove this null check once we have done a release with the architecture field
       (release.architecture === architecture || release.architecture === null)
   );
 

--- a/packages/replayio/src/utils/installation/getLatestReleases.ts
+++ b/packages/replayio/src/utils/installation/getLatestReleases.ts
@@ -16,10 +16,7 @@ export async function getLatestRelease() {
     release =>
       release.platform === platform &&
       release.runtime === runtime &&
-      // TODO(dmiller): remove this null check once we have done a release with the architecture field
-      (release.architecture === architecture ||
-        release.architecture === "unknown" ||
-        release.architecture === null)
+      (release.architecture === architecture || release.architecture === "unknown")
   );
 
   debug("Latest release", latestRelease);

--- a/packages/replayio/src/utils/installation/getLatestReleases.ts
+++ b/packages/replayio/src/utils/installation/getLatestReleases.ts
@@ -22,7 +22,5 @@ export async function getLatestRelease() {
   debug("Latest release", latestRelease);
   assert(latestRelease, `No release found for ${platform}:${runtime}`);
 
-  debug("Latest release on", new Date(latestRelease.time).toLocaleDateString());
-
   return latestRelease;
 }

--- a/packages/replayio/src/utils/installation/types.ts
+++ b/packages/replayio/src/utils/installation/types.ts
@@ -7,7 +7,7 @@ export type Runtime = "chromium" | "node";
 export type Architecture = "arm" | "x86_64" | "unknown";
 
 export type Release = {
-  architecture: Architecture | null;
+  architecture: Architecture;
   buildFile: string;
   buildId: string;
   platform: Platform;

--- a/packages/replayio/src/utils/installation/types.ts
+++ b/packages/replayio/src/utils/installation/types.ts
@@ -4,7 +4,7 @@ export type Platform = "macOS" | "linux" | "windows";
 // This CLI only supports Chromium for the time being
 export type Runtime = "chromium" | "node";
 
-export type Architecture = "arm" | "x86_64";
+export type Architecture = "arm" | "x86_64" | "unknown";
 
 export type Release = {
   architecture: Architecture | null;

--- a/packages/replayio/src/utils/installation/types.ts
+++ b/packages/replayio/src/utils/installation/types.ts
@@ -4,7 +4,10 @@ export type Platform = "macOS" | "linux" | "windows";
 // This CLI only supports Chromium for the time being
 export type Runtime = "chromium" | "node";
 
+export type Architecture = "arm" | "x86_64";
+
 export type Release = {
+  architecture: Architecture | null;
   buildFile: string;
   buildId: string;
   platform: Platform;


### PR DESCRIPTION
The releases API now returns an architecture field. We should make sure to respect that. However, for old releases it will be null and that should be OK.

Fixes TT-1146