### PR TITLE
Annotate tests with related recordings

### DIFF
--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -643,7 +643,7 @@ class ReplayReporter<TRecordingMetadata extends UnstructuredMetadata = Unstructu
     }
   }
 
-  getRecordingsForTest(tests: Test[], includeUploaded: boolean) {
+  getRecordingsForTest(tests: Test[]) {
     const filter = `function($v) { $v.metadata.\`x-replay-test\`.id in ${JSON.stringify([
       ...tests.map(test =>
         this.getTestId({
@@ -655,7 +655,7 @@ class ReplayReporter<TRecordingMetadata extends UnstructuredMetadata = Unstructu
     ])} and $not($exists($v.metadata.test)) }`;
 
     const recordings = listAllRecordings({
-      all: includeUploaded,
+      all: false,
       filter,
     });
 
@@ -745,13 +745,13 @@ class ReplayReporter<TRecordingMetadata extends UnstructuredMetadata = Unstructu
   ): Promise<PendingWork> {
     try {
       const runnerGroupId = runnerGroupKey ? await generateOpaqueId(runnerGroupKey) : null;
-      const recordings = this.getRecordingsForTest(tests, false);
+      const recordings = this.getRecordingsForTest(tests);
 
       if (this.testRunShardId) {
         const recordingIds = recordings.map(r => r.id);
         const testInputs = await Promise.all(
           tests.map<Promise<TestRunTestInputModel>>(async t => {
-            const testId = await buildTestId(specFile, t);
+            const testId = buildTestId(specFile, t);
             if (!testId) {
               throw new Error("Failed to generate test id for test");
             }


### PR DESCRIPTION
Those annotations are automatically rendered by the Playwright's builtin junit reporter:
https://github.com/microsoft/playwright/blob/00bf7ea815684cc429824e01749cfa7f20be7f48/packages/playwright/src/reporters/junit.ts#L161-L170