### PR TITLE
Use node directly in postinstall scripts

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -17,7 +17,7 @@
     "*.d.ts"
   ],
   "scripts": {
-    "postinstall": "\"$npm_node_execpath\" ./first-run.js",
+    "postinstall": "node ./first-run.js",
     "prepare": "npm run build",
     "build": "rm -rf dist/ tsconfig.tsbuildinfo && tsc",
     "test": "echo \"Error: no test specified\"",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -17,7 +17,7 @@
     "*.d.ts"
   ],
   "scripts": {
-    "postinstall": "\"$npm_node_execpath\" ./first-run.js",
+    "postinstall": "node ./first-run.js",
     "prepare": "yarn run build",
     "build": "rm -rf dist/ tsconfig.tsbuildinfo && tsc",
     "test": "echo \"Error: no test specified\"",

--- a/packages/puppeteer/package.json
+++ b/packages/puppeteer/package.json
@@ -12,7 +12,7 @@
     "*.d.ts"
   ],
   "scripts": {
-    "postinstall": "\"$npm_node_execpath\" ./first-run.js",
+    "postinstall": "node ./first-run.js",
     "prepare": "yarn run build",
     "build": "rm -rf dist/ tsconfig.tsbuildinfo && tsc",
     "test": "echo \"Error: no test specified\"",


### PR DESCRIPTION
@crutchcorn reported problems with this on Windows + Dan and Chris had problems with this when running through dotslash. So to address those issues let's just call node directly instead of relying on this env variable. This won't support alternative runtimes as nice but those are esoteric use cases anyway.