### PR TITLE
Precompute expect locations for Playwright

### DIFF
--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -29,6 +29,7 @@
     "@replay-cli/tsconfig": "workspace:^",
     "@types/debug": "^4.1.8",
     "@types/node": "^20.11.27",
+    "@types/stack-utils": "^2.0.3",
     "@types/uuid": "^8.3.4",
     "@types/ws": "^8.5.10",
     "typescript": "^5.4.5"
@@ -47,6 +48,7 @@
     "@replayio/replay": "workspace:^",
     "@replayio/test-utils": "workspace:^",
     "debug": "^4.3.4",
+    "stack-utils": "^2.0.6",
     "uuid": "^8.3.2",
     "ws": "^8.13.0"
   },

--- a/packages/playwright/src/fixture.ts
+++ b/packages/playwright/src/fixture.ts
@@ -294,11 +294,13 @@ export async function replayFixture(
     // https://github.com/microsoft/playwright/blob/5fa0583dcb708e74d2f7fc456b8c44cec9752709/packages/playwright/src/matchers/expect.ts#L267-L275
     // so we need to handle them here
     if (data.category === "expect") {
-      if (!data.location) {
+      let frames = data.location ? [data.location] : undefined;
+      if (!frames) {
         // based on those lines we replicate how Playwright computes the location and precompute it here for it so it uses ours
         // https://github.com/microsoft/playwright/blob/2734a0534256ffde6bd8dc8d27581c7dd26fe2a6/packages/playwright/src/worker/testInfo.ts#L266-L272
         const filteredStack = filteredStackTrace(captureRawStack());
         data.location = filteredStack[0];
+        frames = filteredStack;
       }
 
       const step = addStep.call(this, data, ...rest);
@@ -313,7 +315,7 @@ export async function replayFixture(
           category: step.category,
           title: step.title,
           params: step.params || {},
-          frames: step.location ? [step.location] : [],
+          frames,
           hook: getCurrentHookType(),
         },
       }).catch(err => {

--- a/packages/playwright/src/fixture.ts
+++ b/packages/playwright/src/fixture.ts
@@ -1,4 +1,4 @@
-import { Browser, TestInfo, TestInfoError, test } from "@playwright/test";
+import { Browser, TestInfoError, test } from "@playwright/test";
 import { ReporterError } from "@replayio/test-utils";
 import assert from "assert";
 import dbg from "debug";
@@ -12,6 +12,7 @@ import {
   TestStepInternal,
 } from "./playwrightTypes";
 import { getServerPort } from "./server";
+import { captureRawStack, filteredStackTrace } from "./stackTrace";
 
 function isErrorWithCode<T extends string>(error: unknown, code: T): error is { code: T } {
   return !!error && typeof error === "object" && "code" in error && error.code === code;
@@ -286,15 +287,21 @@ export async function replayFixture(
   }
 
   const addStep = testInfo._addStep;
-  testInfo._addStep = function (...args) {
-    const step = addStep.call(this, ...args);
+  testInfo._addStep = function (data, ...rest) {
+    // expects are not passed through the client side instrumentation (since Playwright 1.41.0: https://github.com/microsoft/playwright/pull/28609)
+    // https://github.com/microsoft/playwright/blob/5fa0583dcb708e74d2f7fc456b8c44cec9752709/packages/playwright-core/src/client/channelOwner.ts#L186-L188
+    // they call `_addStep` directly
+    // https://github.com/microsoft/playwright/blob/5fa0583dcb708e74d2f7fc456b8c44cec9752709/packages/playwright/src/matchers/expect.ts#L267-L275
+    // so we need to handle them here
+    if (data.category === "expect") {
+      if (!data.location) {
+        // based on those lines we replicate how Playwright computes the location and precompute it here for it so it uses ours
+        // https://github.com/microsoft/playwright/blob/2734a0534256ffde6bd8dc8d27581c7dd26fe2a6/packages/playwright/src/worker/testInfo.ts#L266-L272
+        const filteredStack = filteredStackTrace(captureRawStack());
+        data.location = filteredStack[0];
+      }
 
-    if (step.category === "expect") {
-      // expects are not passed through the client side instrumentation (since Playwright 1.41.0: https://github.com/microsoft/playwright/pull/28609)
-      // https://github.com/microsoft/playwright/blob/5fa0583dcb708e74d2f7fc456b8c44cec9752709/packages/playwright-core/src/client/channelOwner.ts#L186-L188
-      // they call `_addStep` directly
-      // https://github.com/microsoft/playwright/blob/5fa0583dcb708e74d2f7fc456b8c44cec9752709/packages/playwright/src/matchers/expect.ts#L267-L275
-      // so we need to handle them here
+      const step = addStep.call(this, data, ...rest);
       expectSteps.add(step.stepId);
 
       handlePlaywrightEvent({
@@ -306,7 +313,6 @@ export async function replayFixture(
           category: step.category,
           title: step.title,
           params: step.params || {},
-          // TODO: this is unhelpful as it points to the monkey-patched function itself
           frames: step.location ? [step.location] : [],
           hook: getCurrentHookType(),
         },
@@ -314,8 +320,11 @@ export async function replayFixture(
         // this should never happen since `handlePlaywrightEvent` should always catch errors internally and shouldn't throw
         debug("Failed to add step:start for an expect: %o", err);
       });
+
+      return step;
     }
-    return step;
+
+    return addStep.call(this, data, ...rest);
   };
 
   const onStepEnd = testInfo._onStepEnd;

--- a/packages/playwright/src/playwrightTypes.ts
+++ b/packages/playwright/src/playwrightTypes.ts
@@ -1,6 +1,6 @@
 // Types imported from playwright and used by our fixture
 
-import { APIRequestContext, BrowserContext, TestInfo, TestInfoError } from "@playwright/test";
+import type { APIRequestContext, BrowserContext, TestInfo, TestInfoError } from "@playwright/test";
 
 // https://github.com/microsoft/playwright/blob/ebafb950542c334147c642cf10d5b6077b58f61e/packages/playwright/src/worker/testInfo.ts#L57
 export interface TestInfoInternal extends TestInfo {

--- a/packages/playwright/src/stackTrace.ts
+++ b/packages/playwright/src/stackTrace.ts
@@ -1,0 +1,95 @@
+/**
+ * based on:
+ * https://github.com/microsoft/playwright/blob/2734a0534256ffde6bd8dc8d27581c7dd26fe2a6/packages/playwright-core/src/utils/stackTrace.ts
+ * https://github.com/microsoft/playwright/blob/2734a0534256ffde6bd8dc8d27581c7dd26fe2a6/packages/playwright-core/src/utilsBundle.ts
+ * https://github.com/microsoft/playwright/blob/2734a0534256ffde6bd8dc8d27581c7dd26fe2a6/packages/playwright/src/util.ts
+ *
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from "path";
+import StackUtils from "stack-utils";
+import url from "url";
+import { StackFrame } from "./playwrightTypes";
+
+type RawStack = string[];
+
+const PLAYWRIGHT_TEST_PATH = path.dirname(require.resolve("@playwright/test/package.json"));
+const PLAYWRIGHT_PATH = path.dirname(
+  require.resolve("playwright/package.json", { paths: [PLAYWRIGHT_TEST_PATH] })
+);
+const PLAYWRIGHT_CORE_PATH = path.dirname(
+  require.resolve("playwright-core/package.json", { paths: [PLAYWRIGHT_PATH] })
+);
+const REPLAYIO_PLAYWRIGHT_PATH = path.dirname(require.resolve("@replayio/playwright/package.json"));
+
+const nodeInternals = StackUtils.nodeInternals();
+const nodeMajorVersion = +process.versions.node.split(".")[0];
+const stackUtils = new StackUtils({ internals: nodeInternals });
+
+export function captureRawStack(): RawStack {
+  const stackTraceLimit = Error.stackTraceLimit;
+  Error.stackTraceLimit = 50;
+  const error = new Error();
+  const stack = error.stack || "";
+  Error.stackTraceLimit = stackTraceLimit;
+  return stack.split("\n");
+}
+
+function parseStackTraceLine(line: string): StackFrame | null {
+  if (
+    !process.env.PWDEBUGIMPL &&
+    nodeMajorVersion < 16 &&
+    nodeInternals.some(internal => internal.test(line))
+  )
+    return null;
+  const frame = stackUtils.parseLine(line);
+  if (!frame) return null;
+  if (
+    !process.env.PWDEBUGIMPL &&
+    (frame.file?.startsWith("internal") || frame.file?.startsWith("node:"))
+  )
+    return null;
+  if (!frame.file) return null;
+  // ESM files return file:// URLs, see here: https://github.com/tapjs/stack-utils/issues/60
+  const file = frame.file.startsWith("file://")
+    ? url.fileURLToPath(frame.file)
+    : path.resolve(process.cwd(), frame.file);
+  return {
+    file,
+    line: frame.line || 0,
+    column: frame.column || 0,
+    function: frame.function,
+  };
+}
+
+function filterStackFile(file: string) {
+  if (!process.env.PWDEBUGIMPL && file.startsWith(PLAYWRIGHT_TEST_PATH)) return false;
+  if (!process.env.PWDEBUGIMPL && file.startsWith(PLAYWRIGHT_PATH)) return false;
+  if (!process.env.PWDEBUGIMPL && file.startsWith(PLAYWRIGHT_CORE_PATH)) return false;
+  if (!process.env.PWDEBUGIMPL && file.startsWith(REPLAYIO_PLAYWRIGHT_PATH)) return false;
+  return true;
+}
+
+export function filteredStackTrace(rawStack: RawStack): StackFrame[] {
+  const frames: StackFrame[] = [];
+  for (const line of rawStack) {
+    const frame = parseStackTraceLine(line);
+    if (!frame || !frame.file) continue;
+    if (!filterStackFile(frame.file)) continue;
+    frames.push(frame);
+  }
+  return frames;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2821,9 +2821,11 @@ __metadata:
     "@replayio/test-utils": "workspace:^"
     "@types/debug": "npm:^4.1.8"
     "@types/node": "npm:^20.11.27"
+    "@types/stack-utils": "npm:^2.0.3"
     "@types/uuid": "npm:^8.3.4"
     "@types/ws": "npm:^8.5.10"
     debug: "npm:^4.3.4"
+    stack-utils: "npm:^2.0.6"
     typescript: "npm:^5.4.5"
     uuid: "npm:^8.3.2"
     ws: "npm:^8.13.0"
@@ -3777,7 +3779,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/stack-utils@npm:^2.0.0":
+"@types/stack-utils@npm:^2.0.0, @types/stack-utils@npm:^2.0.3":
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
   checksum: 10c0/1f4658385ae936330581bcb8aa3a066df03867d90281cdf89cc356d404bd6579be0f11902304e1f775d92df22c6dd761d4451c804b0a4fba973e06211e9bd77c
@@ -14893,7 +14895,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stack-utils@npm:^2.0.3":
+"stack-utils@npm:^2.0.3, stack-utils@npm:^2.0.6":
   version: 2.0.6
   resolution: "stack-utils@npm:2.0.6"
   dependencies:


### PR DESCRIPTION
Those are still not as helpful because we don't compute properly labels/params but it's already a big improvement for being able to locate failed expect steps:

**First expect**
<img width="556" alt="Screenshot 2024-05-16 at 14 58 42" src="https://github.com/replayio/replay-cli/assets/9800850/e405f68f-f2f3-47e0-af2e-9f4b4a343e26">

**Second expect**
<img width="549" alt="Screenshot 2024-05-16 at 14 58 53" src="https://github.com/replayio/replay-cli/assets/9800850/8e28751d-ed65-41c9-b989-881df35156b8">
