### PR TITLE
Ignore steps without frames

### DIFF
--- a/examples/create-react-app-typescript/playwright.config.ts
+++ b/examples/create-react-app-typescript/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "@playwright/test";
 import { devices as replayDevices } from "@replayio/playwright";
 
-const config = defineConfig({
+export default defineConfig({
   forbidOnly: !!process.env.CI,
   use: {
     trace: "on-first-retry",
@@ -33,5 +33,3 @@ const config = defineConfig({
     },
   ],
 });
-
-module.exports = config;


### PR DESCRIPTION
The first steps on the **before** screenshot come from the builtin fixtures that are always executed for tests. They are redundant and unexpected and I think it's worth filtering them out.

**Before**
<img width="545" alt="Screenshot 2024-05-16 at 15 14 18" src="https://github.com/replayio/replay-cli/assets/9800850/65641bce-994d-4c5a-aebb-2364b2298b60">

**After**
<img width="562" alt="Screenshot 2024-05-16 at 15 05 56" src="https://github.com/replayio/replay-cli/assets/9800850/4fb58a18-35ca-4ac6-bee4-3cf5dd045f38">
