### PR TITLE
CLI no longer supports Windows+Chrome

### DIFF
--- a/packages/replayio/src/utils/installation/config.ts
+++ b/packages/replayio/src/utils/installation/config.ts
@@ -1,4 +1,5 @@
 import { getReplayPath } from "../getReplayPath";
+import { emphasize } from "../theme";
 import { Architecture, Platform, Runtime } from "./types";
 
 type Metadata = {
@@ -44,16 +45,24 @@ switch (process.platform) {
     };
     break;
   case "win32":
-    runtimeMetadata = {
-      architecture,
-      destinationName: "replay-chromium",
-      downloadFileName:
-        process.env.RECORD_REPLAY_CHROMIUM_DOWNLOAD_FILE || "windows-replay-chromium.zip",
-      path: ["replay-chromium", "chrome.exe"],
-      platform: "windows",
-      runtime: "chromium",
-      sourceName: "replay-chromium",
-    };
+    if (process.env.REPLAY_WINDOWS_CHROMIUM_OVERRIDE) {
+      // Force override for Replay internal testing purposes
+      runtimeMetadata = {
+        architecture,
+        destinationName: "replay-chromium",
+        downloadFileName:
+          process.env.RECORD_REPLAY_CHROMIUM_DOWNLOAD_FILE || "windows-replay-chromium.zip",
+        path: ["replay-chromium", "chrome.exe"],
+        platform: "windows",
+        runtime: "chromium",
+        sourceName: "replay-chromium",
+      };
+    } else {
+      console.log("");
+      console.log(emphasize("Replay does not support Windows at this time."));
+      console.log("Please use the Windows Subsystem for Linux (WSL) instead.");
+      process.exit(0);
+    }
     break;
   default: {
     throw Error(`Unsupported platform "${process.platform}"`);

--- a/packages/replayio/src/utils/installation/config.ts
+++ b/packages/replayio/src/utils/installation/config.ts
@@ -61,7 +61,7 @@ switch (process.platform) {
       console.log("");
       console.log(emphasize("Replay does not support Windows at this time."));
       console.log("Please use the Windows Subsystem for Linux (WSL) instead.");
-      process.exit(0);
+      process.exit(1);
     }
     break;
   default: {


### PR DESCRIPTION
This behavior can be overridden via the `REPLAY_WINDOWS_CHROMIUM_OVERRIDE` flag.

> [!NOTE]  
> I know, I know. Another env flag. It seemed the best way to allow Replay engineers to work around this like Jason requested. A command flag seems no better as we wouldn't want it to be user-visible.

Open to suggestions on the wording
![Screenshot 2024-05-20 at 3 30 34 PM](https://github.com/replayio/replay-cli/assets/29597/d80c20be-84d4-4dee-b58e-5347027142a4)

