### PR TITLE
Fixed `defaultBrowserType`'s type

### DIFF
--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -39,7 +39,7 @@ function getDeviceConfig() {
       },
       env,
     },
-    defaultBrowserType: "chromium",
+    defaultBrowserType: "chromium" as const,
   };
 }
 


### PR DESCRIPTION
Playwright expects `BrowserName` here - it comes from complex generic types so I didn't bother replicating that in the return's type annotation. Structural typing ftw though, this works just fine :)