### PR TITLE
Add a warning when none of the projects are using Replay Chromium

### DIFF
--- a/.changeset/wicked-suits-cheat.md
+++ b/.changeset/wicked-suits-cheat.md
@@ -1,0 +1,5 @@
+---
+"@replayio/playwright": patch
+---
+
+Added a warning when the reporter gets used without the Replay browser


### PR DESCRIPTION
This PR tries to address a couple of small issues. I think it's worth discussing different scenarios related to this.

1. A user might forget to install our browser but they want to use it
2. A user might accidentally (or on purpose) use our reporter without our browser

### Scenario one (no browser installed, browser configured): PRO-493

At the moment, we throw this and the process stops:
<img width="1109" alt="Screenshot 2024-05-29 at 17 10 02" src="https://github.com/replayio/replay-cli/assets/9800850/56c226a6-99a7-4421-9369-e1b8b77cc499">

This isn't overly noticeable because there is a lot of noise here in the form of a stack trace. We could improve this by wrapping this in an "ASCII box". This is what Playwright itself is doing for some of their stuff:
<img width="701" alt="Screenshot 2024-05-29 at 17 11 29" src="https://github.com/replayio/replay-cli/assets/9800850/d6cd0634-a584-4322-8f1b-b5bb2afe0bfa">

There is a notable difference between the error above and what we can throw in the reporter (where we throw right now). Their error doesn't print the stack trace but we can't avoid that. So we'd end up with an ASCII box followed by a stack trace. I don't think this looks good but it's still rather noticeable

Playwright doesn't always immediately fail the process. If it gets configured with an unknown browser it tries to execute all of the tests with it and fails all of the tests separately, with the same error message:
<img width="735" alt="Screenshot 2024-05-29 at 17 14 32" src="https://github.com/replayio/replay-cli/assets/9800850/2bc9597a-7214-45f4-9e94-203e8e0d5985">

### Scenario two (browser installed, browser not configured): PRO-472

This is a somewhat easy mistake when dealing with complex configs. Our reporter, in a sense, can still work just fine when the tests run using a different browser. The data in the dashboard can get updated just fine but, for obvious reasons, no recordings can be made in such a situation.

This leads, at times, to people being confused because they expect to get some recording links back as they don't realize that they forgot to configure our browser. We can't detect this situation in the `constructor`.

At times, people might want to skip using Replay. For example, when they run their tests on Windows since we don't support that right now. So there are some legitimate use cases when using our reporter **without** our browser is OK/expected.

---

This PR tries to strike a balance to improve both situations. Throwing in the constructor is inaccurate - but it gives us the control over the thrown error message.

I decided to move this logic to `onTestEnd` hook and to create a **warning** there. This mainly improves the scenario two. In the scenario one we end up with something like this:
<img width="1106" alt="Screenshot 2024-05-29 at 17 21 24" src="https://github.com/replayio/replay-cli/assets/9800850/c91e91df-ad7e-4f3e-86d9-fe25412f5de7">

We can't move our error/warning message to the end. Per-test failures are the same as similar failures in Playwright itself and they still give a good hint at what's wrong (the file doesn't exist -> it's not there -> it might not be installed). I think it would be nice if we could customize this somehow and I opened a feature request in Playwright for this: https://github.com/microsoft/playwright/issues/31070
