### PR TITLE
replayio: add trailing newline to recordings.log

### DIFF
--- a/packages/replayio/src/utils/recordings/readRecordingLog.ts
+++ b/packages/replayio/src/utils/recordings/readRecordingLog.ts
@@ -15,6 +15,10 @@ export function readRecordingLog() {
       } catch (err) {
         debug(`Error parsing line:\n${line}`);
 
+        // Early versions of `replayio` could remove the trailing \n from recordings.log,
+        // so the next entry would be appended to the last line, creating a line with two
+        // entries. This workaround lets us read these corrupted entries but it should
+        // be removed eventually.
         const replaced = line.replace(/\}\{/g, "}\n{");
 
         if (replaced.length === line.length) {

--- a/packages/replayio/src/utils/recordings/removeFromDisk.ts
+++ b/packages/replayio/src/utils/recordings/removeFromDisk.ts
@@ -71,7 +71,7 @@ export function removeFromDisk(id?: string) {
 
       writeFileSync(
         recordingLogPath,
-        filteredLogs.map(log => JSON.stringify(log)).join("\n"),
+        filteredLogs.map(log => JSON.stringify(log)).join("\n") + "\n",
         "utf8"
       );
     } else {


### PR DESCRIPTION
[This comment](https://linear.app/replay/issue/PRO-572/playwright-reporter-sometimes-doesnt-write-test-metadata#comment-2c3f1fea) explains how leaving out the trailing newline creates problems.