### PR TITLE
Fixed a race condition that could cause some tests not being added correctly to a test run

### DIFF
--- a/.changeset/proud-eels-decide.md
+++ b/.changeset/proud-eels-decide.md
@@ -1,0 +1,7 @@
+---
+"@replayio/test-utils": patch
+"@replayio/cypress": patch
+"@replayio/playwright": patch
+---
+
+Fixed a race condition that could cause some tests not being added correctly to a test run

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -204,7 +204,7 @@ class ReplayReporter<TRecordingMetadata extends UnstructuredMetadata = Unstructu
   upload = false;
   filter?: (r: RecordingEntry<TRecordingMetadata>) => boolean;
   recordingsToUpload: ExternalRecordingEntry<TRecordingMetadata>[] = [];
-  _testRunShardIdPromise: Promise<TestRunPendingWork> | null = null;
+  private _testRunShardIdPromise: Promise<TestRunPendingWork> | null = null;
 
   constructor(
     runner: TestRunner,


### PR DESCRIPTION
`CreateTestRunShard` is an async call and it's not guaranteed that it completes before we start working on `AddTestsToShard` (or even `CompleteTestRunShard`).

This fixes that problem by always awaiting the shard id "task" before we continue with other calls that depend on this shard ID.