### PR TITLE
Bumped the minimum supported node version to 18 in `@replayio/cypress`

### DIFF
--- a/.changeset/warm-pugs-travel.md
+++ b/.changeset/warm-pugs-travel.md
@@ -1,0 +1,5 @@
+---
+"@replayio/cypress": major
+---
+
+Bumped the minimum supported node version to 18

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -11,6 +11,9 @@
     "./support": "./dist/support.js",
     "./package.json": "./package.json"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "files": [
     "dist",
     "*.js",

--- a/packages/cypress/src/steps.ts
+++ b/packages/cypress/src/steps.ts
@@ -281,13 +281,10 @@ function groupStepsByTest(tests: Test[], steps: StepEvent[]): Test[] {
         "beforeAll",
       ];
       for (const phase of phases) {
-        const events = test.events[phase];
-        for (let index = events.length - 1; index >= 0; index--) {
-          const event = events[index];
-          if (event.data.error) {
-            test.error = event.data.error;
-            break;
-          }
+        const stepWithError = test.events[phase].findLast(step => !!step.data.error);
+        if (stepWithError) {
+          test.error = stepWithError.data.error;
+          break;
         }
       }
     }

--- a/packages/cypress/tsconfig.json
+++ b/packages/cypress/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@replay-cli/tsconfig/base.json",
   "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2023"],
     "rootDir": "./src",
     "outDir": "./dist"
   },


### PR DESCRIPTION
Since we are preparing a major release here now, we have the opportunity to bump this