### PR TITLE
Add "replayio open" command to launch browser in non-recording mode

### DIFF
--- a/.changeset/grumpy-icons-brush.md
+++ b/.changeset/grumpy-icons-brush.md
@@ -1,0 +1,5 @@
+---
+"replayio": patch
+---
+
+Add "open" command to open Replay browser in non-recording mode

--- a/packages/replayio/src/bin.ts
+++ b/packages/replayio/src/bin.ts
@@ -6,6 +6,7 @@ import "./commands/info";
 import "./commands/list";
 import "./commands/login";
 import "./commands/logout";
+import "./commands/open";
 import "./commands/record";
 import "./commands/remove";
 import "./commands/update";

--- a/packages/replayio/src/commands/open.ts
+++ b/packages/replayio/src/commands/open.ts
@@ -1,0 +1,18 @@
+import { killBrowserIfRunning } from "../utils/browser/killBrowserIfRunning";
+import { launchBrowser } from "../utils/browser/launchBrowser";
+import { registerCommand } from "../utils/commander/registerCommand";
+import { exitProcess } from "../utils/exitProcess";
+
+registerCommand("open", { checkForRuntimeUpdate: true, requireAuthentication: true })
+  .argument("[url]", `URL to open (default: "about:blank")`)
+  .description("Open the replay browser with recording disabled")
+  .action(open)
+  .allowUnknownOption();
+
+async function open(url: string = "about:blank") {
+  await killBrowserIfRunning();
+
+  await launchBrowser(url, { record: false });
+
+  await exitProcess(0);
+}

--- a/packages/replayio/src/utils/browser/killBrowserIfRunning.ts
+++ b/packages/replayio/src/utils/browser/killBrowserIfRunning.ts
@@ -1,0 +1,24 @@
+import { confirm } from "../confirm";
+import { exitProcess } from "../exitProcess";
+import { killProcess } from "../killProcess";
+import { getRunningProcess } from "./getRunningProcess";
+
+export async function killBrowserIfRunning() {
+  const process = await getRunningProcess();
+  if (process) {
+    const confirmed = await confirm(
+      "The replay browser is already running. You'll need to close it before running this command.\n\nWould you like to close it now?",
+      true
+    );
+    if (confirmed) {
+      const killResult = await killProcess(process.pid);
+      if (!killResult) {
+        console.log("Something went wrong trying to close the replay browser. Please try again.");
+
+        await exitProcess(1);
+      }
+    } else {
+      await exitProcess(0);
+    }
+  }
+}


### PR DESCRIPTION
This has been requested so that people can do things like authentication (without Replay recording) before starting recording.