### PR TITLE
Mark observability-node pkg as private

### DIFF
--- a/packages/observability-node/package.json
+++ b/packages/observability-node/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@replayio/observability-node",
+  "private": true,
   "version": "0.0.1",
   "description": "Node utilities for Replay.io's own observability",
   "main": "./dist/index.js",


### PR DESCRIPTION
I have second thoughts about this, we might not want to inline this pkg into other ones because it might be important to maintain this as a singleton pkg. It might hold some state, a connection to some server, or similar. By inlining we'll make all its copies independent and that might be bad

But either way, we don't need to publish this right away. So let's mark this as private now and reconsider this when this gets used in more than a single package.