### PR TITLE
Fixed `schemaVersion` used by the Cypress reporter

### DIFF
--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -70,7 +70,7 @@ class CypressReporter {
         version: config.version,
         plugin: require("@replayio/cypress/package.json").version,
       },
-      "2.1.0",
+      "2.2.0",
       { ...this.options, metadataKey: "CYPRESS_REPLAY_METADATA" }
     );
 


### PR DESCRIPTION
I somehow forgot to update this as part of https://github.com/replayio/replay-cli/pull/519