### PR TITLE
Add an explicit dependency on `strip-ansi` module

### DIFF
--- a/.changeset/yellow-windows-know.md
+++ b/.changeset/yellow-windows-know.md
@@ -1,0 +1,5 @@
+---
+"replayio": patch
+---
+
+Add an explicit dependency on `strip-ansi` module

--- a/packages/replayio/package.json
+++ b/packages/replayio/package.json
@@ -52,6 +52,7 @@
     "pretty-ms": "^7.0.1",
     "query-registry": "^2.6.0",
     "semver": "^7.5.4",
+    "strip-ansi": "^6.0.1",
     "superstruct": "^0.15.4",
     "table": "^6.8.2",
     "undici": "^5.28.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15110,6 +15110,7 @@ __metadata:
     pretty-ms: "npm:^7.0.1"
     query-registry: "npm:^2.6.0"
     semver: "npm:^7.5.4"
+    strip-ansi: "npm:^6.0.1"
     superstruct: "npm:^0.15.4"
     table: "npm:^6.8.2"
     ts-jest: "npm:^28.0.6"


### PR DESCRIPTION
fixes https://github.com/replayio/replay-cli/issues/534

Without an explicit dependency we accidentally relied on node modules hoisting. It could load `strip-ansi@7.x` this way and that's esm-only. I pinned it to 6.x here since it's the one that supports CJS