### PR TITLE
Add a snapshot releases workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,69 @@
+name: release-pr
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  release-check:
+    if: github.repository == 'replayio/replay-cli' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/release-pr')
+    runs-on: ubuntu-latest
+    steps:
+      - id: check_authorization
+        run: |
+          if [[ $AUTHOR_ASSOCIATION == 'MEMBER' || $AUTHOR_ASSOCIATION == 'OWNER' ]]
+          then
+            echo "User is authorized to release"
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "User is not authorized to release"
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
+    outputs:
+      authorized: ${{ steps.check_authorization.outputs.authorized }}
+
+  release:
+    if: github.repository == 'replayio/replay-cli' && needs.release-check.outputs.authorized == 'true'
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    needs: release-check
+    steps:
+      - name: Checkout pull request
+        run: gh pr checkout ${{ github.event.issue.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if Version Packages PR
+        id: check_version_packages
+        run: |
+          echo "version_packages=$(gh pr view ${{ github.event.issue.number }} --json headRefName --jq '.headRefName|startswith("changeset-release/")')" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reset Version Packages PR
+        if: steps.check_version_packages.outputs.version_packages == 'true'
+        run: git reset --hard HEAD~1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "yarn"
+
+      - run: yarn --immutable
+
+      - run: yarn run bootstrap
+
+      - name: Set up NPM token
+        run: |
+          echo "npmAuthToken: $NPM_TOKEN" >> .yarnrc.yml
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Release snapshot versions
+        run: |
+          yarn changeset version --snapshot pr${{ github.event.issue.number }}
+          yarn build && yarn changeset publish --tag pr${{ github.event.issue.number }} --no-git-tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -64,6 +64,6 @@ jobs:
       - name: Release snapshot versions
         run: |
           yarn changeset version --snapshot pr${{ github.event.issue.number }}
-          yarn build && yarn changeset publish --tag pr${{ github.event.issue.number }} --no-git-tag
+          yarn build && yarn run release --tag pr${{ github.event.issue.number }} --no-git-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-check
     steps:
+      - uses: actions/checkout@v4
+
       - name: Checkout pull request
         run: gh pr checkout ${{ github.event.issue.number }}
         env:
@@ -64,6 +66,6 @@ jobs:
       - name: Release snapshot versions
         run: |
           yarn changeset version --snapshot pr${{ github.event.issue.number }}
-          yarn build && yarn run release --tag pr${{ github.event.issue.number }} --no-git-tag
+          yarn build && yarn run release:pr --tag pr${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -63,9 +63,11 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Release snapshot versions
-        run: |
-          yarn changeset version --snapshot pr${{ github.event.issue.number }}
-          yarn build && yarn run release:pr --tag pr${{ github.event.issue.number }}
+      - run: yarn changeset version --snapshot pr${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: yarn build
+
+      - name: Release snapshot versions
+        run: yarn run release:pr --tag pr${{ github.event.issue.number }}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "typecheck": "yarn workspaces foreach --all run typecheck",
     "lint": "prettier --check .",
     "changeset": "changeset",
-    "release": "yarn workspaces foreach --no-private --all --topological npm publish --tolerate-republish --access public && changeset tag"
+    "release": "yarn workspaces foreach --no-private --all --topological npm publish --tolerate-republish --access public && changeset tag",
+    "release:pr": "yarn workspaces foreach --no-private --all --topological npm publish --tolerate-republish --access public"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
To make it easier to test out "disposable releases", I created this workflow. 

It allows us to post `/release-pr` in any given PR to release all packages related to pending changesets. The released versions are in the `0.0.0-pr123-THE_TIME_YOU_DID_THIS` format. 

To get more information about snapshot releases you can read those docs: https://github.com/changesets/changesets/blob/761b2d3d26b996a91ddfaa91c6887e50145dcbd7/docs/snapshot-releases.md

I tested this in a private repo using dummy packages.