### PR TITLE
Avoid reporting duplicated API errors

### DIFF
--- a/.changeset/seven-cameras-help.md
+++ b/.changeset/seven-cameras-help.md
@@ -1,0 +1,7 @@
+---
+"@replayio/test-utils": patch
+"@replayio/cypress": patch
+"@replayio/playwright": patch
+---
+
+Avoid reporting duplicated API errors


### PR DESCRIPTION
**Before**
```
[replay.io]: Encountered unexpected errors while processing replays
[replay.io]:   Error: GraphQL request for CreateTestRunShard failed (Unknown API key)
[replay.io]:   Error: GraphQL request for CreateTestRunShard failed (Unknown API key)
[replay.io]:   Error: GraphQL request for CreateTestRunShard failed (Unknown API key)
```

**After**
```
[replay.io]: 🕑 Completing some outstanding work ...
[replay.io]: 
[replay.io]: ❌ We encountered some unexpected errors creating your tests on replay.io
[replay.io]:    - Unknown API key
```