### PR TITLE
Add emoji reactions to release PR requests

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,34 +1,39 @@
-name: release-pr
+name: Release PR
 
 on:
   issue_comment:
     types: [created]
 
 jobs:
-  release-check:
+  release_check:
     if: github.repository == 'replayio/replay-cli' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/release-pr')
     runs-on: ubuntu-latest
     steps:
+      - id: report_in_progress
+        run: |
+          echo "in_progress_reaction_id=$(gh api /repos/${{github.repository}}/issues/comments/${{github.event.comment.id}}/reactions -f content='eyes' --jq '.id')" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - id: check_authorization
         run: |
           if [[ $AUTHOR_ASSOCIATION == 'MEMBER' || $AUTHOR_ASSOCIATION == 'OWNER' ]]
           then
             echo "User is authorized to release"
-            echo "authorized=true" >> "$GITHUB_OUTPUT"
           else
             echo "User is not authorized to release"
-            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            exit 1
           fi
         env:
           AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
     outputs:
-      authorized: ${{ steps.check_authorization.outputs.authorized }}
+      in_progress_reaction_id: ${{ steps.report_in_progress.outputs.in_progress_reaction_id }}
 
   release:
-    if: github.repository == 'replayio/replay-cli' && needs.release-check.outputs.authorized == 'true'
+    if: github.repository == 'replayio/replay-cli'
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    needs: release-check
+    needs: release_check
     steps:
       - uses: actions/checkout@v4
 
@@ -71,3 +76,25 @@ jobs:
 
       - name: Release snapshot versions
         run: yarn run release:pr --tag pr${{ github.event.issue.number }}
+
+      - run: gh api /repos/${{github.repository}}/issues/comments/${{github.event.comment.id}}/reactions -f content='rocket'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: gh api -X DELETE /repos/${{github.repository}}/issues/comments/${{github.event.comment.id}}/reactions/${{needs.release_check.outputs.in_progress_reaction_id}}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  report-failure-if-needed:
+    needs: [release_check, release]
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    if: failure() && github.repository == 'replayio/replay-cli' && (needs.release_check.result == 'failure' || needs.release.result == 'failure')
+    steps:
+      - run: gh api /repos/${{github.repository}}/issues/comments/${{github.event.comment.id}}/reactions -f content='-1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: gh api -X DELETE /repos/${{github.repository}}/issues/comments/${{github.event.comment.id}}/reactions/${{needs.release_check.outputs.in_progress_reaction_id}}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR toggles between 👀 🚀 👎  emojis on comments invoking the `/release-pr` workflow. Those github actions are not linked to PRs so they are not displayed in the checks section at the bottom.

<img width="935" alt="github comments showing all mentioned emoji reactions" src="https://github.com/replayio/replay-cli/assets/9800850/d154cf46-976b-4199-86d7-c21a0c9b1321">

