### PR TITLE
Add an explicit dependency on `uuid` module

### DIFF
--- a/.changeset/loud-ligers-yell.md
+++ b/.changeset/loud-ligers-yell.md
@@ -1,0 +1,5 @@
+---
+"replayio": patch
+---
+
+Add an explicit dependency on `uuid` module

--- a/packages/replayio/package.json
+++ b/packages/replayio/package.json
@@ -57,6 +57,7 @@
     "superstruct": "^0.15.4",
     "table": "^6.8.2",
     "undici": "^5.28.4",
+    "uuid": "^8.3.2",
     "ws": "^7.5.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15118,6 +15118,7 @@ __metadata:
     ts-jest: "npm:^28.0.6"
     typescript: "npm:^5.5.2"
     undici: "npm:^5.28.4"
+    uuid: "npm:^8.3.2"
     ws: "npm:^7.5.0"
   bin:
     replayio: ./replayio.js


### PR DESCRIPTION
This should be the last one. This one was flagged automatically by the work done in https://github.com/replayio/replay-cli/pull/549 . Once that PR lands, we shouldn't ever run into this problem again. I'm still working on that PR though so I think it's worth fixing this in the meantime.