### PR TITLE
Update glob version to fix nested dependency deprecation warning

### DIFF
--- a/.changeset/large-cups-grin.md
+++ b/.changeset/large-cups-grin.md
@@ -1,0 +1,6 @@
+---
+"@replayio/sourcemap-upload-webpack-plugin": patch
+"@replayio/sourcemap-upload": patch
+---
+
+Updated glob version to fix nested dependency deprecation warning

--- a/packages/sourcemap-upload-webpack-plugin/README.md
+++ b/packages/sourcemap-upload-webpack-plugin/README.md
@@ -6,9 +6,76 @@ will execute automatically when the Webpack build has completed.
 ## PluginOptions
 
 The Webpack plugin, which is the default export of this module, exposes all of
-the same options as [sourcemap-upload][1], along with some additional:
+the same options as [sourcemap-upload][1], along with some additional options:
 
 ```typescript
+// Exported from `@replayio/sourcemap-upload`
+export interface UploadOptions {
+  /**
+   * The files/directories to search for sourcemaps. All files that match the
+   * 'extensions' list and fail to match 'ignore' will be searched for
+   * sourcemap JSON or `//#sourceMappingURL=` coments in order to find pairs
+   * of generated-file + sourcemap, and the sourcemap will be uploaded.
+   */
+  filepaths: Array<string> | string;
+  /**
+   * To allow for tracking and browsing of maps that have been uploaded, we
+   * require uploaded sourcemaps to have an overall group name associated with
+   * them. This could for instance be a version number, or commit hash.
+   */
+  group: string;
+  /**
+   * The API key to use when connecting to Replay's servers.
+   * Defaults to `process.env.REPLAY_API_KEY`.
+   */
+  key?: string;
+  /**
+   * Run all of the local processing and searching for maps, but skip uploading them.
+   */
+  dryRun?: boolean;
+  /**
+   * Delete all found sourcemap files after they have been uploaded.
+   */
+  deleteAfterUpload?: boolean;
+  /**
+   * If sourcemaps can't be matched to generated files by their sourceMappingURL, try matching by filenames on disk
+   */
+  matchSourcemapsByFilename?: boolean;
+  /**
+   * The set of file extensions to search for sourcemap-related data.
+   * Defaults to [".js", ".map"].
+   */
+  extensions?: Array<string>;
+  /**
+   * The set of pattern for files to ignore when searching for sourcemap-related data.
+   */
+  ignore?: Array<string>;
+  /**
+   * Set the directory that relative paths should be computed with respect to.
+   * The relative path of sourcemaps is included in the uploaded entry, and will be
+   * visible in the UI, so this can be used to strip off unimportant directories in
+   * the build path. Defaults to `process.cwd()`.
+   */
+  root?: string;
+  /**
+   * A callback function that will be called with log messages.
+   */
+  log?: LogCallback;
+  /**
+   * URL of the Replay server to upload to. Defaults to `https://api.replay.io`.
+   */
+  server?: string;
+  /**
+   * The number of concurrent uploads to perform. Defaults to 25.
+   */
+  concurrency?: number;
+  /**
+   * A string to append to the User-Agent header when making requests to the Replay API.
+   */
+  userAgentAddition?: string;
+}
+
+// Exported from `@replayio/sourcemap-upload-webpack-plugin`
 export interface PluginOptions extends UploadOptions {
   // Choose how verbose the plugin should be when logging.
   logLevel?: "quiet" | "normal" | "verbose";
@@ -20,4 +87,4 @@ export interface PluginOptions extends UploadOptions {
 }
 ```
 
-[1]: ../sourcemap-upload
+[1]: https://www.npmjs.com/package/@replayio/sourcemap-upload

--- a/packages/sourcemap-upload/package.json
+++ b/packages/sourcemap-upload/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "commander": "^7.2.0",
     "debug": "^4.3.1",
-    "glob": "^7.1.6",
+    "glob": "^10",
     "node-fetch": "^2.6.1",
     "p-map": "^4.0.0",
     "string.prototype.matchall": "^4.0.5"

--- a/packages/sourcemap-upload/src/index.ts
+++ b/packages/sourcemap-upload/src/index.ts
@@ -5,7 +5,6 @@
 import { pathToFileURL, URL } from "url";
 import path from "path";
 import fs from "fs";
-import util from "util";
 import crypto from "crypto";
 import assert from "assert";
 
@@ -14,8 +13,6 @@ import pMap from "p-map";
 import makeDebug from "debug";
 import glob from "glob";
 import matchAll from "string.prototype.matchall";
-
-const globPromisified = util.promisify(glob);
 
 const debug = makeDebug("replay:sourcemap-upload");
 
@@ -581,7 +578,7 @@ async function listAllFiles(
   } else if (stat.isDirectory()) {
     assert(extensions.every((ext) => !glob.hasMagic(ext)));
 
-    return globPromisified(`**/*+(${extensions.join("|")})`, {
+    return glob.glob(`**/*+(${extensions.join("|")})`, {
       cwd: absPath,
       ignore: ignorePatterns,
       absolute: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3428,7 +3428,7 @@ __metadata:
     eslint: "npm:^7.25.0"
     eslint-config-prettier: "npm:^8.3.0"
     eslint-plugin-prettier: "npm:^3.4.0"
-    glob: "npm:^7.1.6"
+    glob: "npm:^10"
     node-fetch: "npm:^2.6.1"
     p-map: "npm:^4.0.0"
     prettier: "npm:^2.2.1"
@@ -9291,6 +9291,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^10":
+  version: 10.4.2
+  resolution: "glob@npm:10.4.2"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^3.1.2"
+    minimatch: "npm:^9.0.4"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^1.11.1"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/2c7296695fa75a935f3ad17dc62e4e170a8bb8752cf64d328be8992dd6ad40777939003754e10e9741ff8fbe43aa52fba32d6930d0ffa0e3b74bc3fb5eebaa2f
+  languageName: node
+  linkType: hard
+
 "glob@npm:^10.2.2, glob@npm:^10.3.10":
   version: 10.3.10
   resolution: "glob@npm:10.3.10"
@@ -10524,6 +10540,19 @@ __metadata:
     "@pkgjs/parseargs":
       optional: true
   checksum: 10c0/f01d8f972d894cd7638bc338e9ef5ddb86f7b208ce177a36d718eac96ec86638a6efa17d0221b10073e64b45edc2ce15340db9380b1f5d5c5d000cbc517dc111
+  languageName: node
+  linkType: hard
+
+"jackspeak@npm:^3.1.2":
+  version: 3.4.0
+  resolution: "jackspeak@npm:3.4.0"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+    "@pkgjs/parseargs": "npm:^0.11.0"
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: 10c0/7e42d1ea411b4d57d43ea8a6afbca9224382804359cb72626d0fc45bb8db1de5ad0248283c3db45fe73e77210750d4fcc7c2b4fe5d24fda94aaa24d658295c5f
   languageName: node
   linkType: hard
 
@@ -12112,6 +12141,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^10.2.0":
+  version: 10.2.2
+  resolution: "lru-cache@npm:10.2.2"
+  checksum: 10c0/402d31094335851220d0b00985084288136136992979d0e015f0f1697e15d1c86052d7d53ae86b614e5b058425606efffc6969a31a091085d7a2b80a8a1e26d6
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^4.0.1":
   version: 4.1.5
   resolution: "lru-cache@npm:4.1.5"
@@ -12404,6 +12440,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^9.0.4":
+  version: 9.0.4
+  resolution: "minimatch@npm:9.0.4"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10c0/2c16f21f50e64922864e560ff97c587d15fd491f65d92a677a344e970fe62aafdbeafe648965fa96d33c061b4d0eabfe0213466203dd793367e7f28658cf6414
+  languageName: node
+  linkType: hard
+
 "minimist-options@npm:^4.0.2":
   version: 4.1.0
   resolution: "minimist-options@npm:4.1.0"
@@ -12493,6 +12538,13 @@ __metadata:
   version: 7.0.4
   resolution: "minipass@npm:7.0.4"
   checksum: 10c0/6c7370a6dfd257bf18222da581ba89a5eaedca10e158781232a8b5542a90547540b4b9b7e7f490e4cda43acfbd12e086f0453728ecf8c19e0ef6921bc5958ac5
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "minipass@npm:7.1.2"
+  checksum: 10c0/b0fd20bb9fb56e5fa9a8bfac539e8915ae07430a619e4b86ff71f5fc757ef3924b23b2c4230393af1eda647ed3d75739e4e0acb250a6b1eb277cf7f8fe449557
   languageName: node
   linkType: hard
 
@@ -13116,6 +13168,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-json-from-dist@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "package-json-from-dist@npm:1.0.0"
+  checksum: 10c0/e3ffaf6ac1040ab6082a658230c041ad14e72fabe99076a2081bb1d5d41210f11872403fc09082daf4387fc0baa6577f96c9c0e94c90c394fd57794b66aa4033
+  languageName: node
+  linkType: hard
+
 "param-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "param-case@npm:3.0.4"
@@ -13220,6 +13279,16 @@ __metadata:
     lru-cache: "npm:^9.1.1 || ^10.0.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10c0/e5dc78a7348d25eec61ab166317e9e9c7b46818aa2c2b9006c507a6ff48c672d011292d9662527213e558f5652ce0afcc788663a061d8b59ab495681840c0c1e
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^1.11.1":
+  version: 1.11.1
+  resolution: "path-scurry@npm:1.11.1"
+  dependencies:
+    lru-cache: "npm:^10.2.0"
+    minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
+  checksum: 10c0/32a13711a2a505616ae1cc1b5076801e453e7aae6ac40ab55b388bb91b9d0547a52f5aaceff710ea400205f18691120d4431e520afbe4266b836fadede15872d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR:

- Bumps the `glob` dep from 7.x to 10.x, to fix this annoying warning any time `replayio` gets installed:

```
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
```

and adds a Webpack plugin README tweak I forgot to commit earlier