### PR TITLE
Add a changeset to kick off sourcemap packages release

### DIFF
--- a/.changeset/tough-fireants-happen.md
+++ b/.changeset/tough-fireants-happen.md
@@ -1,0 +1,9 @@
+---
+"@replayio/sourcemap-upload-webpack-plugin": patch
+"@replayio/sourcemap-upload": patch
+---
+
+pr: #549
+commit: ac7aa52
+
+Fixed the generated `.js` output to correctly reference `glob` package


### PR DESCRIPTION
https://github.com/replayio/replay-cli/pull/556 introduced a regression that happens to be fixed by (unreleased) https://github.com/replayio/replay-cli/pull/549