### PR TITLE
Remove `cli-multipart-upload` flag

### DIFF
--- a/packages/replay/src/main.ts
+++ b/packages/replay/src/main.ts
@@ -341,8 +341,7 @@ async function doUploadRecording(
 
   let recordingId: string;
   try {
-    const isMultipartEnabled = await getLaunchDarkly().isEnabled("cli-multipart-upload", false);
-    if (size > MIN_MULTIPART_UPLOAD_SIZE && isMultipartEnabled) {
+    if (size > MIN_MULTIPART_UPLOAD_SIZE) {
       recordingId = await multipartUploadRecording(
         server,
         client,

--- a/packages/replayio/src/utils/recordings/upload/uploadRecording.ts
+++ b/packages/replayio/src/utils/recordings/upload/uploadRecording.ts
@@ -27,14 +27,13 @@ export async function uploadRecording(
   client: ProtocolClient,
   recording: LocalRecording,
   options: {
-    multiPartUpload: boolean;
     processingBehavior: ProcessingBehavior;
   }
 ) {
   const { buildId, id, path } = recording;
   assert(path, "Recording path is required");
 
-  const { multiPartUpload, processingBehavior } = options;
+  const { processingBehavior } = options;
 
   const { size } = await stat(path);
 
@@ -45,7 +44,7 @@ export async function uploadRecording(
   recording.uploadStatus = "uploading";
 
   try {
-    if (multiPartUpload && size > multiPartMinSizeThreshold) {
+    if (size > multiPartMinSizeThreshold) {
       const { chunkSize, partLinks, recordingId, uploadId } = await beginRecordingMultipartUpload(
         client,
         {

--- a/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
+++ b/packages/replayio/src/utils/recordings/upload/uploadRecordings.ts
@@ -39,7 +39,6 @@ export const uploadRecordings = withTrackAsyncEvent(
       return [];
     }
 
-    const multiPartUpload = await getFeatureFlagValue<boolean>("cli-multipart-upload", false);
     const client = new ProtocolClient();
     try {
       await client.waitUntilAuthenticated();
@@ -70,7 +69,7 @@ export const uploadRecordings = withTrackAsyncEvent(
       } else {
         return createSettledDeferred<LocalRecording>(
           recording,
-          uploadRecording(client, recording, { multiPartUpload, processingBehavior })
+          uploadRecording(client, recording, { processingBehavior })
         );
       }
     });


### PR DESCRIPTION
Once we roll out the flag, and ensure everything's stable, we can get this in. I'm thinking of waiting 2 weeks after the full rollout (like tomorrow). I'm tracking in Linear and have set a reminder for after 2 weeks.

https://linear.app/replay/issue/PRO-723/remove-the-mulitpart-flag-check-from-the-clis-code