### PR TITLE
Migrate logs in `playwright` package

### DIFF
--- a/packages/playwright/src/fixture.ts
+++ b/packages/playwright/src/fixture.ts
@@ -13,6 +13,7 @@ import {
 } from "./playwrightTypes";
 import { getServerPort } from "./server";
 import { captureRawStack, filteredStackTrace } from "./stackTrace";
+import { logger } from "@replay-cli/shared/logger";
 
 function isErrorWithCode<T extends string>(error: unknown, code: T): error is { code: T } {
   return !!error && typeof error === "object" && "code" in error && error.code === code;
@@ -169,7 +170,7 @@ export async function replayFixture(
     }
   }
 
-  debug("Setting up replay fixture");
+  logger.info("ReplayFixture:SettingUp");
 
   const expectSteps = new Set<string>();
   const ignoredSteps = new Set<string>();
@@ -227,7 +228,7 @@ export async function replayFixture(
               // it's not worth it when a convenient API is available though
               // even when the issue gets fixed, it's still a good idea to catch those errors here and `debug` them
               // they can't be *logged* here because that interferes with the active reporter output
-              debug("Failed to add annotation: %o", e);
+              logger.error("ReplayFixture:FailedToAddAnnotation", { error: e });
             }
           });
         })
@@ -287,7 +288,7 @@ export async function replayFixture(
           })
         );
       } catch (wsError) {
-        debug("Failed to send error to reporter", wsError);
+        logger.error("ReplayFixture:FailedToSendErrorToReporter", { wsError });
       }
     }
   }
@@ -326,7 +327,7 @@ export async function replayFixture(
         },
       }).catch(err => {
         // this should never happen since `handlePlaywrightEvent` should always catch errors internally and shouldn't throw
-        debug("Failed to add step:start for an expect: %o", err);
+        logger.error("ReplayFixture:FailedToAddExpectStep", { error: err });
       });
 
       return step;
@@ -350,7 +351,7 @@ export async function replayFixture(
         },
       }).catch(err => {
         // this should never happen since `handlePlaywrightEvent` should always catch errors internally and shouldn't throw
-        debug("Failed to add step:end for an expect: %o", err);
+        logger.error("ReplayFixture:FailedToAddExpectStepEnd", { error: err });
       });
     }
   };
@@ -439,7 +440,7 @@ export function addReplayFixture() {
   const testTypeSymbol = Object.getOwnPropertySymbols(test).find(s => s.description === "testType");
   const fixtures = testTypeSymbol ? (test as any)[testTypeSymbol]?.fixtures : null;
   if (!fixtures) {
-    debug("Failed to inject replay fixture");
+    logger.error("ReplayFixture:FailedToInject");
     return;
   }
 

--- a/packages/playwright/src/server.ts
+++ b/packages/playwright/src/server.ts
@@ -2,6 +2,7 @@ import { ReporterError } from "@replayio/test-utils";
 import dbg from "debug";
 import { WebSocketServer } from "ws";
 import { FixtureEvent, FixtureStepEnd, FixtureStepStart, TestExecutionIdData } from "./fixture";
+import { logger } from "@replay-cli/shared/logger";
 
 const debug = dbg("replay:playwright:server");
 const debugMessages = debug.extend("messages");
@@ -17,7 +18,8 @@ export function startServer({
   onStepEnd?: (test: TestExecutionIdData, stepEnd: FixtureStepEnd) => void;
   onError?: (test: TestExecutionIdData, error: ReporterError) => void;
 }) {
-  debug("Starting server on %d with handlers %o", port, {
+  logger.info("PlaywrightServer:Starting", {
+    port,
     onStepStart: !!onStepStart,
     onStepEnd: !!onStepEnd,
     onError: !!onError,
@@ -26,7 +28,7 @@ export function startServer({
   const wss = new WebSocketServer({ port });
 
   wss.on("connection", function connection(ws) {
-    debug("Connection established");
+    logger.info("PlaywrightServer:ConnectionEstablished");
 
     ws.on("error", console.error);
 
@@ -61,7 +63,7 @@ export function startServer({
     throw new Error("Unexpected server listening on pipe or domain socket");
   }
 
-  debug("Server started on %d", address.port);
+  logger.info("PlaywrightServer:Started", { port: address.port });
 
   return wss;
 }

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -273,7 +273,8 @@ class ReplayReporter<TRecordingMetadata extends UnstructuredMetadata = Unstructu
     this._runner = runner;
     this._schemaVersion = schemaVersion;
 
-    initLogger(this._runner.name, this._runner.version);
+    // TODO: PRO-736 Remove init when test-utils is inlined
+    initLogger(this._runner.name, this._runner.plugin);
 
     if (config) {
       const { metadataKey, ...rest } = config;
@@ -1246,6 +1247,7 @@ class ReplayReporter<TRecordingMetadata extends UnstructuredMetadata = Unstructu
       log(output.join("\n"));
 
       return results;
+      // TODO: PRO-736 Remove close when test-utils is inlined
     } finally {
       await logger.close().catch(() => {});
     }


### PR DESCRIPTION
- Sets up logger initialization a level up in ReplayPlaywrightReporter.
- Left initLogger in `ReplayReporter`. Once we have test-utils inlined we'd remove logger init and close from `ReplayReporter` in test-utils. The side effect right now is we'll have two different session IDs between these packages.

Closes PRO-701.