### PR TITLE
Change dependency on shared package to a devDependency

### DIFF
--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -35,11 +35,11 @@
   },
   "homepage": "https://github.com/replayio/replay-cli/blob/main/packages/replay/README.md",
   "dependencies": {
-    "@replay-cli/shared": "workspace:^",
     "@replayio/sourcemap-upload": "workspace:^",
     "@types/semver": "^7.5.6",
     "commander": "^12.0.0",
     "debug": "^4.3.4",
+    "fs-extra": "^11.2.0",
     "is-uuid": "^1.0.2",
     "jsonata": "^1.8.6",
     "launchdarkly-node-client-sdk": "^3.2.1",
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "@replay-cli/pkg-build": "workspace:^",
+    "@replay-cli/shared": "workspace:^",
     "@replay-cli/tsconfig": "workspace:^",
     "@types/debug": "^4.1.7",
     "@types/jest": "^28.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3664,6 +3664,7 @@ __metadata:
     "@types/ws": "npm:^8.5.10"
     commander: "npm:^12.0.0"
     debug: "npm:^4.3.4"
+    fs-extra: "npm:^11.2.0"
     is-uuid: "npm:^1.0.2"
     jest: "npm:^28.1.3"
     jsonata: "npm:^1.8.6"


### PR DESCRIPTION
The `shared` package isn't published so we can't have a dependency on it. We don't need this dependency because our build creates a bundle containing the code from the `shared` package.