### PR TITLE
Release PR action should allow "COLLABORATOR" roles

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -24,12 +24,6 @@ jobs:
             echo "User is not authorized to release"
             exit 1
           fi
-          then
-            echo "User is authorized to release"
-          else
-            echo "User is not authorized to release"
-            exit 1
-          fi
         env:
           AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
     outputs:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -17,7 +17,13 @@ jobs:
 
       - id: check_authorization
         run: |
-          if [[ $AUTHOR_ASSOCIATION == 'MEMBER' || $AUTHOR_ASSOCIATION == 'OWNER' ]]
+          if [[ $AUTHOR_ASSOCIATION == 'MEMBER' || $AUTHOR_ASSOCIATION == 'OWNER' || $AUTHOR_ASSOCIATION == 'COLLABORATOR' ]]
+          then
+            echo "User is authorized to release"
+          else
+            echo "User is not authorized to release"
+            exit 1
+          fi
           then
             echo "User is authorized to release"
           else


### PR DESCRIPTION
Based on [GitHub's docs](https://docs.github.com/en/graphql/reference/enums#commentauthorassociation) I think it would make sense for us to allow "COLLABORATOR" roles to trigger the release PR workflow. (If they don't have sufficient NPM permissions, it won't matter anyway.)

Based on my own experience (see [here](https://github.com/replayio/replay-cli/actions/runs/9745082131)) and discussions like [this](https://github.com/orgs/community/discussions/18690) and [this](https://github.com/github/rest-api-description/issues/173#issuecomment-1152353747), it seems the `$AUTHOR_ASSOCIATION` is somewhat inconsistent and may label team members as collaborators anyway.