### PR TITLE
migrate log points to the new logger in `packages/test-utils/src/legacy-cli/main.ts`

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,6 +22,7 @@
     "mixpanel": "^0.18.0",
     "open": "^8.4.2",
     "pretty-ms": "^7.0.1",
+    "stack-utils": "^2.0.6",
     "strip-ansi": "^6.0.1",
     "superstruct": "^1.0.4",
     "table": "^6.8.2",
@@ -33,6 +34,7 @@
   "devDependencies": {
     "@replay-cli/pkg-build": "workspace:^",
     "@types/jest": "^28.1.5",
+    "@types/stack-utils": "^2.0.3",
     "jest": "^28.1.3",
     "typescript": "^5.5.2"
   },

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -119,9 +119,7 @@ class Logger {
       if (value instanceof Error) {
         result = {
           ...result,
-          errorName: value.name,
-          errorMessage: value.message,
-          errorStack: value.stack,
+          [key]: { name: value.name, message: value.message, stack: value.stack },
         };
         continue;
       }

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -113,21 +113,20 @@ class Logger {
       return;
     }
 
-    let result: Record<string, unknown> = {};
-
-    for (const [key, value] of Object.entries(tags)) {
+    return Object.entries(tags).reduce((result, [key, value]) => {
       if (value instanceof Error) {
-        result = {
-          ...result,
-          [key]: { name: value.name, message: value.message, stack: value.stack },
+        result[key] = {
+          // Intentionally keeping this for any extra properties attached in `Error`
+          ...(value as any),
+          errorName: value.name,
+          errorMessage: value.message,
+          errorStack: value.stack,
         };
-        continue;
+      } else {
+        result[key] = value;
       }
-
-      result = { ...result, [key]: value };
-    }
-
-    return result;
+      return result;
+    }, {} as Record<string, unknown>);
   }
 
   async close() {

--- a/packages/test-utils/src/legacy-cli/error.ts
+++ b/packages/test-utils/src/legacy-cli/error.ts
@@ -1,0 +1,3 @@
+export function getErrorMessage(e: unknown) {
+  return e && typeof e === "object" && "message" in e ? (e.message as string) : "Unknown Error";
+}

--- a/packages/test-utils/src/legacy-cli/error.ts
+++ b/packages/test-utils/src/legacy-cli/error.ts
@@ -1,3 +1,15 @@
 export function getErrorMessage(e: unknown) {
   return e && typeof e === "object" && "message" in e ? (e.message as string) : "Unknown Error";
 }
+
+export function getErrorTags(e: unknown) {
+  if (e instanceof Error) {
+    return {
+      errorMessage: e.message,
+      errorStack: e.stack,
+      errorName: e.name,
+    };
+  }
+
+  return { errorMessage: "Unknown Error" };
+}

--- a/packages/test-utils/src/legacy-cli/error.ts
+++ b/packages/test-utils/src/legacy-cli/error.ts
@@ -1,15 +1,3 @@
 export function getErrorMessage(e: unknown) {
   return e && typeof e === "object" && "message" in e ? (e.message as string) : "Unknown Error";
 }
-
-export function getErrorTags(e: unknown) {
-  if (e instanceof Error) {
-    return {
-      errorMessage: e.message,
-      errorStack: e.stack,
-      errorName: e.name,
-    };
-  }
-
-  return { errorMessage: "Unknown Error" };
-}

--- a/packages/test-utils/src/legacy-cli/main.ts
+++ b/packages/test-utils/src/legacy-cli/main.ts
@@ -26,7 +26,7 @@ import {
 import { ReplayClient } from "./upload";
 import { getDirectory, maybeLog as maybeLogToConsole } from "./utils";
 import { logger } from "@replay-cli/shared/logger";
-import { getErrorMessage } from "./error";
+import { getErrorTags } from "./error";
 export type { RecordingEntry } from "./types";
 export { updateStatus } from "./updateStatus";
 
@@ -195,15 +195,15 @@ async function setMetadata(
         e => {
           logger.error("SetMetadata:WillRetry", {
             recordingId,
-            errorMessage: getErrorMessage(e),
+            ...getErrorTags(e),
           });
         }
       );
     } catch (e) {
       logger.error("SetMetadata:Failed", {
         recordingId,
-        errorMessage: getErrorMessage(e),
         strict,
+        ...getErrorTags(e),
       });
       handleUploadingError(`Failed to set recording metadata ${e}`, strict, verbose, e);
     }
@@ -272,7 +272,7 @@ async function directUploadRecording(
     e => {
       logger.error("DirectUploadRecording:WillRetry", {
         recordingId,
-        errorMessage: getErrorMessage(e),
+        ...getErrorTags(e),
       });
     }
   );
@@ -441,7 +441,7 @@ async function doUploadRecording(
         logger.error("DoUploadRecording:CannotUploadSourcemapFromDisk", {
           recordingId: recording.id,
           sourcemapPath: sourcemap.path,
-          errorMessage: getErrorMessage(e),
+          ...getErrorTags(e),
         });
 
         handleUploadingError(
@@ -508,7 +508,7 @@ function maybeRemoveAssetFile(asset?: string) {
         fs.unlinkSync(asset);
       }
     } catch (e) {
-      logger.error("MaybeRemoveAssetFile:Failed", { asset, errorMessage: getErrorMessage(e) });
+      logger.error("MaybeRemoveAssetFile:Failed", { asset, ...getErrorTags(e) });
     }
   }
 }

--- a/packages/test-utils/src/legacy-cli/main.ts
+++ b/packages/test-utils/src/legacy-cli/main.ts
@@ -500,51 +500,6 @@ async function uploadRecording(id: string, opts: UploadOptions = {}) {
   );
 }
 
-// MBUDAYR - unused function, can remove.
-async function processUploadedRecording(recordingId: string, opts: Options) {
-  const server = getServer(opts);
-  const agent = getHttpAgent(server, opts.agentOptions);
-  const { verbose } = opts;
-  let apiKey = opts.apiKey;
-
-  logger.info("ProcessUploadedRecording:Started", { recordingId });
-  maybeLogToConsole(verbose, `Processing recording ${recordingId}...`);
-
-  if (!apiKey) {
-    apiKey = await readToken(opts);
-  }
-
-  const client = new ReplayClient();
-  if (!(await client.initConnection(server, apiKey, verbose, agent))) {
-    maybeLogToConsole(verbose, `Processing failed: can't connect to server ${server}`);
-    logger.error("ProcessUploadedRecording:CannotConnectToServer", {
-      recordingId,
-      server,
-    });
-
-    return false;
-  }
-
-  try {
-    const error = await client.connectionWaitForProcessed(recordingId);
-    if (error) {
-      logger.error("ProcessUploadedRecording:Failed", {
-        recordingId,
-        server,
-        errorMessage: getErrorMessage(error),
-      });
-      maybeLogToConsole(verbose, `Processing failed: ${error}`);
-      return false;
-    }
-  } finally {
-    client.closeConnection();
-  }
-
-  logger.info("ProcessUploadedRecording:Succeeded", { recordingId });
-  maybeLogToConsole(verbose, "Finished processing.");
-  return true;
-}
-
 function maybeRemoveAssetFile(asset?: string) {
   if (asset) {
     try {

--- a/packages/test-utils/src/legacy-cli/main.ts
+++ b/packages/test-utils/src/legacy-cli/main.ts
@@ -26,7 +26,6 @@ import {
 import { ReplayClient } from "./upload";
 import { getDirectory, maybeLog as maybeLogToConsole } from "./utils";
 import { logger } from "@replay-cli/shared/logger";
-import { getErrorTags } from "./error";
 export type { RecordingEntry } from "./types";
 export { updateStatus } from "./updateStatus";
 
@@ -192,20 +191,20 @@ async function setMetadata(
     try {
       await retryWithExponentialBackoff(
         () => client.setRecordingMetadata(recordingId, metadata),
-        e => {
+        error => {
           logger.error("SetMetadata:WillRetry", {
             recordingId,
-            ...getErrorTags(e),
+            error,
           });
         }
       );
-    } catch (e) {
+    } catch (error) {
       logger.error("SetMetadata:Failed", {
         recordingId,
         strict,
-        ...getErrorTags(e),
+        error,
       });
-      handleUploadingError(`Failed to set recording metadata ${e}`, strict, verbose, e);
+      handleUploadingError(`Failed to set recording metadata ${error}`, strict, verbose, error);
     }
   }
 }
@@ -269,10 +268,10 @@ async function directUploadRecording(
   });
   await retryWithExponentialBackoff(
     () => client.uploadRecording(recording.path!, uploadLink, size),
-    e => {
+    error => {
       logger.error("DirectUploadRecording:WillRetry", {
         recordingId,
-        ...getErrorTags(e),
+        error,
       });
     }
   );
@@ -437,18 +436,18 @@ async function doUploadRecording(
           },
           { concurrency: 5, stopOnError: false }
         );
-      } catch (e) {
+      } catch (error) {
         logger.error("DoUploadRecording:CannotUploadSourcemapFromDisk", {
           recordingId: recording.id,
           sourcemapPath: sourcemap.path,
-          ...getErrorTags(e),
+          error,
         });
 
         handleUploadingError(
-          `Cannot upload sourcemap ${sourcemap.path} from disk: ${e}`,
+          `Cannot upload sourcemap ${sourcemap.path} from disk: ${error}`,
           strict,
           verbose,
-          e
+          error
         );
       }
     },
@@ -507,8 +506,8 @@ function maybeRemoveAssetFile(asset?: string) {
         logger.info("MaybeRemoveAssetFile:Removing", { asset });
         fs.unlinkSync(asset);
       }
-    } catch (e) {
-      logger.error("MaybeRemoveAssetFile:Failed", { asset, ...getErrorTags(e) });
+    } catch (error) {
+      logger.error("MaybeRemoveAssetFile:Failed", { asset, error });
     }
   }
 }

--- a/packages/test-utils/src/legacy-cli/main.ts
+++ b/packages/test-utils/src/legacy-cli/main.ts
@@ -144,7 +144,7 @@ async function doUploadCrash(
   );
   addRecordingEvent(dir, "crashUploaded", recording.id, { server });
   maybeLogToConsole(verbose, `Crash data upload finished.`);
-  logger.info("DoUploadCrash:Finished", { recordingId: recording.id, server });
+  logger.info("DoUploadCrash:Successful", { recordingId: recording.id, server });
   client.closeConnection();
 }
 

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -251,9 +251,9 @@ export default class ReplayReporter<
           logger.identify(authInfo);
           logger.info("ReplayReporter:LoggerIdentificationAdded");
         })
-        .catch(e =>
+        .catch(error =>
           logger.info("ReplayReporter:LoggerIdentificationFailed", {
-            errorMessage: getErrorMessage(e),
+            error,
           })
         );
     }
@@ -457,9 +457,9 @@ export default class ReplayReporter<
     let metadata: any = {};
     try {
       metadata = await sourceMetadata.init();
-    } catch (e) {
+    } catch (error) {
       logger.error("StartTestRunShard:InitMetadataFailed", {
-        errorMessage: getErrorMessage(e),
+        error,
       });
     }
 
@@ -534,14 +534,14 @@ export default class ReplayReporter<
           phase: "start",
         };
       });
-    } catch (e) {
+    } catch (error) {
       logger.error("StartTestRunShardFailed", {
-        errorMessage: getErrorMessage(e),
+        error,
       });
 
       return {
         type: "test-run",
-        error: new Error(`Unexpected error starting test run shard: ${getErrorMessage(e)}`),
+        error: new Error(`Unexpected error starting test run shard: ${getErrorMessage(error)}`),
       };
     }
   }
@@ -598,11 +598,11 @@ export default class ReplayReporter<
       return {
         type: "test-run-tests",
       };
-    } catch (e) {
-      logger.error("AddTestsToShard:Failed", { errorMessage: getErrorMessage(e) });
+    } catch (error) {
+      logger.error("AddTestsToShard:Failed", { error });
       return {
         type: "test-run-tests",
-        error: new Error(`Unexpected error adding tests to run: ${getErrorMessage(e)}`),
+        error: new Error(`Unexpected error adding tests to run: ${getErrorMessage(error)}`),
       };
     }
   }
@@ -655,14 +655,14 @@ export default class ReplayReporter<
         id: testRunShardId,
         phase: "complete",
       };
-    } catch (e) {
+    } catch (error) {
       logger.error("CompleteTestRunShard:Failed", {
-        errorMessage: getErrorMessage(e),
+        error,
         testRunShardId,
       });
       return {
         type: "test-run",
-        error: new Error(`Unexpected error completing test run shard: ${getErrorMessage(e)}`),
+        error: new Error(`Unexpected error completing test run shard: ${getErrorMessage(error)}`),
       };
     }
   }
@@ -683,9 +683,9 @@ export default class ReplayReporter<
     try {
       mkdirSync(dirname(metadataFilePath), { recursive: true });
       writeFileSync(metadataFilePath, JSON.stringify(metadata, undefined, 2), {});
-    } catch (e) {
+    } catch (error) {
       logger.error("OnTestBegin:InitReplayMetadataFailed", {
-        errorMessage: getErrorMessage(e),
+        error,
       });
     }
   }
@@ -754,16 +754,16 @@ export default class ReplayReporter<
         type: "upload",
         recording: recordings[0],
       };
-    } catch (e) {
+    } catch (error) {
       logger.error("UploadRecording:Failed", {
-        errorMessage: getErrorMessage(e),
+        error,
         recordingId: recording.id,
         buildId: recording.buildId,
       });
       return {
         type: "upload",
         recording,
-        error: new Error(getErrorMessage(e)),
+        error: new Error(getErrorMessage(error)),
       };
     }
   }
@@ -857,9 +857,9 @@ export default class ReplayReporter<
         ...mergedMetadata,
         ...validatedSourceMetadata,
       };
-    } catch (e) {
+    } catch (error) {
       logger.error("SetRecordingMetadata:GenerateSourceMetadataFailed", {
-        errorMessage: getErrorMessage(e),
+        error,
       });
     }
 
@@ -956,11 +956,11 @@ export default class ReplayReporter<
         recordings,
         testRun,
       };
-    } catch (e) {
-      logger.error("EnqueuePostTestWork:Failed");
+    } catch (error) {
+      logger.error("EnqueuePostTestWork:Failed", { error });
       return {
         type: "post-test",
-        error: new Error(`Error setting metadata and uploading replays: ${getErrorMessage(e)}`),
+        error: new Error(`Error setting metadata and uploading replays: ${getErrorMessage(error)}`),
       };
     }
   }
@@ -1135,9 +1135,9 @@ export default class ReplayReporter<
       uploadStatusThreshold: this._uploadStatusThreshold,
     });
 
-    await this._cacheAuthIdsPromise?.catch(e => {
+    await this._cacheAuthIdsPromise?.catch(error => {
       logger.error("OnEnd:AddingLoggerAuthFailed", {
-        errorMessage: getErrorMessage(e),
+        error,
       });
     });
 

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -18,6 +18,7 @@ import { getMetadataFilePath } from "./metadata";
 import { pingTestMetrics } from "./metrics";
 import { buildTestId, generateOpaqueId } from "./testId";
 import { RecordingEntry, ReplayReporterConfig, UploadStatusThreshold } from "./types";
+import { getErrorMessage } from "./legacy-cli/error";
 
 function last<T>(arr: T[]): T | undefined {
   return arr[arr.length - 1];
@@ -108,10 +109,6 @@ export type PendingWork =
   | TestRunTestsPendingWork
   | UploadPendingWork
   | PostTestPendingWork;
-
-function getErrorMessage(e: unknown) {
-  return e && typeof e === "object" && "message" in e ? (e.message as string) : "Unknown Error";
-}
 
 function logPendingWorkErrors(errors: PendingWorkError<any>[]) {
   return errors.map(e => `   - ${e.error.message}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3440,6 +3440,7 @@ __metadata:
   dependencies:
     "@replay-cli/pkg-build": "workspace:^"
     "@types/jest": "npm:^28.1.5"
+    "@types/stack-utils": "npm:^2.0.3"
     bvaughn-enquirer: "npm:2.4.2"
     chalk: "npm:^4.1.2"
     cli-spinners: "npm:^2.9.2"
@@ -3453,6 +3454,7 @@ __metadata:
     mixpanel: "npm:^0.18.0"
     open: "npm:^8.4.2"
     pretty-ms: "npm:^7.0.1"
+    stack-utils: "npm:^2.0.6"
     strip-ansi: "npm:^6.0.1"
     superstruct: "npm:^1.0.4"
     table: "npm:^6.8.2"


### PR DESCRIPTION
This is one part of a series of migration changes.

I started with `packages/test-utils/src/legacy-cli/main.ts` because `packages/test-utils/src/reporter.ts` directly imports from it. Some of the most consequential functions like `listAllRecordings` and `uploadRecording` are defined in `packages/test-utils/src/legacy-cli/main.ts` as well.