### PR TITLE
Change formatting for browser warning

### DIFF
--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -5,26 +5,27 @@ import type {
   TestError,
   TestResult,
 } from "@playwright/test/reporter";
+import { emphasize, highlight, link } from "@replay-cli/shared/theme";
 import {
-  getMetadataFilePath as getMetadataFilePathBase,
-  removeAnsiCodes,
   ReplayReporter,
   ReplayReporterConfig,
   TestMetadataV2,
+  getMetadataFilePath as getMetadataFilePathBase,
+  removeAnsiCodes,
 } from "@replayio/test-utils";
-import { readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import path from "path";
 import { WebSocketServer } from "ws";
 
 type UserActionEvent = TestMetadataV2.UserActionEvent;
 
+import { initLogger, logger } from "@replay-cli/shared/logger";
 import { getRuntimePath } from "@replay-cli/shared/runtime/getRuntimePath";
+import { setUserAgent } from "@replay-cli/shared/userAgent";
+import pkgJson from "../package.json";
 import { FixtureStepStart, ParsedErrorFrame, TestExecutionIdData } from "./fixture";
 import { StackFrame } from "./playwrightTypes";
 import { getServerPort, startServer } from "./server";
-import { initLogger, logger } from "@replay-cli/shared/logger";
-import pkgJson from "../package.json";
-import { setUserAgent } from "@replay-cli/shared/userAgent";
 
 export function getMetadataFilePath(workerIndex = 0) {
   return getMetadataFilePathBase("PLAYWRIGHT", workerIndex);
@@ -328,9 +329,19 @@ class ReplayPlaywrightReporter implements Reporter {
     try {
       await this.reporter.onEnd();
       if (!this._foundReplayBrowser) {
-        console.warn(
-          "[replay.io]: None of the configured projects ran using Replay Chromium. Please recheck your Playwright config and make sure that Replay Chromium is installed. You can install it using `npx replayio install`"
+        const output: string[] = [];
+        output.push(emphasize("None of the configured projects ran using Replay Chromium."));
+        if (!existsSync(getRuntimePath())) {
+          output.push("");
+          output.push(`Install Replay Chromium by running ${highlight("npx replayio install")}`);
+        }
+        output.push("");
+        output.push(
+          `Learn more at ${link(
+            "https://docs.replay.io/reference/test-runners/playwright/overview"
+          )}`
         );
+        output.map(line => console.warn(`[replay.io]: ${line}`));
       }
     } finally {
       await logger.close().catch(() => {});


### PR DESCRIPTION
If you have not installed the Replay browser we will show the following message:
![Screenshot 2024-07-01 at 12 23 12 PM](https://github.com/replayio/replay-cli/assets/29597/57739d70-79f3-4d08-a5e5-367ab0f2ad16)

If you have already installed the Replay browser, we will show:
![Screenshot 2024-07-01 at 12 25 43 PM](https://github.com/replayio/replay-cli/assets/29597/9f84c96d-1406-40b9-b5a6-32929f3adf77)
