### PR TITLE
Only save test data for tests run with Replay browser

### DIFF
--- a/.changeset/late-cars-doubt.md
+++ b/.changeset/late-cars-doubt.md
@@ -1,0 +1,5 @@
+---
+"@replayio/playwright": patch
+---
+
+Only save test data for tests run with Replay browser

--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -79,7 +79,8 @@ export default class ReplayPlaywrightReporter implements Reporter {
     string,
     { steps: FixtureStep[]; stacks: Record<string, StackFrame[]>; filenames: Set<string> }
   > = {};
-  private _projects: Record<string, { executed: boolean; usingReplay: boolean }> = {};
+
+  private _executedProjects: Record<string, { usesReplayBrowser: boolean }> = {};
 
   constructor(config: ReplayPlaywrightConfig) {
     setUserAgent(`${packageName}/${packageVersion}`);
@@ -152,7 +153,7 @@ export default class ReplayPlaywrightReporter implements Reporter {
     return this.fixtureData[id];
   }
 
-  // Playwright alrady provides a unique test id:
+  // Playwright already provides a unique test id:
   // https://github.com/microsoft/playwright/blob/6fb214de2378a9d874b46df6ea99d04da5765cba/packages/playwright/src/common/suiteUtils.ts#L56-L57
   // this is different because it includes `repeatEachIndex` and `attempt`
   // TODO(PRO-667): this could be simplified to `${test.testId}-${test.repeatEachIndex}-${test.attempt}`
@@ -175,25 +176,31 @@ export default class ReplayPlaywrightReporter implements Reporter {
     };
   }
 
-  onBegin({ version, projects }: FullConfig) {
-    const replayBrowserPath = getRuntimePath();
-    for (const project of projects) {
-      this._projects[project.name] = {
-        executed: false,
-        usingReplay: project.use.launchOptions?.executablePath === replayBrowserPath,
-      };
-    }
+  onBegin({ version }: FullConfig) {
     this.reporter.setTestRunnerVersion(version);
     this.reporter.onTestSuiteBegin();
   }
 
-  onTestBegin(test: TestCase, testResult: TestResult) {
-    const projectName = test.parent.project()?.name;
-
-    // it's important to handle the root project's name here and that's an empty string
-    if (typeof projectName === "string") {
-      this._projects[projectName].executed = true;
+  private _registerExecutedProject(test: TestCase) {
+    const project = test.parent.project();
+    if (project) {
+      let projectMetadata = this._executedProjects[project.name];
+      if (!projectMetadata) {
+        projectMetadata = this._executedProjects[project.name] = {
+          usesReplayBrowser: project.use.launchOptions?.executablePath === getRuntimePath(),
+        };
+      }
+      return projectMetadata;
     }
+
+    return null;
+  }
+
+  onTestBegin(test: TestCase, testResult: TestResult) {
+    const projectMetadata = this._registerExecutedProject(test);
+
+    // Don't save metadata for non-Replay projects
+    if (projectMetadata?.usesReplayBrowser === false) return;
 
     const testExecutionId = this._getTestExecutionId({
       filePath: test.location.file,
@@ -202,6 +209,7 @@ export default class ReplayPlaywrightReporter implements Reporter {
       attempt: testResult.retry + 1,
       source: this.getSource(test),
     });
+
     this.reporter.onTestBegin(testExecutionId, getMetadataFilePath(testResult.workerIndex));
   }
 
@@ -266,8 +274,14 @@ export default class ReplayPlaywrightReporter implements Reporter {
 
   onTestEnd(test: TestCase, result: TestResult) {
     const status = result.status;
-    // skipped tests won't have a reply so nothing to do here
+
+    // Skipped tests won't have a reply so nothing to do here
     if (status === "skipped") return;
+
+    const projectMetadata = this._registerExecutedProject(test);
+
+    // Don't save metadata for non-Replay projects
+    if (projectMetadata?.usesReplayBrowser === false) return;
 
     const testExecutionIdData = {
       filePath: test.location.file,
@@ -351,25 +365,23 @@ export default class ReplayPlaywrightReporter implements Reporter {
     try {
       await this.reporter.onEnd();
 
+      const didUseReplayBrowser = Object.values(this._executedProjects).some(
+        ({ usesReplayBrowser }) => usesReplayBrowser
+      );
+      const isReplayBrowserInstalled = existsSync(getRuntimePath());
+
       const output: string[] = [];
 
-      const executedProjectWithReplay = !Object.keys(this._projects).some(projectName => {
-        const { executed, usingReplay } = this._projects[projectName];
-        return executed && usingReplay;
-      });
-
-      if (!executedProjectWithReplay) {
+      if (!didUseReplayBrowser) {
         mixpanelAPI.trackEvent("playwright.warning.reporter-used-without-replay-project");
         output.push(emphasize("None of the configured projects ran using Replay Chromium."));
       }
 
-      if (!existsSync(getRuntimePath())) {
-        if (executedProjectWithReplay) {
+      if (!isReplayBrowserInstalled) {
+        if (didUseReplayBrowser) {
           mixpanelAPI.trackEvent("playwright.warning.replay-browser-not-installed");
         }
-        if (output.length) {
-          output.push("");
-        }
+
         output.push(
           `To record tests with Replay, you need to install the Replay browser: ${highlight(
             "npx replayio install"
@@ -378,13 +390,16 @@ export default class ReplayPlaywrightReporter implements Reporter {
       }
 
       if (output.length) {
-        output.push("");
         output.push(
           `Learn more at ${link(
             "https://docs.replay.io/reference/test-runners/playwright/overview"
           )}`
         );
-        output.forEach(line => {
+
+        output.forEach((line, index) => {
+          if (index > 0) {
+            console.log("[replay.io]:");
+          }
           console.warn(`[replay.io]: ${line}`);
         });
       }

--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -200,7 +200,7 @@ export default class ReplayPlaywrightReporter implements Reporter {
     const projectMetadata = this._registerExecutedProject(test);
 
     // Don't save metadata for non-Replay projects
-    if (projectMetadata?.usesReplayBrowser === false) return;
+    if (!projectMetadata?.usesReplayBrowser) return;
 
     const testExecutionId = this._getTestExecutionId({
       filePath: test.location.file,
@@ -281,7 +281,7 @@ export default class ReplayPlaywrightReporter implements Reporter {
     const projectMetadata = this._registerExecutedProject(test);
 
     // Don't save metadata for non-Replay projects
-    if (projectMetadata?.usesReplayBrowser === false) return;
+    if (!projectMetadata?.usesReplayBrowser) return;
 
     const testExecutionIdData = {
       filePath: test.location.file,

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -446,7 +446,7 @@ export default class ReplayReporter<
       return;
     }
 
-    // Don't event record test metadata yet unless/until a test is run with the Replay browser (see onTestBegin)
+    // Don't even record test metadata yet unless/until a test is run with the Replay browser (see onTestBegin)
   }
 
   private async _startTestRunShard(): Promise<TestRunPendingWork> {
@@ -668,13 +668,11 @@ export default class ReplayReporter<
   onTestBegin(testExecutionId?: string, metadataFilePath = getMetadataFilePath("REPLAY_TEST", 0)) {
     logger.info("OnTestBegin:Started", { testExecutionId });
 
-    if (this._apiKey) {
-      if (!this._testRunShardIdPromise) {
-        // This method won't be called until a test is run with the Replay browser
-        // We shouldn't save any test metadata until that happens
-        this._testRunShardIdPromise = this._startTestRunShard();
-        this._pendingWork.push(this._testRunShardIdPromise);
-      }
+    if (this._apiKey && !this._testRunShardIdPromise) {
+      // This method won't be called until a test is run with the Replay browser
+      // We shouldn't save any test metadata until that happens
+      this._testRunShardIdPromise = this._startTestRunShard();
+      this._pendingWork.push(this._testRunShardIdPromise);
     }
 
     this._errors = [];
@@ -1152,7 +1150,7 @@ export default class ReplayReporter<
     let completedWork: PromiseSettledResult<PendingWork | undefined>[] = [];
 
     if (this._pendingWork.length) {
-      log("🕑 Completing some outstanding work ...");
+      log("Finishing up. This should only take a moment ...");
     }
 
     while (this._pendingWork.length) {

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -446,12 +446,7 @@ export default class ReplayReporter<
       return;
     }
 
-    if (this._testRunShardIdPromise) {
-      return;
-    }
-
-    this._testRunShardIdPromise = this._startTestRunShard();
-    this._pendingWork.push(this._testRunShardIdPromise);
+    // Don't event record test metadata yet unless/until a test is run with the Replay browser (see onTestBegin)
   }
 
   private async _startTestRunShard(): Promise<TestRunPendingWork> {
@@ -672,6 +667,15 @@ export default class ReplayReporter<
 
   onTestBegin(testExecutionId?: string, metadataFilePath = getMetadataFilePath("REPLAY_TEST", 0)) {
     logger.info("OnTestBegin:Started", { testExecutionId });
+
+    if (this._apiKey) {
+      if (!this._testRunShardIdPromise) {
+        // This method won't be called until a test is run with the Replay browser
+        // We shouldn't save any test metadata until that happens
+        this._testRunShardIdPromise = this._startTestRunShard();
+        this._pendingWork.push(this._testRunShardIdPromise);
+      }
+    }
 
     this._errors = [];
     const metadata = {
@@ -1230,14 +1234,14 @@ export default class ReplayReporter<
       numUploaded = uploaded.length;
 
       if (uploaded.length > 0) {
-        output.push(`\n🚀 Successfully uploaded ${uploads.length} recordings:\n`);
+        output.push(`\n🚀 Successfully uploaded ${uploads.length} recordings:`);
         const sortedUploads = sortRecordingsByResult(uploads);
         sortedUploads.forEach(r => {
           output.push(
-            `   ${getTestResultEmoji(r)} ${(r.metadata.title as string | undefined) || "Unknown"}`
+            `\n   ${getTestResultEmoji(r)} ${(r.metadata.title as string | undefined) || "Unknown"}`
           );
           output.push(
-            `      ${process.env.REPLAY_VIEW_HOST || "https://app.replay.io"}/recording/${r.id}\n`
+            `      ${process.env.REPLAY_VIEW_HOST || "https://app.replay.io"}/recording/${r.id}`
           );
         });
       }
@@ -1256,7 +1260,9 @@ export default class ReplayReporter<
       numUploaded,
     });
 
-    log(output.join("\n"));
+    if (output.length > 0) {
+      log(output.join("\n"));
+    }
 
     return results;
   }


### PR DESCRIPTION
Only upload test metadata for tests that were run with the Replay browser. If a given test run has no tests that match this criteria, then we should not even upload any metadata for it.

## Testing
I've tested the following scenarios...

### Upload behavior
<details><summary>Only upload tests run with Replay browser</summary>

```js
// playwright.config.js
reporter: [
  ["dot"] as const,
  replayReporter({
    apiKey: process.env.REPLAY_API_KEY,
    upload: true,
  })
],
projects: [
  {
    name: "chromium",
    testMatch: "**/*login-logout-devtools.spec.ts",
    use: { ...devices["Desktop Chrome"] },
  },
  {
    testMatch: "**/*login-logout-library.spec.ts",
    use: { ...replayDevices["Replay Chromium"] },
  },
],
```

I was testing a few things with this configuration:
- We do upload recordings but only for tests that were run by the Replay browser
- We don't even upload metadata for tests that were run with other browsers

Here is the terminal output from the above test run:

```
[replay.io]: 🕑 Completing some outstanding work ...
[replay.io]: 
[replay.io]: 🚀 Successfully uploaded 1 recordings:
[replay.io]: 
[replay.io]:    ✅ login-logout-library: should login and logout from the library
[replay.io]:       https://app.replay.io/recording/8dc7d529-d7ff-4a0d-8cb4-7177b21b33df
```

And [here](https://app.replay.io/team/dzpkN2MzMDk5YS1mYzI3LTRiZjctYWU1ZC0wN2RhMTVhNzY1MjE=/runs?testRunId=de278eb2-a2e2-4a0f-a9fa-c81c7daee945&testId=) are the results in our dashboard which seem to confirm that it worked as expected:
![image](https://github.com/replayio/replay-cli/assets/29597/b86df651-85cb-4066-9226-8b7c927cc61f)

</details> 

<details><summary>Upload all tests if all are run with Replay browser</summary>

```js
// playwright.config.js
reporter: [
  ["dot"] as const,
  replayReporter({
    apiKey: process.env.REPLAY_API_KEY,
    upload: true,
  })
],
projects: [
  {
    name: "chromium",
    use: { ...devices["Desktop Chrome"] },
  },
  {
    name: "replay-chromium",
    use: { ...replayDevices["Replay Chromium"] },
  },
],
```

Terminal output:
```
····
  4 passed (13.7s)

[replay.io]: 🕑 Completing some outstanding work ...
[replay.io]: 
[replay.io]: 🚀 Successfully uploaded 2 recordings:
[replay.io]: 
[replay.io]:    ✅ login-logout-devtools: should login and logout from devtools
[replay.io]:       https://app.replay.io/recording/2fb6449f-c078-48f5-bd08-19cff3dabe6a
[replay.io]:
[replay.io]:    ✅ login-logout-library: should login and logout from the library
[replay.io]:       https://app.replay.io/recording/deef79df-d011-4b52-a917-662dab981adf
```

[Dashboard has both tests](https://app.replay.io/team/dzpkN2MzMDk5YS1mYzI3LTRiZjctYWU1ZC0wN2RhMTVhNzY1MjE=/runs?testRunId=53d01471-8c83-44d4-8605-21558ddfd3b8&testId=dHJ0OjIwZThlYjA0M2RiMjMwOGE4NjA3NmNiODFlNGNiNjE1MjRiOGFhZjQ%3D) (with recordings)
![image](https://github.com/replayio/replay-cli/assets/29597/a5f7fa52-26b3-4424-b39f-f5235a90a283)

</details> 

<details><summary>Don't upload any data if no tests are run with Replay</summary>

Same config but with `--project=chromium` so the Replay browser doesn't get run:
```
··
  2 passed (11.3s)
[replay.io]: None of the configured projects ran using Replay Chromium.
[replay.io]:
[replay.io]: Learn more at https://docs.replay.io/reference/test-runners/playwright/overview
```

And does not create a dashboard test run.

</details> 

### Logged warnings

<details><summary>Trying to record tests without the Replay browser being installed</summary>

```
  2 failed
    [replay-chromium] › login-logout-devtools.spec.ts:5:5 › login-logout-devtools: should login and logout from devtools 
    [replay-chromium] › login-logout-library.spec.ts:5:5 › login-logout-library: should login and logout from the library 
[replay.io]: 🕑 Completing some outstanding work ...
[replay.io]: To record tests with Replay, you need to install the Replay browser: npx replayio install
[replay.io]:
[replay.io]: Learn more at https://docs.replay.io/reference/test-runners/playwright/overview
```

</details> 

<details><summary>Using the Replay reporter without the Replay browser installed or configured</summary>

```
··
  2 passed (10.6s)
[replay.io]: None of the configured projects ran using Replay Chromium.
[replay.io]:
[replay.io]: To record tests with Replay, you need to install the Replay browser: npx replayio install
[replay.io]:
[replay.io]: Learn more at https://docs.replay.io/reference/test-runners/playwright/overview
```

</details> 