### PR TITLE
Initialize Mixpanel events for Cypress reporter

### DIFF
--- a/packages/cypress/src/reporter.ts
+++ b/packages/cypress/src/reporter.ts
@@ -1,21 +1,19 @@
 /// <reference types="cypress" />
 import {
-  getMetadataFilePath as getMetadataFilePathBase,
   ReplayReporter,
-  TestMetadataV2,
-  ReporterError,
-  fetchWorkspaceConfig,
   ReplayReporterConfig,
+  ReporterError,
+  TestMetadataV2,
+  fetchWorkspaceConfig,
+  getMetadataFilePath as getMetadataFilePathBase,
 } from "@replayio/test-utils";
-import * as pkgJson from "../package.json";
 
+import { logger } from "@replay-cli/shared/logger";
 import { Errors } from "./error";
+import { PluginFeature, getFeatures, isFeatureEnabled } from "./features";
 import { appendToFixtureFile, initFixtureFile } from "./fixture";
 import { getTestsFromResults, groupStepsByTest, sortSteps } from "./steps";
 import type { StepEvent } from "./support";
-import { PluginFeature, getFeatures, isFeatureEnabled } from "./features";
-import { logger } from "@replay-cli/shared/logger";
-import { setUserAgent } from "@replay-cli/shared/userAgent";
 
 type Test = TestMetadataV2.Test;
 
@@ -60,7 +58,6 @@ class CypressReporter {
   private _extraEnv: NodeJS.ProcessEnv = {};
 
   constructor(config: Cypress.PluginConfigOptions, options: PluginOptions) {
-    setUserAgent(`${pkgJson.name}/${pkgJson.version}`);
     initFixtureFile();
 
     this.config = config;

--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -93,7 +93,7 @@ export default class ReplayPlaywrightReporter implements Reporter {
     });
 
     if (!config || typeof config !== "object") {
-      mixpanelAPI.trackEvent("playwright.error.invalid-reporter-config", { config });
+      mixpanelAPI.trackEvent("error.invalid-reporter-config", { config });
 
       throw new Error(
         `Expected an object for @replayio/playwright/reporter configuration but received: ${config}`
@@ -373,13 +373,13 @@ export default class ReplayPlaywrightReporter implements Reporter {
       const output: string[] = [];
 
       if (!didUseReplayBrowser) {
-        mixpanelAPI.trackEvent("playwright.warning.reporter-used-without-replay-project");
+        mixpanelAPI.trackEvent("warning.reporter-used-without-replay-project");
         output.push(emphasize("None of the configured projects ran using Replay Chromium."));
       }
 
       if (!isReplayBrowserInstalled) {
         if (didUseReplayBrowser) {
-          mixpanelAPI.trackEvent("playwright.warning.replay-browser-not-installed");
+          mixpanelAPI.trackEvent("warning.replay-browser-not-installed");
         }
 
         output.push(


### PR DESCRIPTION
This will unblock the logger done by test-utils (which previously would not have been sent anywhere, because it waits until Mixpanel has been initialized).

I also logged a couple of Cypress specific events that might be relevant to onboarding. (TBH I'm not sure how our onboarding funnel is going to work and I'm kind of just taking guesses here.)