### PR TITLE
Remove filter function from test utils config

### DIFF
--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -224,7 +224,6 @@ export default class ReplayReporter<
   private _apiKey?: string;
   private _pendingWork: Promise<PendingWork | undefined>[] = [];
   private _upload = false;
-  private _filter?: (r: RecordingEntry<TRecordingMetadata>) => boolean;
   private _minimizeUploads = false;
   private _uploadableResults: Map<string, UploadableTestResult<TRecordingMetadata>> = new Map();
   private _testRunShardIdPromise: Promise<TestRunPendingWork> | null = null;
@@ -355,8 +354,6 @@ export default class ReplayReporter<
       config.runTitle ||
       getFallbackRunTitle();
 
-    this._filter = config.filter;
-
     // RECORD_REPLAY_METADATA is our "standard" metadata environment variable.
     // We suppress it for the browser process so we can use
     // RECORD_REPLAY_METADATA_FILE but can still use the metadata here which
@@ -425,14 +422,12 @@ export default class ReplayReporter<
       baseMetadata: this._baseMetadata,
       upload: this._upload,
       hasApiKey: !!this._apiKey,
-      hasFilter: !!this._filter,
     });
 
     mixpanelAPI.trackEvent("test-suite.begin", {
       baseId: this._baseId,
       runTitle: this._runTitle,
       upload: this._upload,
-      hasFilter: !!this._filter,
     });
 
     if (!this._apiKey) {
@@ -1092,10 +1087,7 @@ export default class ReplayReporter<
     }
 
     this._pendingWork.push(
-      ...toUpload
-        .flatMap(result => result.recordings)
-        .filter(r => (this._filter ? this._filter(r) : true))
-        .map(r => this._uploadRecording(r))
+      ...toUpload.flatMap(result => result.recordings).map(r => this._uploadRecording(r))
     );
   }
 

--- a/packages/test-utils/src/types.ts
+++ b/packages/test-utils/src/types.ts
@@ -45,11 +45,9 @@ export type UploadOptions = {
 export interface ReplayReporterConfig<
   TRecordingMetadata extends UnstructuredMetadata = UnstructuredMetadata
 > {
-  runTitle?: string;
-  metadata?: Record<string, any> | string;
-  metadataKey?: string;
-  upload?: UploadOptions | boolean;
   apiKey?: string;
-  /** @deprecated Use `upload.minimizeUploads` and `upload.statusThreshold` instead */
-  filter?: (r: RecordingEntry<TRecordingMetadata>) => boolean;
+  metadata?: TRecordingMetadata;
+  metadataKey?: string;
+  runTitle?: string;
+  upload?: UploadOptions | boolean;
 }


### PR DESCRIPTION
Once the Cypress 3.1 plug-in release has been published, we are unblocked to remove the deprecated `filter` config option. This PR does that.