### PR TITLE
Log filter function to Grafana

### DIFF
--- a/.changeset/loud-trainers-dress.md
+++ b/.changeset/loud-trainers-dress.md
@@ -1,0 +1,5 @@
+---
+"@replayio/test-utils": patch
+---
+
+Gather data about deprecated `filter` config usage (as preparation to remove it)

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -257,6 +257,17 @@ export default class ReplayReporter<
           })
         );
     }
+
+    // Logging this here instead of in _parseConfig is intentional; the logger has been associated with the user's API key
+    if (config) {
+      if (config.filter) {
+        logger.info("ReplayReporter:Config:HasFilter", {
+          filter: config.filter.toString(),
+        });
+      } else {
+        logger.info("ReplayReporter:Config:NoFilter");
+      }
+    }
   }
 
   setTestRunnerVersion(version: TestRunner["version"]) {


### PR DESCRIPTION
Before we remove the deprecated test `filter` config (#602) we should learn more about how many people are using it, and if it's possible for us to support all of their use cases with the new advanced `upload` config. This PR logs the filter function to Grafana.

Is this okay to do or should the contents of this function be considered private? I assume this function is unlikely to have sensitive info in it, and if there were any- it would be passed in via an env variable. But is that okay to assume?