### PR TITLE
Use a unified DEBUG namespace

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { initLogger, logger } from "@replay-cli/shared/logger";
+import { logger } from "@replay-cli/shared/logger";
 import { mixpanelAPI } from "@replay-cli/shared/mixpanel/mixpanelAPI";
 import { getRuntimePath } from "@replay-cli/shared/runtime/getRuntimePath";
 import { setUserAgent } from "@replay-cli/shared/userAgent";
@@ -263,7 +263,7 @@ const plugin = (
 ) => {
   setUserAgent(`${packageName}/${packageVersion}`);
 
-  initLogger(packageName, packageVersion);
+  logger.initialize(packageName, packageVersion);
   mixpanelAPI.initialize({
     accessToken: getAuthKey(config),
     packageName,

--- a/packages/jest/src/runner.ts
+++ b/packages/jest/src/runner.ts
@@ -1,17 +1,17 @@
 import type { JestEnvironment } from "@jest/environment";
 import type { TestFileEvent, TestResult } from "@jest/test-result";
 import type { Circus, Config } from "@jest/types";
+import { logger } from "@replay-cli/shared/logger";
+import { setUserAgent } from "@replay-cli/shared/userAgent";
 import {
   ReplayReporter,
-  removeAnsiCodes,
   getMetadataFilePath as getMetadataFilePathBase,
   initMetadataFile,
+  removeAnsiCodes,
 } from "@replayio/test-utils";
 import type Runtime from "jest-runtime";
 import path from "path";
 import * as pkgJson from "../package.json";
-import { setUserAgent } from "@replay-cli/shared/userAgent";
-import { initLogger } from "@replay-cli/shared/logger";
 
 const runner = require("jest-circus/runner");
 const pluginVersion = require("@replayio/jest/package.json").version;
@@ -39,7 +39,7 @@ const ReplayRunner = async (
   sendMessageToJest?: TestFileEvent
 ): Promise<TestResult> => {
   setUserAgent(`${pkgJson.name}/${pkgJson.version}`);
-  initLogger(pkgJson.name, pkgJson.version);
+  logger.initialize(pkgJson.name, pkgJson.version);
   if (!version) {
     try {
       version = require(require.resolve("jest/package.json", {

--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -5,7 +5,7 @@ import type {
   TestError,
   TestResult,
 } from "@playwright/test/reporter";
-import { initLogger, logger } from "@replay-cli/shared/logger";
+import { logger } from "@replay-cli/shared/logger";
 import { mixpanelAPI } from "@replay-cli/shared/mixpanel/mixpanelAPI";
 import { getRuntimePath } from "@replay-cli/shared/runtime/getRuntimePath";
 import { emphasize, highlight, link } from "@replay-cli/shared/theme";
@@ -85,7 +85,7 @@ export default class ReplayPlaywrightReporter implements Reporter {
   constructor(config: ReplayPlaywrightConfig) {
     setUserAgent(`${packageName}/${packageVersion}`);
 
-    initLogger(packageName, packageVersion);
+    logger.initialize(packageName, packageVersion);
     mixpanelAPI.initialize({
       accessToken: getAccessToken(config),
       packageName,

--- a/packages/puppeteer/src/install.ts
+++ b/packages/puppeteer/src/install.ts
@@ -1,9 +1,9 @@
-import { initLogger, logger } from "@replay-cli/shared/logger";
+import { logger } from "@replay-cli/shared/logger";
 import { installLatestRuntimeRelease } from "@replay-cli/shared/runtime/installLatestRuntimeRelease";
 import { name, version } from "../package.json";
 
 export default async function install() {
-  initLogger(name, version);
+  logger.initialize(name, version);
   try {
     await installLatestRuntimeRelease();
   } finally {

--- a/packages/replayio/src/bin.ts
+++ b/packages/replayio/src/bin.ts
@@ -1,4 +1,4 @@
-import { initLogger, logger } from "@replay-cli/shared/logger";
+import { logger } from "@replay-cli/shared/logger";
 import { exitProcess } from "@replay-cli/shared/process/exitProcess";
 import { setUserAgent } from "@replay-cli/shared/userAgent";
 import { name, version } from "../package.json";
@@ -17,7 +17,7 @@ import "./commands/upload";
 import "./commands/upload-source-maps";
 import "./commands/whoami";
 
-initLogger(name, version);
+logger.initialize(name, version);
 
 setUserAgent(`${name}/${version}`);
 

--- a/packages/replayio/src/commands/record.ts
+++ b/packages/replayio/src/commands/record.ts
@@ -28,7 +28,7 @@ async function record(url: string = "about:blank") {
   // this flag is intentionally not listed in the command options
   const verbose = process.argv.includes("--verbose");
   if (verbose) {
-    debug.enable("replayio:*");
+    debug.enable("replay");
   }
 
   const processGroupId = uuid();

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -94,9 +94,6 @@ class Logger {
   }
 
   private log(message: string, level: LogLevel, tags?: Tags) {
-    if (!this.initialized) {
-      throw new Error("Logger not initialized. Call `logger.initialize` first.");
-    }
     const formattedTags = this.formatTags(tags);
 
     this.localDebugger(message, formattedTags);

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -51,13 +51,14 @@ class Logger {
     this.sessionId = randomUUID();
   }
 
+  // This should be called with the name once at the entry point.
+  // For example, with the Playwright plugin, it is called in the Reporter interface constructor.
   initialize(app: string, version: string | undefined) {
     if (this.initialized) {
       console.warn(`Logger already initialized.`);
     }
 
     this.initialized = true;
-    this.localDebugger = dbg(app);
     this.grafana = this.initGrafana(app, version);
   }
 
@@ -93,6 +94,9 @@ class Logger {
   }
 
   private log(message: string, level: LogLevel, tags?: Tags) {
+    if (!this.initialized) {
+      throw new Error("Logger not initialized. Call `logger.initialize` first.");
+    }
     const formattedTags = this.formatTags(tags);
 
     this.localDebugger(message, formattedTags);
@@ -176,9 +180,3 @@ class Logger {
 }
 
 export const logger = new Logger();
-
-// This should be called with the name once at the entry point.
-// For example, with the Playwright plugin, it is called in the Reporter interface constructor.
-export function initLogger(app: string, version: string | undefined) {
-  logger.initialize(app, version);
-}


### PR DESCRIPTION
In the past, we could use `DEBUG=replay:*` or `DEBUG=replayio:*`. None of those work now because we ditched "nested namespaces". The new logger configured the `localDebugger` once (or well, twice - once in the constructor + it gives us the ability to override it in the `initialize` method) and it only uses a single namespace without any colons.

It means that now we should use `DEBUG=replayio`. Since all packages configure the `localDebugger` to use their package names as the namespace... we even have to use verbose names like `DEBUG=@replayio/playwright`. I think we should settle on a single namespace - let it be either `replay` or `replayio`