### PR TITLE
Call `logger.identify` properly

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -264,6 +264,7 @@ const plugin = (
   setUserAgent(`${packageName}/${packageVersion}`);
 
   logger.initialize(packageName, packageVersion);
+  logger.identify(getAuthKey(config));
   mixpanelAPI.initialize({
     accessToken: getAuthKey(config),
     packageName,

--- a/packages/playwright/src/reporter.ts
+++ b/packages/playwright/src/reporter.ts
@@ -86,6 +86,7 @@ export default class ReplayPlaywrightReporter implements Reporter {
     setUserAgent(`${packageName}/${packageVersion}`);
 
     logger.initialize(packageName, packageVersion);
+    logger.identify(getAccessToken(config));
     mixpanelAPI.initialize({
       accessToken: getAccessToken(config),
       packageName,

--- a/packages/puppeteer/src/install.ts
+++ b/packages/puppeteer/src/install.ts
@@ -1,9 +1,17 @@
 import { logger } from "@replay-cli/shared/logger";
 import { installLatestRuntimeRelease } from "@replay-cli/shared/runtime/installLatestRuntimeRelease";
 import { name, version } from "../package.json";
+import { getAccessToken } from "@replay-cli/shared/authentication/getAccessToken";
 
 export default async function install() {
-  logger.initialize(name, version);
+  try {
+    logger.initialize(name, version);
+    const accessToken = await getAccessToken();
+    await logger.identify(accessToken.accessToken);
+  } catch (error) {
+    logger.error("Failed to identify for logger", { error });
+  }
+
   try {
     await installLatestRuntimeRelease();
   } finally {

--- a/packages/replayio/src/utils/initialization/initialize.ts
+++ b/packages/replayio/src/utils/initialization/initialize.ts
@@ -9,6 +9,7 @@ import { checkForRuntimeUpdate } from "./checkForRuntimeUpdate";
 import { promptForAuthentication } from "./promptForAuthentication";
 import { promptForNpmUpdate } from "./promptForNpmUpdate";
 import { promptForRuntimeUpdate } from "./promptForRuntimeUpdate";
+import { logger } from "@replay-cli/shared/logger";
 
 export async function initialize({
   checkForNpmUpdate: shouldCheckForNpmUpdate,
@@ -42,6 +43,8 @@ export async function initialize({
     npmUpdateCheck = { hasUpdate: undefined },
   ] = await promises;
 
+  await logger.identify(accessToken);
+
   if (requireAuthentication && !accessToken) {
     accessToken = await promptForAuthentication();
   }
@@ -50,6 +53,8 @@ export async function initialize({
   // These tasks don't print anything so they can be done in parallel with the upgrade prompts
   // They also shouldn't block on failure, so we should only wait a couple of seconds before giving up
   const abortController = new AbortController();
+
+  const loggerPromise = raceWithTimeout(logger.identify(accessToken), 2_500, abortController);
 
   const launchDarklyPromise = accessToken
     ? raceWithTimeout(
@@ -73,5 +78,5 @@ export async function initialize({
     await promptForRuntimeUpdate(runtimeUpdateCheck);
   }
 
-  await Promise.all([launchDarklyPromise, mixpanelPromise]);
+  await Promise.all([loggerPromise, launchDarklyPromise, mixpanelPromise]);
 }

--- a/packages/replayio/src/utils/initialization/initialize.ts
+++ b/packages/replayio/src/utils/initialization/initialize.ts
@@ -43,8 +43,6 @@ export async function initialize({
     npmUpdateCheck = { hasUpdate: undefined },
   ] = await promises;
 
-  await logger.identify(accessToken);
-
   if (requireAuthentication && !accessToken) {
     accessToken = await promptForAuthentication();
   }

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -5,6 +5,7 @@ import { AuthInfo } from "./graphql/fetchAuthInfoFromGraphQL";
 import { getDeviceId } from "./getDeviceId";
 import { randomUUID } from "crypto";
 import StackUtils from "stack-utils";
+import { getAuthInfo } from "./graphql/getAuthInfo";
 
 const GRAFANA_USER = "909360";
 const GRAFANA_PUBLIC_TOKEN =
@@ -89,8 +90,14 @@ class Logger {
     };
   }
 
-  identify(authInfo: AuthInfo) {
-    this.authInfo = authInfo;
+  async identify(accessToken: string | undefined) {
+    try {
+      if (accessToken) {
+        this.authInfo = await getAuthInfo(accessToken);
+      }
+    } catch (error) {
+      logger.error("Logger:InitializationFailed", { error });
+    }
   }
 
   private log(message: string, level: LogLevel, tags?: Tags) {

--- a/packages/test-utils/src/reporter.ts
+++ b/packages/test-utils/src/reporter.ts
@@ -231,7 +231,6 @@ export default class ReplayReporter<
   private _uploadableResults: Map<string, UploadableTestResult<TRecordingMetadata>> = new Map();
   private _testRunShardIdPromise: Promise<TestRunPendingWork> | null = null;
   private _uploadStatusThreshold: UploadStatusThresholdInternal = "none";
-  private _cacheAuthIdsPromise: Promise<void> | null = null;
   private _uploadedRecordings = new Set<string>();
 
   constructor(
@@ -245,19 +244,6 @@ export default class ReplayReporter<
     if (config) {
       const { metadataKey, ...rest } = config;
       this._parseConfig(rest, metadataKey);
-    }
-
-    if (this._apiKey) {
-      this._cacheAuthIdsPromise = getAuthInfo(this._apiKey)
-        .then(authInfo => {
-          logger.identify(authInfo);
-          logger.info("ReplayReporter:LoggerIdentificationAdded");
-        })
-        .catch(error =>
-          logger.info("ReplayReporter:LoggerIdentificationFailed", {
-            error,
-          })
-        );
     }
 
     // Logging this here instead of in _parseConfig is intentional; the logger has been associated with the user's API key
@@ -1151,12 +1137,6 @@ export default class ReplayReporter<
       minimizeUploads: this._minimizeUploads,
       numPendingWork: this._pendingWork.length,
       uploadStatusThreshold: this._uploadStatusThreshold,
-    });
-
-    await this._cacheAuthIdsPromise?.catch(error => {
-      logger.error("OnEnd:AddingLoggerAuthFailed", {
-        error,
-      });
     });
 
     const output: string[] = [];


### PR DESCRIPTION
- Moves the logic for getting authInfo from `test-utils/reporter` directly inside th elogger.
- Moves `logger.identify` directly intro the entrypoints of Cypress and Playwright.
- Adds `logger.identify` call into the `replayio`'s `initialize` function.

Limitations
- The Cypress and Playwright entrypoints are not async; therefore, this identify call isn't awaited, so first few logs would be missing `workspaceId` / `userId`.
-  There are a few logs before the `identify` call in `replayio` (for example: log inside `getAccessToken`) that would be missing `workspaceId` / `userId`. I'm not sure where else to put this async call.