### PR TITLE
Update ts-configs to not reference the deleted "replay" package

### DIFF
--- a/packages/cypress/tsconfig.json
+++ b/packages/cypress/tsconfig.json
@@ -8,9 +8,6 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../replay"
-    },
-    {
       "path": "../test-utils"
     }
   ]

--- a/packages/jest/tsconfig.json
+++ b/packages/jest/tsconfig.json
@@ -6,9 +6,6 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../replay"
-    },
-    {
       "path": "../test-utils"
     }
   ]

--- a/packages/playwright/tsconfig.json
+++ b/packages/playwright/tsconfig.json
@@ -7,9 +7,6 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../replay"
-    },
-    {
       "path": "../test-utils"
     }
   ]

--- a/packages/puppeteer/tsconfig.json
+++ b/packages/puppeteer/tsconfig.json
@@ -7,9 +7,6 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../replay"
-    },
-    {
       "path": "../test-utils"
     }
   ]

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -8,9 +8,6 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../replay"
-    },
-    {
       "path": "../shared"
     }
   ]


### PR DESCRIPTION
Why didn't #616 catch this?