### PR TITLE
Filter out node_modules metadata

### DIFF
--- a/.changeset/afraid-horses-shave.md
+++ b/.changeset/afraid-horses-shave.md
@@ -1,0 +1,5 @@
+---
+"@replay-cli/shared": patch
+---
+
+Ignore node_modules-only metadata

--- a/packages/shared/src/recording/canUpload.ts
+++ b/packages/shared/src/recording/canUpload.ts
@@ -3,7 +3,7 @@ import { LocalRecording } from "./types";
 export function canUpload(recording: LocalRecording) {
   return (
     recording.path &&
-    recording.uploadStatus === undefined &&
+    (recording.uploadStatus === undefined || recording.uploadStatus === "failed") &&
     (recording.recordingStatus === "crashed" || recording.recordingStatus === "finished")
   );
 }

--- a/packages/shared/src/recording/canUpload.ts
+++ b/packages/shared/src/recording/canUpload.ts
@@ -3,7 +3,7 @@ import { LocalRecording } from "./types";
 export function canUpload(recording: LocalRecording) {
   return (
     recording.path &&
-    (recording.uploadStatus === undefined || recording.uploadStatus === "failed") &&
+    recording.uploadStatus === undefined &&
     (recording.recordingStatus === "crashed" || recording.recordingStatus === "finished")
   );
 }

--- a/packages/shared/src/recording/metadata/sanitizeMetadata.ts
+++ b/packages/shared/src/recording/metadata/sanitizeMetadata.ts
@@ -54,5 +54,22 @@ export async function sanitizeMetadata(metadata: UnstructuredMetadata, opts: Opt
     }
   }
 
+  filterNodeModulesStacks(updated);
+
   return updated;
+}
+
+function filterNodeModulesStacks(metadata: UnstructuredMetadata) {
+  const playwright = metadata["x-replay-playwright"] as
+    | { stacks?: Record<string, Array<{ file?: string }>> }
+    | undefined;
+  if (!playwright?.stacks) {
+    return;
+  }
+
+  for (const [key, frames] of Object.entries(playwright.stacks)) {
+    if (frames.every(frame => frame.file?.includes("node_modules"))) {
+      delete playwright.stacks[key];
+    }
+  }
 }

--- a/packages/shared/src/recording/metadata/sanitizeMetadata.ts
+++ b/packages/shared/src/recording/metadata/sanitizeMetadata.ts
@@ -67,9 +67,34 @@ function filterNodeModulesStacks(metadata: UnstructuredMetadata) {
     return;
   }
 
+  const removedIds = new Set<string>();
   for (const [key, frames] of Object.entries(playwright.stacks)) {
     if (frames.every(frame => frame.file?.includes("node_modules"))) {
       delete playwright.stacks[key];
+      removedIds.add(key);
+    }
+  }
+
+  if (removedIds.size === 0) {
+    return;
+  }
+
+  const test = metadata["test"] as
+    | { tests?: Array<{ events?: Record<string, Array<{ data?: { id?: string } }>> }> }
+    | undefined;
+  if (!test?.tests) {
+    return;
+  }
+
+  for (const entry of test.tests) {
+    if (!entry.events) {
+      continue;
+    }
+    for (const phase of Object.keys(entry.events)) {
+      const events = entry.events[phase];
+      if (Array.isArray(events)) {
+        entry.events[phase] = events.filter(e => !removedIds.has(e.data?.id ?? ""));
+      }
     }
   }
 }

--- a/packages/shared/src/recording/upload/uploadRecording.ts
+++ b/packages/shared/src/recording/upload/uploadRecording.ts
@@ -1,7 +1,10 @@
-import { ReadStream, createReadStream, readFile, stat } from "fs-extra";
+import { ReadStream, createReadStream, readFile, stat, writeFile } from "fs-extra";
 import assert from "node:assert/strict";
 import { fetch } from "undici";
 import { Buffer } from "node:buffer";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { inspect } from "node:util";
 import { createDeferred } from "../../async/createDeferred";
 import { createPromiseQueue } from "../../async/createPromiseQueue";
 import { retryWithExponentialBackoff, retryWithLinearBackoff } from "../../async/retryOnFailure";
@@ -23,6 +26,26 @@ import { uploadSourceMaps } from "./uploadSourceMaps";
 import { validateRecordingMetadata } from "./validateRecordingMetadata";
 
 const uploadQueue = createPromiseQueue({ concurrency: 10 });
+
+async function setMetadataWithRetry(
+  client: ProtocolClient,
+  metadata: Record<string, unknown>,
+  recordingData: Record<string, unknown>
+) {
+  await retryWithExponentialBackoff(
+    () => setRecordingMetadata(client, { metadata, recordingData }),
+    (error: unknown, attemptNumber: number) => {
+      logDebug(`Attempt ${attemptNumber} to set metadata failed`, { error });
+      if (attemptNumber === 1) {
+        const filePath = join(tmpdir(), `replay-metadata-${Date.now()}.txt`);
+        const content = inspect({ metadata, recordingData }, { depth: null, maxStringLength: null });
+        writeFile(filePath, content).then(() => {
+          logDebug(`Metadata written to ${filePath}`);
+        });
+      }
+    }
+  );
+}
 
 export async function uploadRecording(
   client: ProtocolClient,
@@ -67,12 +90,7 @@ export async function uploadRecording(
       recording.id = recordingId;
       recordingData.id = recordingId;
 
-      await retryWithExponentialBackoff(
-        () => setRecordingMetadata(client, { metadata, recordingData }),
-        (error: unknown, attemptNumber: number) => {
-          logDebug(`Attempt ${attemptNumber} to set metadata failed`, { error });
-        }
-      );
+      await setMetadataWithRetry(client, metadata, recordingData);
     } else if (multiPartUpload && size > multiPartMinSizeThreshold) {
       const { chunkSize, partLinks, recordingId, uploadId } = await beginRecordingMultipartUpload(
         client,
@@ -89,12 +107,7 @@ export async function uploadRecording(
         server: replayWsServer,
       });
 
-      await retryWithExponentialBackoff(
-        () => setRecordingMetadata(client, { metadata, recordingData }),
-        (error: unknown, attemptNumber: number) => {
-          logDebug(`Attempt ${attemptNumber} to set metadata failed`, { error });
-        }
-      );
+      await setMetadataWithRetry(client, metadata, recordingData);
 
       const partIds = await uploadRecordingFileInParts({
         chunkSize,
@@ -115,12 +128,7 @@ export async function uploadRecording(
         server: replayWsServer,
       });
 
-      await retryWithExponentialBackoff(
-        () => setRecordingMetadata(client, { metadata, recordingData }),
-        (error: unknown, attemptNumber: number) => {
-          logDebug(`Attempt ${attemptNumber} to set metadata failed`, { error });
-        }
-      );
+      await setMetadataWithRetry(client, metadata, recordingData);
       await uploadQueue.add(() =>
         retryWithExponentialBackoff(
           () =>


### PR DESCRIPTION
I'm getting errors with metadata being too large when setting things in graphQL.  I think there was a regression with a recent release where we're setting tons of unwanted metadata in playwright recordings for some reason.