### PR TITLE
PRO-2387 forward REPLAY_CLIENT_SOURCE env as request header

### DIFF
--- a/.changeset/client-attribution.md
+++ b/.changeset/client-attribution.md
@@ -1,0 +1,9 @@
+---
+"replayio": patch
+"@replayio/playwright": patch
+"@replayio/cypress": patch
+"@replayio/jest": patch
+"@replayio/puppeteer": patch
+---
+
+add client attribution headers for telemetry. sends X-Client-Info on outbound HTTP requests to enable backend source tracking. forwards REPLAY_CLIENT_SOURCE env var as X-Replay-Source header when set by orchestrated environments.

--- a/.changeset/client-attribution.md
+++ b/.changeset/client-attribution.md
@@ -6,4 +6,4 @@
 "@replayio/puppeteer": patch
 ---
 
-add client attribution headers for telemetry. sends X-Client-Info on outbound HTTP requests to enable backend source tracking. forwards REPLAY_CLIENT_SOURCE env var as X-Replay-Source header when set by orchestrated environments.
+internal: add a way to attribute the client origin of the outbound traffic to Replay services

--- a/packages/shared/src/graphql/queryGraphQL.ts
+++ b/packages/shared/src/graphql/queryGraphQL.ts
@@ -23,9 +23,7 @@ export async function queryGraphQL(name: string, query: string, variables = {}, 
     options.headers.Authorization = `Bearer ${apiKey.trim()}`;
   }
 
-  if (process.env.REPLAY_CLIENT_SOURCE) {
-    options.headers["X-Replay-Source"] = process.env.REPLAY_CLIENT_SOURCE;
-  }
+  options.headers["X-Replay-Source"] = process.env.REPLAY_CLIENT_SOURCE || "cli";
 
   logDebug("Querying graphql endpoint", { name, replayApiServer });
   const result = await fetch(`${replayApiServer}/v1/graphql`, options);

--- a/packages/shared/src/graphql/queryGraphQL.ts
+++ b/packages/shared/src/graphql/queryGraphQL.ts
@@ -23,6 +23,10 @@ export async function queryGraphQL(name: string, query: string, variables = {}, 
     options.headers.Authorization = `Bearer ${apiKey.trim()}`;
   }
 
+  if (process.env.REPLAY_CLIENT_SOURCE) {
+    options.headers["X-Replay-Source"] = process.env.REPLAY_CLIENT_SOURCE;
+  }
+
   logDebug("Querying graphql endpoint", { name, replayApiServer });
   const result = await fetch(`${replayApiServer}/v1/graphql`, options);
 

--- a/packages/shared/src/graphql/queryGraphQL.ts
+++ b/packages/shared/src/graphql/queryGraphQL.ts
@@ -2,18 +2,15 @@ import { fetch } from "undici";
 import { replayApiServer } from "../config";
 import { logDebug } from "../logger";
 import { getUserAgent } from "../session/getUserAgent";
-import { waitForPackageInfo } from "../session/waitForPackageInfo";
 
 export async function queryGraphQL(name: string, query: string, variables = {}, apiKey?: string) {
   const userAgent = await getUserAgent();
-  const { packageName } = await waitForPackageInfo();
 
   const options = {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       "User-Agent": userAgent,
-      "X-Replay-Source": process.env.REPLAY_CLIENT_SOURCE || packageName,
     } as Record<string, string>,
     body: JSON.stringify({
       query,

--- a/packages/shared/src/graphql/queryGraphQL.ts
+++ b/packages/shared/src/graphql/queryGraphQL.ts
@@ -2,15 +2,18 @@ import { fetch } from "undici";
 import { replayApiServer } from "../config";
 import { logDebug } from "../logger";
 import { getUserAgent } from "../session/getUserAgent";
+import { waitForPackageInfo } from "../session/waitForPackageInfo";
 
 export async function queryGraphQL(name: string, query: string, variables = {}, apiKey?: string) {
   const userAgent = await getUserAgent();
+  const { packageName } = await waitForPackageInfo();
 
   const options = {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       "User-Agent": userAgent,
+      "X-Replay-Source": process.env.REPLAY_CLIENT_SOURCE || packageName,
     } as Record<string, string>,
     body: JSON.stringify({
       query,
@@ -22,8 +25,6 @@ export async function queryGraphQL(name: string, query: string, variables = {}, 
   if (apiKey) {
     options.headers.Authorization = `Bearer ${apiKey.trim()}`;
   }
-
-  options.headers["X-Replay-Source"] = process.env.REPLAY_CLIENT_SOURCE || "cli";
 
   logDebug("Querying graphql endpoint", { name, replayApiServer });
   const result = await fetch(`${replayApiServer}/v1/graphql`, options);

--- a/packages/shared/src/recording/upload/uploadRecording.ts
+++ b/packages/shared/src/recording/upload/uploadRecording.ts
@@ -379,9 +379,7 @@ async function uploadRecordingWithoutPresignedUrls({
     "Content-Type": "application/octet-stream",
     "User-Agent": userAgent,
   };
-  if (process.env.REPLAY_CLIENT_SOURCE) {
-    authHeaders["X-Replay-Source"] = process.env.REPLAY_CLIENT_SOURCE;
-  }
+  authHeaders["X-Replay-Source"] = process.env.REPLAY_CLIENT_SOURCE || "cli";
 
   if (numChunks <= 1) {
     // Small file: send everything directly to create-recording.
@@ -485,9 +483,7 @@ async function uploadRecordingReadStream(
           "Content-Length": size.toString(),
           "User-Agent": userAgent,
           Connection: "keep-alive",
-          ...(process.env.REPLAY_CLIENT_SOURCE
-            ? { "X-Replay-Source": process.env.REPLAY_CLIENT_SOURCE }
-            : {}),
+          "X-Replay-Source": process.env.REPLAY_CLIENT_SOURCE || "cli",
         },
         method: "PUT",
         body: stream,

--- a/packages/shared/src/recording/upload/uploadRecording.ts
+++ b/packages/shared/src/recording/upload/uploadRecording.ts
@@ -479,6 +479,9 @@ async function uploadRecordingReadStream(
           "Content-Length": size.toString(),
           "User-Agent": userAgent,
           Connection: "keep-alive",
+          ...(process.env.REPLAY_CLIENT_SOURCE
+            ? { "X-Replay-Source": process.env.REPLAY_CLIENT_SOURCE }
+            : {}),
         },
         method: "PUT",
         body: stream,

--- a/packages/shared/src/recording/upload/uploadRecording.ts
+++ b/packages/shared/src/recording/upload/uploadRecording.ts
@@ -38,7 +38,10 @@ async function setMetadataWithRetry(
       logDebug(`Attempt ${attemptNumber} to set metadata failed`, { error });
       if (attemptNumber === 1) {
         const filePath = join(tmpdir(), `replay-metadata-${Date.now()}.txt`);
-        const content = inspect({ metadata, recordingData }, { depth: null, maxStringLength: null });
+        const content = inspect(
+          { metadata, recordingData },
+          { depth: null, maxStringLength: null }
+        );
         writeFile(filePath, content).then(() => {
           logDebug(`Metadata written to ${filePath}`);
         });

--- a/packages/shared/src/recording/upload/uploadRecording.ts
+++ b/packages/shared/src/recording/upload/uploadRecording.ts
@@ -18,6 +18,7 @@ import { endRecordingUpload } from "../../protocol/api/endRecordingUpload";
 import { processRecording } from "../../protocol/api/processRecording";
 import { setRecordingMetadata } from "../../protocol/api/setRecordingMetadata";
 import { getUserAgent } from "../../session/getUserAgent";
+import { waitForPackageInfo } from "../../session/waitForPackageInfo";
 import { multiPartChunkSize, multiPartMinSizeThreshold } from "../config";
 import { LocalRecording, RECORDING_LOG_KIND } from "../types";
 import { updateRecordingLog } from "../updateRecordingLog";
@@ -369,6 +370,7 @@ async function uploadRecordingWithoutPresignedUrls({
 }): Promise<string> {
   const baseUrl = getDispatchHttpUrl();
   const userAgent = await getUserAgent();
+  const { packageName } = await waitForPackageInfo();
   const fileBuffer = await readFile(recordingPath);
   const numChunks = Math.ceil(size / NO_PRESIGNED_CHUNK_SIZE);
 
@@ -378,8 +380,8 @@ async function uploadRecordingWithoutPresignedUrls({
     Authorization: `Bearer ${accessToken}`,
     "Content-Type": "application/octet-stream",
     "User-Agent": userAgent,
+    "X-Replay-Source": process.env.REPLAY_CLIENT_SOURCE || packageName,
   };
-  authHeaders["X-Replay-Source"] = process.env.REPLAY_CLIENT_SOURCE || "cli";
 
   if (numChunks <= 1) {
     // Small file: send everything directly to create-recording.
@@ -475,6 +477,7 @@ async function uploadRecordingReadStream(
   stream.on("error", streamError.reject);
 
   const userAgent = await getUserAgent();
+  const { packageName } = await waitForPackageInfo();
 
   try {
     const response = await Promise.race([
@@ -483,7 +486,7 @@ async function uploadRecordingReadStream(
           "Content-Length": size.toString(),
           "User-Agent": userAgent,
           Connection: "keep-alive",
-          "X-Replay-Source": process.env.REPLAY_CLIENT_SOURCE || "cli",
+          "X-Replay-Source": process.env.REPLAY_CLIENT_SOURCE || packageName,
         },
         method: "PUT",
         body: stream,

--- a/packages/shared/src/recording/upload/uploadRecording.ts
+++ b/packages/shared/src/recording/upload/uploadRecording.ts
@@ -374,11 +374,14 @@ async function uploadRecordingWithoutPresignedUrls({
 
   logDebug(`No-presigned upload: ${size} bytes in ${numChunks} chunk(s)`);
 
-  const authHeaders = {
+  const authHeaders: Record<string, string> = {
     Authorization: `Bearer ${accessToken}`,
     "Content-Type": "application/octet-stream",
     "User-Agent": userAgent,
   };
+  if (process.env.REPLAY_CLIENT_SOURCE) {
+    authHeaders["X-Replay-Source"] = process.env.REPLAY_CLIENT_SOURCE;
+  }
 
   if (numChunks <= 1) {
     // Small file: send everything directly to create-recording.

--- a/packages/shared/src/recording/upload/uploadRecording.ts
+++ b/packages/shared/src/recording/upload/uploadRecording.ts
@@ -18,7 +18,6 @@ import { endRecordingUpload } from "../../protocol/api/endRecordingUpload";
 import { processRecording } from "../../protocol/api/processRecording";
 import { setRecordingMetadata } from "../../protocol/api/setRecordingMetadata";
 import { getUserAgent } from "../../session/getUserAgent";
-import { waitForPackageInfo } from "../../session/waitForPackageInfo";
 import { multiPartChunkSize, multiPartMinSizeThreshold } from "../config";
 import { LocalRecording, RECORDING_LOG_KIND } from "../types";
 import { updateRecordingLog } from "../updateRecordingLog";
@@ -370,7 +369,6 @@ async function uploadRecordingWithoutPresignedUrls({
 }): Promise<string> {
   const baseUrl = getDispatchHttpUrl();
   const userAgent = await getUserAgent();
-  const { packageName } = await waitForPackageInfo();
   const fileBuffer = await readFile(recordingPath);
   const numChunks = Math.ceil(size / NO_PRESIGNED_CHUNK_SIZE);
 
@@ -380,8 +378,11 @@ async function uploadRecordingWithoutPresignedUrls({
     Authorization: `Bearer ${accessToken}`,
     "Content-Type": "application/octet-stream",
     "User-Agent": userAgent,
-    "X-Replay-Source": process.env.REPLAY_CLIENT_SOURCE || packageName,
+    "X-Client-Info": userAgent,
   };
+  if (process.env.REPLAY_CLIENT_SOURCE) {
+    authHeaders["X-Replay-Source"] = process.env.REPLAY_CLIENT_SOURCE;
+  }
 
   if (numChunks <= 1) {
     // Small file: send everything directly to create-recording.
@@ -477,7 +478,6 @@ async function uploadRecordingReadStream(
   stream.on("error", streamError.reject);
 
   const userAgent = await getUserAgent();
-  const { packageName } = await waitForPackageInfo();
 
   try {
     const response = await Promise.race([
@@ -486,7 +486,9 @@ async function uploadRecordingReadStream(
           "Content-Length": size.toString(),
           "User-Agent": userAgent,
           Connection: "keep-alive",
-          "X-Replay-Source": process.env.REPLAY_CLIENT_SOURCE || packageName,
+          ...(process.env.REPLAY_CLIENT_SOURCE
+            ? { "X-Replay-Source": process.env.REPLAY_CLIENT_SOURCE }
+            : {}),
         },
         method: "PUT",
         body: stream,


### PR DESCRIPTION
when `REPLAY_CLIENT_SOURCE` is set in the environment, forward it as the `X-Replay-Source` header on outbound graphql and recording upload requests. lets the backend attribute traffic from inside orchestrated environments (e.g. the autobuilder container) to the driving context.

no-op when the env var is unset.

## related

- replayio/backend: reads `x-replay-source` as `replay.client.context` telemetry attribute
- replayio/app-building: sets the env var in the autobuilder container