### PR TITLE
PRO-2372: forward ad attribution on browser login

### DIFF
--- a/packages/shared/src/authentication/authenticateByBrowser.ts
+++ b/packages/shared/src/authentication/authenticateByBrowser.ts
@@ -11,13 +11,30 @@ import { refreshAccessTokenOrThrow } from "./refreshAccessTokenOrThrow";
 
 // TODO [PRO-24] Change authentication to remove polling and GraphQL mutation
 
-export async function authenticateByBrowser() {
+export type AdAttribution = Partial<{
+  li_fat_id: string;
+  twclid: string;
+  rdt_cid: string;
+  utm_source: string;
+  utm_medium: string;
+  utm_campaign: string;
+  utm_content: string;
+  utm_term: string;
+}>;
+
+export async function authenticateByBrowser(attribution?: AdAttribution) {
   const key = hashValue(String(globalThis.performance.now()));
 
   console.log("\nPlease log in or register in the browser to continue.");
 
   logDebug(`Launching browser to sign into Replay: ${replayAppHost}`);
-  await open(`${replayAppHost}/api/browser/auth?key=${key}&source=cli`);
+  const params = new URLSearchParams({ key, source: "cli" });
+  if (attribution) {
+    for (const [k, v] of Object.entries(attribution)) {
+      if (v) params.set(k, v);
+    }
+  }
+  await open(`${replayAppHost}/api/browser/auth?${params}`);
 
   const { accessToken, refreshToken } = await pollForAuthentication(key);
 


### PR DESCRIPTION
adds an optional `attribution` arg to `authenticateByBrowser` so `replay login` can append ad click IDs + UTMs to the `/api/browser/auth?...` URL. ticket: PRO-2372.

## how it works

- `authenticateByBrowser(attribution?)` accepts an optional record of click IDs + UTMs
- if present, keys with truthy values are appended to the `/api/browser/auth` URL
- dashboard's `/api/browser/auth` handler (see dashboard PR) forwards them to `/login` -> `/api/auth/login` -> auth0 `/authorize` -> post-login action -> backend `ensureUserForAuth`

## what's NOT here

no caller populates `attribution` yet. follow-up options:
- CLI flags on `replay login` (e.g. `--li-fat-id=...`)
- env vars (e.g. `REPLAY_UTM_SOURCE`)

the cli context has no access to a browser's localStorage, so the user has to volunteer attribution somehow. in practice most cli users come from docs/github rather than paid ads, so the coverage gap is acknowledged per the ticket.

## test plan

- [x] `authenticateByBrowser()` with no arg behaves identically (url has just `key` and `source`)
- [ ] manual: `authenticateByBrowser({ li_fat_id: 'smoke' })` opens `/api/browser/auth?key=X&source=cli&li_fat_id=smoke`